### PR TITLE
DIGEQ-1 protecting survey screens. Fixing login screen.

### DIFF
--- a/author/settings.py
+++ b/author/settings.py
@@ -147,4 +147,4 @@ LOGGING = {
 }
 
 LOGIN_URL = reverse_lazy('login')
-LOGIN_REDIRECT_URL = reverse_lazy('welcome')
+LOGIN_REDIRECT_URL = reverse_lazy('survey:index')

--- a/author/static/js/app.js
+++ b/author/static/js/app.js
@@ -11,23 +11,23 @@ $(function() { // dom is ready
 
   /* set class based on correct/incorrect sign in */
 
-  $("#dosignin").submit(function(event) {
-    if ($('#password').val() !== "password") {
-      $('.pwd-container label').addClass("wrong");
-      $('.signin-error').fadeIn();
-      setTimeout(function() {
-        $('.pwd-container label').removeClass("wrong");
-        $('.signin-error').fadeOut();
-        $('#password').val("").focus();
-      }, 4000);
-    } else if ($('#password').val() === "password") {
-      $('.pwd-container').addClass("correct");
-      setTimeout(function() {
-        $('.pwd-container').removeClass("correct");
-      }, 4000);
-    }
-    event.preventDefault();
-  });
+  //$("#dosignin").submit(function(event) {
+  //  if ($('#password').val() !== "password") {
+  //    $('.pwd-container label').addClass("wrong");
+  //    $('.signin-error').fadeIn();
+  //    setTimeout(function() {
+  //      $('.pwd-container label').removeClass("wrong");
+  //      $('.signin-error').fadeOut();
+  //      $('#password').val("").focus();
+  //    }, 4000);
+  //    event.preventDefault();
+  //  } else if ($('#password').val() === "password") {
+  //    $('.pwd-container').addClass("correct");
+  //    setTimeout(function() {
+  //      $('.pwd-container').removeClass("correct");
+  //    }, 4000);
+  //  }
+  //});
 
   /* user settings panel */
 

--- a/survey/views.py
+++ b/survey/views.py
@@ -3,13 +3,14 @@ from django.core.urlresolvers import reverse
 from django.http import HttpRequest, HttpResponse
 from .models import Survey, Questionnaire
 from .forms import SurveyForm
+from author.views import LoginRequiredMixin
 
 
-class SurveyList(ListView):
+class SurveyList(LoginRequiredMixin, ListView):
     model = Survey
 
 
-class SurveyCreate(CreateView):
+class SurveyCreate(LoginRequiredMixin, CreateView):
     model = Survey
     form_class = SurveyForm
 
@@ -17,7 +18,7 @@ class SurveyCreate(CreateView):
         return reverse("survey:index")
 
 
-class QuestionnaireCreate(CreateView):
+class QuestionnaireCreate(LoginRequiredMixin, CreateView):
     model = Questionnaire
     fields = ['title', 'questionnaire_id', 'overview']
 


### PR DESCRIPTION
*What**
This pull request fixes the login screen, i.e. allows the user to login with a password other than 'password'. It also protects the survey screens, forcing the user to login first. After login the user is automatically redirected to the survey page.

**How to test**
1. Check out the branch and start the survey
2. Navigate to the login page http://127.0.0.1:8000/login/
3. Login with valid credentials
4. Logout and then attempt to access the survey pages directly http://127.0.0.1:8000/surveys/

**Who can review**
Anyone apart from @warren-methods and @weapdiv-david 

**Note**
Alex's code for restricting the users password to 'password' has been commented out rather than removed to allow him to change it if necessary.