### PR TITLE
DIG-EQ3 create new questionnaire

### DIFF
--- a/survey/forms.py
+++ b/survey/forms.py
@@ -1,5 +1,5 @@
 from django.forms import ModelForm, Select, ChoiceField
-from .models import Survey
+from .models import Survey, Questionnaire
 
 
 SURVEY_STORE = (

--- a/survey/forms.py
+++ b/survey/forms.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm, Select, ChoiceField
+from django.forms import ModelForm, Select, ChoiceField, ValidationError
 from .models import Survey, Questionnaire
 
 
@@ -31,6 +31,12 @@ class SurveyForm(ModelForm):
         widgets = {
             'survey_list': Select(),
         }
+
+    def clean_survey_list(self):
+        survey_id = self.cleaned_data['survey_list']
+        if Survey.objects.filter(survey_id=survey_id).exists():
+            raise ValidationError("Survey has already been added")
+        return survey_id
 
     def save(self):
         data = self.cleaned_data

--- a/survey/migrations/0002_questionnaire.py
+++ b/survey/migrations/0002_questionnaire.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Questionnaire',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('questionnaire_id', models.CharField(max_length=10)),
+                ('title', models.CharField(max_length=120)),
+                ('overview', models.TextField(max_length=3000)),
+                ('survey', models.ForeignKey(to='survey.Survey')),
+            ],
+        ),
+    ]

--- a/survey/migrations/0002_questionnaire.py
+++ b/survey/migrations/0002_questionnaire.py
@@ -18,7 +18,16 @@ class Migration(migrations.Migration):
                 ('questionnaire_id', models.CharField(max_length=10)),
                 ('title', models.CharField(max_length=120)),
                 ('overview', models.TextField(max_length=3000)),
-                ('survey', models.ForeignKey(to='survey.Survey')),
             ],
+        ),
+        migrations.AlterField(
+            model_name='survey',
+            name='survey_id',
+            field=models.CharField(unique=True, max_length=10),
+        ),
+        migrations.AddField(
+            model_name='questionnaire',
+            name='survey',
+            field=models.ForeignKey(to='survey.Survey'),
         ),
     ]

--- a/survey/models.py
+++ b/survey/models.py
@@ -8,3 +8,12 @@ class Survey(models.Model):
     def __unicode__(self):
         return self.title
 
+
+class Questionnaire(models.Model):
+    questionnaire_id = models.CharField(max_length=10)
+    title = models.CharField(max_length=120)
+    overview = models.TextField(max_length=3000)
+    survey = models.ForeignKey(Survey)
+
+    def __unicode__(self):
+        return self.title

--- a/survey/models.py
+++ b/survey/models.py
@@ -3,7 +3,7 @@ from django.db import models
 
 class Survey(models.Model):
     title = models.CharField(max_length=120)
-    survey_id = models.CharField(max_length=10)
+    survey_id = models.CharField(max_length=10, unique=True)
 
     def __unicode__(self):
         return self.title

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -1,11 +1,16 @@
 from django.test import TestCase, Client
-from .models import Survey
+from .models import Survey, Questionnaire
+
+
+def create_surveys():
+    Survey.objects.create(title="Test Survey 1", survey_id="1")
+    Survey.objects.create(title="Test Survey 2", survey_id="2")
 
 
 class SurveyTestCase(TestCase):
+
     def setUp(self):
-        Survey.objects.create(title="Test Survey 1", survey_id="1")
-        Survey.objects.create(title="Test Survey 2", survey_id="2")
+        create_surveys()
 
     def test_survey(self):
         survey1 = Survey.objects.get(survey_id="1")
@@ -45,3 +50,76 @@ class SurveyTestCase(TestCase):
         # attempt to add an invalid survey
         response = client.post('/surveys/add/', {'survey_list': '9999'}, follow=True)
         self.assertContains(response, "Select a valid choice. 9999 is not one of the available choices")
