### PR TITLE
Add Travis CI integration for our django project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ target/
 
 # Sqlite
 *.db
+*.sqlite3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+
+language: python
+
+python:
+  - 2.7
+
+services: postgresql
+
+before_install:
+  - export DJANGO_SETTINGS_MODULE=author.settings
+
+install:
+  - pip install -r requirements.txt
+  - pip install psycopg2 --quiet
+
+script:
+  - python manage.py test

--- a/author/settings.py
+++ b/author/settings.py
@@ -82,6 +82,17 @@ DATABASES = {
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
+if 'TRAVIS' in os.environ:
+    DATABASES = {
+        'default': {
+            'ENGINE':   'django.db.backends.postgresql_psycopg2',
+            'NAME':     'travisci',
+            'USER':     'postgres',
+            'PASSWORD': '',
+            'HOST':     'localhost',
+            'PORT':     '',
+        }
+    }
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/


### PR DESCRIPTION
__What__
This PR adds the basic travis CI integration for Django to run on the hosted travis CI service.
It makes use of a postgresql database although does not currently run migrations.

__How to test__

This PR should be marked as passing travis CI tests if the integration has worked correctly.

__Who can review__

Anyone but @dhilton