+
+
+class QuestionnaireTestCase(TestCase):
+
+    def setUp(self):
+        create_surveys()
+        Questionnaire.objects.create(title="Test Questionnaire 1", survey=Survey.objects.get(survey_id='1'), questionnaire_id="1", overview='questionnaire overview 1')
+        Questionnaire.objects.create(title="Test Questionnaire 2", survey=Survey.objects.get(survey_id='2'), questionnaire_id="2", overview='questionnaire overview 2')
+
+    def test_questionnaire(self):
+        questionnaire1 = Questionnaire.objects.get(questionnaire_id='1')
+        questionnaire2 = Questionnaire.objects.get(questionnaire_id='2')
+        self.assertEqual("Test Questionnaire 1", questionnaire1.title)
+        self.assertEqual("Test Questionnaire 2", questionnaire2.title)
+        self.assertEqual("questionnaire overview 1", questionnaire1.overview)
+        self.assertEqual("questionnaire overview 2", questionnaire2.overview)
+        self.assertEqual(Survey.objects.get(survey_id='1'), questionnaire1.survey)
+        self.assertEqual(Survey.objects.get(survey_id='2'), questionnaire2.survey)
+
+    def test_check_question_count(self):
+        client = Client()
+        response = client.get("/surveys/")
+
+        # check that survey one has a single questionnaire with id 1
+        survey = response.context['object_list'][0]
+        self.assertEqual(Survey.objects.get(survey_id='1'), survey)
+        questionnaire_set = survey.questionnaire_set.all()
+        self.assertEqual(len(questionnaire_set), 1)
+        self.assertEqual(Questionnaire.objects.get(questionnaire_id='1'), questionnaire_set[0])
+
+        # check that survey two has a single questionnaire with id 2
+        survey = response.context['object_list'][1]
+        self.assertEqual(Survey.objects.get(survey_id='2'), survey)
+        questionnaire_set = survey.questionnaire_set.all()
+        self.assertEqual(len(questionnaire_set), 1)
+        self.assertEqual(Questionnaire.objects.get(questionnaire_id='2'), questionnaire_set[0])
+
+    def test_add_questionnaire(self):
+        client = Client()
+
+        # add a new questionnaire to survey 1
+        response = client.post("/surveys/questionnaire/1/", {'title' : 'Test Questionnaire 3', 'questionnaire_id': '3', 'overview': 'questionnaire overview 3'}, follow=True)
+        self.assertEqual(200, response.status_code)
+
+        # now check that survey 1 has two questionnaires
+        response = client.get("/surveys/")
+        survey = response.context['object_list'][0]
+        self.assertEqual(Survey.objects.get(survey_id='1'), survey)
+        questionnaire_set = survey.questionnaire_set.all()
+        self.assertEqual(len(questionnaire_set), 2)
+        self.assertEqual(Questionnaire.objects.get(questionnaire_id='3'), questionnaire_set[0])
+        self.assertEqual(Questionnaire.objects.get(questionnaire_id='1'), questionnaire_set[1])
+
+    def test_add_questionnaire_fails_when_overview_is_missing(self):
+        client = Client()
+        # attempt to add an invalid questionnaire (i.e. missing the overview field)
+        response = client.post("/surveys/questionnaire/1/", {'title': 'Test Questionnaire 4', 'questionnaire_id': '4'}, follow=True)
+
+        self.assertContains(response, "This field is required")
+
+    def test_add_questionnaire_fails_when_title_is_missing(self):
+        client = Client()
+        # attempt to add an invalid questionnaire (i.e. missing the overview field)
+        response = client.post("/surveys/questionnaire/1/", {'questionnaire_id': '4', 'overview': 'questionnaire overview 4'}, follow=True)
+
+        self.assertContains(response, "This field is required")
+
+    def test_add_questionnaire_fails_when_id_is_missing(self):
+        client = Client()
+        # attempt to add an invalid questionnaire (i.e. missing the overview field)
+        response = client.post("/surveys/questionnaire/1/", {'title': 'Test Questionnaire 4', 'overview': 'questionnaire overview 4'}, follow=True)
+
+        self.assertContains(response, "This field is required")

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -51,6 +51,29 @@ class SurveyTestCase(TestCase):
         response = client.post('/surveys/add/', {'survey_list': '9999'}, follow=True)
         self.assertContains(response, "Select a valid choice. 9999 is not one of the available choices")
 
+    def test_add_survey_fails_if_already_added(self):
+        client = Client()
+
+        # first see how many surveys exist
+        response = client.get('/surveys/')
+        self.assertEqual(len(response.context['object_list']), 2)
+
+         # now add a new survey
+        response = client.post('/surveys/add/', {'survey_list': '024'}, follow=True)
+        self.assertEqual(200, response.status_code)
+        # check we've got an additional survey
+        self.assertEqual(len(response.context['object_list']), 3)
+
+        # now attempt to add the same survey
+        response = client.post('/surveys/add/', {'survey_list': '024'}, follow=True)
+
+        # check we got an error message
+        self.assertContains(response, "Survey has already been added")
+
+        # check we've still got 3
+        response = client.get('/surveys/')
+        self.assertEqual(len(response.context['object_list']), 3)
+
 
 class QuestionnaireTestCase(TestCase):
 

--- a/survey/urls.py
+++ b/survey/urls.py
@@ -1,7 +1,8 @@
 from django.conf.urls import url
-from .views import SurveyList, SurveyCreate
+from .views import SurveyList, SurveyCreate, QuestionnaireCreate
 
 urlpatterns = [
     url(r'add/$', SurveyCreate.as_view(), name='create'),
+    url(r'questionnaire/(.*)/$', QuestionnaireCreate.as_view(), name='create-questionnaire'),
     url(r'$', SurveyList.as_view(), name='index'),
 ]

--- a/survey/views.py
+++ b/survey/views.py
@@ -1,6 +1,7 @@
 from django.views.generic import ListView, CreateView
 from django.core.urlresolvers import reverse
-from .models import Survey
+from django.http import HttpRequest, HttpResponse
+from .models import Survey, Questionnaire
 from .forms import SurveyForm
 
 
@@ -11,6 +12,19 @@ class SurveyList(ListView):
 class SurveyCreate(CreateView):
     model = Survey
     form_class = SurveyForm
+
+    def get_success_url(self):
+        return reverse("survey:index")
+
+
+class QuestionnaireCreate(CreateView):
+    model = Questionnaire
+    fields = ['title', 'questionnaire_id', 'overview']
+
+    def form_valid(self, form):
+        survey = Survey.objects.get(survey_id=self.args[0])
+        form.instance.survey = survey
+        return super(QuestionnaireCreate, self).form_valid(form)
 
     def get_success_url(self):
         return reverse("survey:index")

--- a/templates/survey/questionnaire_form.html
+++ b/templates/survey/questionnaire_form.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block base_body %}
+    <h2>Setup new questionnaire</h2>
+    <form action="" method="post">{% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="Create" />
+</form>
+{% endblock base_body%}
+
+

--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -3,12 +3,26 @@
     <section class="row fullvh">
         <div>
             <h2>Surveys</h2>
-            <a href="{%  url 'survey:create' %}">Add new survey</a>
-            <ul>
-                {% for survey in object_list %}
-                    <li>{{ survey.title}}</li>
-                {% endfor %}
-            </ul>
+            <p>
+                <a href="{%  url 'survey:create' %}">Add new survey</a>
+            </p>
+            <p>
+                <ul>
+                    {% for survey in object_list %}
+                        <li>{{ survey.title}}</li>
+                            <ul>
+                            {%  for questionnaire in survey.questionnaire_set.all %}
+                                <li>{{ questionnaire.title }}</li>
+                            {% endfor %}
+                            <li>
+                                <a href="{%  url 'survey:create-questionnaire' survey.survey_id %}">Add new questionnaire</a>
+                            </li>
+                        </ul>
+
+                    {% endfor %}
+                </ul>
+            </p>
+
         </div>
     </section>
 {% endblock base_body%}


### PR DESCRIPTION
**What**
This pull request delivers the functionality for DIGEQ-3 - Add a new questionnaire. It will allow an user to create a new questionnaire linked to a activated survey in the Digital EQ system 

**How to test**

1. Check out this branch: git checkout digeq-3-create-new-questionnaire
2. Create a Virtual Environment: mkvirtualenv digeq-3
3. Install requirements: pip install -r requirements.txt
4. Run database migration: python manage.py migrate
5. Run collect static: python manage.py collectstatic
6. Run the server: python manage.py runserver
7. Browse to http://127.0.0.1:8000/surveys/
8. Click add new survey
9. Select a survey and click create.
11. Click 'add new questionnaire'
12. Enter title, overview and id
13. Click create

**Who can review**
Anyone on Digital EQ apart from @warren-methods