### PR TITLE
Digeq 4 add question to questionnaire

### DIFF
--- a/survey/migrations/0003_question.py
+++ b/survey/migrations/0003_question.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0002_questionnaire'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Question',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('title', models.CharField(max_length=120)),
+                ('description', models.TextField(max_length=500)),
+                ('help_text', models.CharField(max_length=120)),
+                ('error_text', models.CharField(max_length=120)),
+                ('questionnaire', models.ForeignKey(to='survey.Questionnaire')),
+            ],
+        ),
+    ]

--- a/survey/models.py
+++ b/survey/models.py
@@ -10,10 +10,22 @@ class Survey(models.Model):
 
 
 class Questionnaire(models.Model):
-    questionnaire_id = models.CharField(max_length=10)
+    questionnaire_id = models.CharField(max_length=10, unique=True)
     title = models.CharField(max_length=120)
     overview = models.TextField(max_length=3000)
     survey = models.ForeignKey(Survey)
 
     def __unicode__(self):
         return self.title
+
+
+class Question(models.Model):
+    title = models.CharField(max_length=120)
+    description = models.TextField(max_length=500)
+    help_text = models.CharField(max_length=120)
+    error_text = models.CharField(max_length=120)
+    questionnaire = models.ForeignKey(Questionnaire)
+
+    def __unicode__(self):
+        return self.title
+

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -38,53 +38,53 @@ class SurveyTestCase(TestCase):
         self.assertEqual("Test Survey 2", survey2.title)
 
     def test_check_survey_count(self):
-        response = SurveyTestCase.client.get('/surveys/', follow=True)
+        response = SurveyTestCase.client.get(reverse('survey:index'), follow=True)
         self.assertEqual(len(response.context['object_list']), 2)
 
     def test_add_survey(self):
         # first see how many surveys exist (2 are added in the setup method)
-        response = SurveyTestCase.client.get('/surveys/')
+        response = SurveyTestCase.client.get(reverse('survey:index'))
         self.assertEqual(len(response.context['object_list']), 2)
 
         # now add a new survey
-        response = SurveyTestCase.client.post('/surveys/add/', {'survey_list': '024'}, follow=True)
+        response = SurveyTestCase.client.post(reverse('survey:create'), {'survey_list': '024'}, follow=True)
         self.assertEqual(200, response.status_code)
         # check we've got an additional survey
         self.assertEqual(len(response.context['object_list']), 3)
 
         # double check by sending a request to the main survey page again
-        response = SurveyTestCase.client.get('/surveys/')
+        response = SurveyTestCase.client.get(reverse('survey:index'))
         self.assertEqual(len(response.context['object_list']), 3)
 
     def test_add_survey_fails(self):
         # first see how many surveys exist
-        response = SurveyTestCase.client.get('/surveys/')
+        response = SurveyTestCase.client.get(reverse('survey:index'))
         self.assertEqual(len(response.context['object_list']), 2)
 
         # attempt to add an invalid survey
-        response = SurveyTestCase.client.post('/surveys/add/', {'survey_list': '9999'}, follow=True)
+        response = SurveyTestCase.client.post(reverse('survey:create'), {'survey_list': '9999'}, follow=True)
         self.assertContains(response, "Select a valid choice. 9999 is not one of the available choices")
 
     def test_add_survey_fails_if_already_added(self):
 
         # first see how many surveys exist
-        response = SurveyTestCase.client.get('/surveys/')
+        response = SurveyTestCase.client.get(reverse('survey:index'))
         self.assertEqual(len(response.context['object_list']), 2)
 
         # now add a new survey
-        response = SurveyTestCase.client.post('/surveys/add/', {'survey_list': '024'}, follow=True)
+        response = SurveyTestCase.client.post(reverse('survey:create'), {'survey_list': '024'}, follow=True)
         self.assertEqual(200, response.status_code)
         # check we've got an additional survey
         self.assertEqual(len(response.context['object_list']), 3)
 
         # now attempt to add the same survey
-        response = SurveyTestCase.client.post('/surveys/add/', {'survey_list': '024'}, follow=True)
+        response = SurveyTestCase.client.post(reverse('survey:create'), {'survey_list': '024'}, follow=True)
 
         # check we got an error message
         self.assertContains(response, "Survey has already been added")
 
         # check we've still got 3
-        response = SurveyTestCase.client.get('/surveys/')
+        response = SurveyTestCase.client.get(reverse('survey:index'))
         self.assertEqual(len(response.context['object_list']), 3)
 
 
@@ -109,7 +109,7 @@ class QuestionnaireTestCase(TestCase):
         self.assertEqual(Survey.objects.get(survey_id='2'), questionnaire2.survey)
 
     def test_check_question_count(self):
-        response = QuestionnaireTestCase.client.get("/surveys/")
+        response = QuestionnaireTestCase.client.get(reverse('survey:index'))
         # check that survey one has a single questionnaire with id 1
         survey = response.context['object_list'][0]
         self.assertEqual(Survey.objects.get(survey_id='1'), survey)
@@ -126,11 +126,11 @@ class QuestionnaireTestCase(TestCase):
 
     def test_add_questionnaire(self):
         # add a new questionnaire to survey 1
-        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/new/1/", {'title' : 'Test Questionnaire 3', 'questionnaire_id': '3', 'overview': 'questionnaire overview 3'}, follow=True)
+        response = QuestionnaireTestCase.client.post(reverse("survey:create-questionnaire", kwargs={'survey_slug': '1'}), {'title' : 'Test Questionnaire 3', 'questionnaire_id': '3', 'overview': 'questionnaire overview 3'}, follow=True)
         self.assertEqual(200, response.status_code)
 
         # now check that survey 1 has two questionnaires
-        response = QuestionnaireTestCase.client.get("/surveys/")
+        response = QuestionnaireTestCase.client.get(reverse('survey:index'))
         survey = response.context['object_list'][0]
         self.assertEqual(Survey.objects.get(survey_id='1'), survey)
         questionnaire_set = survey.questionnaire_set.all()
@@ -140,17 +140,17 @@ class QuestionnaireTestCase(TestCase):
 
     def test_add_questionnaire_fails_when_overview_is_missing(self):
         # attempt to add an invalid questionnaire (i.e. missing the overview field)
-        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/new/1/", {'title': 'Test Questionnaire 4', 'questionnaire_id': '4'}, follow=True)
+        response = QuestionnaireTestCase.client.post(reverse("survey:create-questionnaire", kwargs={'survey_slug': '1'}), {'title': 'Test Questionnaire 4', 'questionnaire_id': '4'}, follow=True)
         self.assertContains(response, "This field is required")
 
     def test_add_questionnaire_fails_when_title_is_missing(self):
         # attempt to add an invalid questionnaire (i.e. missing the overview field)
-        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/new/1/", {'questionnaire_id': '4', 'overview': 'questionnaire overview 4'}, follow=True)
+        response = QuestionnaireTestCase.client.post(reverse("survey:create-questionnaire", kwargs={'survey_slug': '1'}), {'questionnaire_id': '4', 'overview': 'questionnaire overview 4'}, follow=True)
         self.assertContains(response, "This field is required")
 
     def test_add_questionnaire_fails_when_id_is_missing(self):
         # attempt to add an invalid questionnaire (i.e. missing the overview field)
-        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/new/1/", {'title': 'Test Questionnaire 4', 'overview': 'questionnaire overview 4'}, follow=True)
+        response = QuestionnaireTestCase.client.post(reverse("survey:create-questionnaire", kwargs={'survey_slug': '1'}), {'title': 'Test Questionnaire 4', 'overview': 'questionnaire overview 4'}, follow=True)
         self.assertContains(response, "This field is required")
 
 
@@ -186,7 +186,7 @@ class QuestionTestCase(TestCase):
             index += 1
 
     def test_check_question_count(self):
-        response = QuestionTestCase.client.get("/surveys/")
+        response = QuestionTestCase.client.get(reverse('survey:index'))
 
         # check that survey one has a single questionnaire with id 1
         survey = response.context['object_list'][0]
@@ -210,7 +210,7 @@ class QuestionTestCase(TestCase):
         response = QuestionTestCase.client.post(reverse("survey:create-question", kwargs={'questionnaire_slug': '2'}), {'title': 'Test Question 6', 'description': 'question description 6', 'help_text': 'question help text 6', 'error_text' : 'question error text 6'}, follow=True)
         self.assertEqual(200, response.status_code)
         # now check that questionnaire 2 has 3 questions
-        response = QuestionTestCase.client.get("/surveys/questionnaire/2/")
+        response = QuestionTestCase.client.get(reverse("survey:questionnaire-summary", kwargs={'slug': '2'}))
         questionnaire = response.context['object']
         self.assertEqual(Questionnaire.objects.get(questionnaire_id="2"), questionnaire)
         question_set = questionnaire.question_set.all()

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -1,6 +1,7 @@
+from django.core.urlresolvers import reverse
 from django.test import TestCase, Client
-from .models import Survey, Questionnaire
 from author.tests import create_user
+from .models import Survey, Questionnaire, Question
 
 
 def create_surveys():
@@ -15,6 +16,11 @@ def login(user, email, password):
     return client
 
 
+def create_questionnaires():
+    Questionnaire.objects.create(title="Test Questionnaire 1", survey=Survey.objects.get(survey_id='1'), questionnaire_id="1", overview='questionnaire overview 1')
+    Questionnaire.objects.create(title="Test Questionnaire 2", survey=Survey.objects.get(survey_id='2'), questionnaire_id="2", overview='questionnaire overview 2')
+
+
 class SurveyTestCase(TestCase):
 
     @classmethod
@@ -23,6 +29,7 @@ class SurveyTestCase(TestCase):
 
     def setUp(self):
         create_surveys()
+        create_questionnaires()
 
     def test_survey(self):
         survey1 = Survey.objects.get(survey_id="1")
@@ -89,8 +96,7 @@ class QuestionnaireTestCase(TestCase):
 
     def setUp(self):
         create_surveys()
-        Questionnaire.objects.create(title="Test Questionnaire 1", survey=Survey.objects.get(survey_id='1'), questionnaire_id="1", overview='questionnaire overview 1')
-        Questionnaire.objects.create(title="Test Questionnaire 2", survey=Survey.objects.get(survey_id='2'), questionnaire_id="2", overview='questionnaire overview 2')
+        create_questionnaires()
 
     def test_questionnaire(self):
         questionnaire1 = Questionnaire.objects.get(questionnaire_id='1')
@@ -104,7 +110,6 @@ class QuestionnaireTestCase(TestCase):
 
     def test_check_question_count(self):
         response = QuestionnaireTestCase.client.get("/surveys/")
-
         # check that survey one has a single questionnaire with id 1
         survey = response.context['object_list'][0]
         self.assertEqual(Survey.objects.get(survey_id='1'), survey)
@@ -121,7 +126,7 @@ class QuestionnaireTestCase(TestCase):
 
     def test_add_questionnaire(self):
         # add a new questionnaire to survey 1
-        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/1/", {'title' : 'Test Questionnaire 3', 'questionnaire_id': '3', 'overview': 'questionnaire overview 3'}, follow=True)
+        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/new/1/", {'title' : 'Test Questionnaire 3', 'questionnaire_id': '3', 'overview': 'questionnaire overview 3'}, follow=True)
         self.assertEqual(200, response.status_code)
 
         # now check that survey 1 has two questionnaires
@@ -135,18 +140,94 @@ class QuestionnaireTestCase(TestCase):
 
     def test_add_questionnaire_fails_when_overview_is_missing(self):
         # attempt to add an invalid questionnaire (i.e. missing the overview field)
-        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/1/", {'title': 'Test Questionnaire 4', 'questionnaire_id': '4'}, follow=True)
-
+        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/new/1/", {'title': 'Test Questionnaire 4', 'questionnaire_id': '4'}, follow=True)
         self.assertContains(response, "This field is required")
 
     def test_add_questionnaire_fails_when_title_is_missing(self):
         # attempt to add an invalid questionnaire (i.e. missing the overview field)
-        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/1/", {'questionnaire_id': '4', 'overview': 'questionnaire overview 4'}, follow=True)
-
+        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/new/1/", {'questionnaire_id': '4', 'overview': 'questionnaire overview 4'}, follow=True)
         self.assertContains(response, "This field is required")
 
     def test_add_questionnaire_fails_when_id_is_missing(self):
         # attempt to add an invalid questionnaire (i.e. missing the overview field)
-        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/1/", {'title': 'Test Questionnaire 4', 'overview': 'questionnaire overview 4'}, follow=True)
+        response = QuestionnaireTestCase.client.post("/surveys/questionnaire/new/1/", {'title': 'Test Questionnaire 4', 'overview': 'questionnaire overview 4'}, follow=True)
+        self.assertContains(response, "This field is required")
 
+
+class QuestionTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = login(user="question-user", email="question-user@example.com", password="password")
+
+    def setUp(self):
+        create_surveys()
+        create_questionnaires()
+        # first questionnaire has three questions
+        Question.objects.create(title="Test Question 1", questionnaire=Questionnaire.objects.get(questionnaire_id='1'), description='question description 1', help_text='question help text 1', error_text='question error text 1')
+        Question.objects.create(title="Test Question 2", questionnaire=Questionnaire.objects.get(questionnaire_id='1'), description='question description 2', help_text='question help text 2', error_text='question error text 2')
+        Question.objects.create(title="Test Question 3", questionnaire=Questionnaire.objects.get(questionnaire_id='1'), description='question description 3', help_text='question help text 3', error_text='question error text 3')
+
+        # whilst the second questionnaire has two questions
+        Question.objects.create(title="Test Question 4", questionnaire=Questionnaire.objects.get(questionnaire_id='2'), description='question description 4', help_text='question help text 4', error_text='question error text 4')
+        Question.objects.create(title="Test Question 5", questionnaire=Questionnaire.objects.get(questionnaire_id='2'), description='question description 5', help_text='question help text 5', error_text='question error text 5')
+
+    def test_question(self):
+        index = 1
+        for question in Question.objects.order_by('title').all():
+            self.assertEqual("Test Question %d" % index, question.title)
+            if index < 4:
+                self.assertEqual(Questionnaire.objects.get(questionnaire_id='1'), question.questionnaire)
+            else:
+                self.assertEqual(Questionnaire.objects.get(questionnaire_id='2'), question.questionnaire)
+            self.assertEqual("question description %d" % index, question.description)
+            self.assertEqual("question help text %d" % index, question.help_text)
+            self.assertEqual("question error text %d" % index, question.error_text)
+            index += 1
+
+    def test_check_question_count(self):
+        response = QuestionTestCase.client.get("/surveys/")
+
+        # check that survey one has a single questionnaire with id 1
+        survey = response.context['object_list'][0]
+        questionnaire_set = survey.questionnaire_set.all()
+        self.assertEqual(Questionnaire.objects.get(questionnaire_id='1'), questionnaire_set[0])
+
+        # now check that questionnaire 1 has three questions
+        question_set = questionnaire_set[0].question_set.all()
+        self.assertEqual(len(question_set), 3)
+
+        # check that survey two has a single questionnaire with id 2
+        survey = response.context['object_list'][1]
+        questionnaire_set = survey.questionnaire_set.all()
+        self.assertEqual(Questionnaire.objects.get(questionnaire_id='2'), questionnaire_set[0])
+
+        question_set = questionnaire_set[0].question_set.all()
+        self.assertEqual(len(question_set), 2)
+
+    def test_add_question(self):
+        # add a new question to questionnaire 2
+        response = QuestionTestCase.client.post(reverse("survey:create-question", kwargs={'questionnaire_slug': '2'}), {'title': 'Test Question 6', 'description': 'question description 6', 'help_text': 'question help text 6', 'error_text' : 'question error text 6'}, follow=True)
+        self.assertEqual(200, response.status_code)
+        # now check that questionnaire 2 has 3 questions
+        response = QuestionTestCase.client.get("/surveys/questionnaire/2/")
+        questionnaire = response.context['object']
+        self.assertEqual(Questionnaire.objects.get(questionnaire_id="2"), questionnaire)
+        question_set = questionnaire.question_set.all()
+        self.assertEqual(len(question_set), 3)
+
+    def test_add_question_fails_with_missing_title(self):
+        response = QuestionTestCase.client.post(reverse("survey:create-question", kwargs={'questionnaire_slug': '2'}), {'description': 'question description 6', 'help_text': 'question help text 6', 'error_text' : 'question error text 6'}, follow=True)
+        self.assertContains(response, "This field is required")
+
+    def test_add_question_fails_with_missing_description(self):
+        response = QuestionTestCase.client.post(reverse("survey:create-question", kwargs={'questionnaire_slug': '2'}), {'title': 'Test Question 6', 'help_text': 'question help text 6', 'error_text' : 'question error text 6'}, follow=True)
+        self.assertContains(response, "This field is required")
+
+    def test_add_question_fails_with_missing_help_text(self):
+        response = QuestionTestCase.client.post(reverse("survey:create-question", kwargs={'questionnaire_slug': '2'}), {'title': 'Test Question 6', 'description': 'question description 6', 'error_text' : 'question error text 6'}, follow=True)
+        self.assertContains(response, "This field is required")
+
+    def test_add_question_fails_with_missing_error_text(self):
+        response = QuestionTestCase.client.post(reverse("survey:create-question", kwargs={'questionnaire_slug': '2'}), {'title': 'Test Question 6', 'description': 'question description 6', 'help_text': 'question help text 6'}, follow=True)
         self.assertContains(response, "This field is required")

--- a/survey/urls.py
+++ b/survey/urls.py
@@ -1,8 +1,10 @@
 from django.conf.urls import url
-from .views import SurveyList, SurveyCreate, QuestionnaireCreate
+from .views import SurveyList, SurveyCreate, QuestionnaireCreate, QuestionCreate, QuestionnaireDetail
 
 urlpatterns = [
     url(r'add/$', SurveyCreate.as_view(), name='create'),
-    url(r'questionnaire/(.*)/$', QuestionnaireCreate.as_view(), name='create-questionnaire'),
+    url(r'questionnaire/new/(.*)/$', QuestionnaireCreate.as_view(), name='create-questionnaire'),
+    url(r'questionnaire/(?P<slug>[-\w]+)/$', QuestionnaireDetail.as_view(), name='questionnaire-summary'),
+    url(r'question/(?P<questionnaire_slug>[-\w]+)$', QuestionCreate.as_view(), name='create-question'),
     url(r'$', SurveyList.as_view(), name='index'),
 ]

--- a/survey/urls.py
+++ b/survey/urls.py
@@ -3,7 +3,7 @@ from .views import SurveyList, SurveyCreate, QuestionnaireCreate, QuestionCreate
 
 urlpatterns = [
     url(r'add/$', SurveyCreate.as_view(), name='create'),
-    url(r'questionnaire/new/(.*)/$', QuestionnaireCreate.as_view(), name='create-questionnaire'),
+    url(r'questionnaire/new/(?P<survey_slug>[-\w]+)/$', QuestionnaireCreate.as_view(), name='create-questionnaire'),
     url(r'questionnaire/(?P<slug>[-\w]+)/$', QuestionnaireDetail.as_view(), name='questionnaire-summary'),
     url(r'question/(?P<questionnaire_slug>[-\w]+)$', QuestionCreate.as_view(), name='create-question'),
     url(r'$', SurveyList.as_view(), name='index'),

--- a/survey/views.py
+++ b/survey/views.py
@@ -27,7 +27,7 @@ class QuestionnaireCreate(LoginRequiredMixin, CreateView):
     fields = ['title', 'questionnaire_id', 'overview']
 
     def form_valid(self, form):
-        survey = Survey.objects.get(survey_id=self.args[0])
+        survey = Survey.objects.get(survey_id=self.kwargs['survey_slug'])
         form.instance.survey = survey
         return super(QuestionnaireCreate, self).form_valid(form)
 

--- a/survey/views.py
+++ b/survey/views.py
@@ -17,7 +17,7 @@ class SurveyCreate(LoginRequiredMixin, CreateView):
         return reverse("survey:index")
 
 
-class QuestionnaireDetail(DetailView):
+class QuestionnaireDetail(LoginRequiredMixin, DetailView):
     model = Questionnaire
     slug_field = 'questionnaire_id'
 
@@ -35,11 +35,11 @@ class QuestionnaireCreate(LoginRequiredMixin, CreateView):
         return reverse("survey:index")
 
 
-class QuestionList(ListView):
+class QuestionList(LoginRequiredMixin, ListView):
     model = Question
 
 
-class QuestionCreate(CreateView):
+class QuestionCreate(LoginRequiredMixin, CreateView):
     model = Question
     fields = ['title', 'description', 'help_text', 'error_text']
 

--- a/survey/views.py
+++ b/survey/views.py
@@ -1,7 +1,6 @@
-from django.views.generic import ListView, CreateView
+from django.views.generic import ListView, CreateView, DetailView
 from django.core.urlresolvers import reverse
-from django.http import HttpRequest, HttpResponse
-from .models import Survey, Questionnaire
+from .models import Survey, Questionnaire, Question
 from .forms import SurveyForm
 from author.views import LoginRequiredMixin
 
@@ -18,6 +17,11 @@ class SurveyCreate(LoginRequiredMixin, CreateView):
         return reverse("survey:index")
 
 
+class QuestionnaireDetail(DetailView):
+    model = Questionnaire
+    slug_field = 'questionnaire_id'
+
+
 class QuestionnaireCreate(LoginRequiredMixin, CreateView):
     model = Questionnaire
     fields = ['title', 'questionnaire_id', 'overview']
@@ -29,3 +33,20 @@ class QuestionnaireCreate(LoginRequiredMixin, CreateView):
 
     def get_success_url(self):
         return reverse("survey:index")
+
+
+class QuestionList(ListView):
+    model = Question
+
+
+class QuestionCreate(CreateView):
+    model = Question
+    fields = ['title', 'description', 'help_text', 'error_text']
+
+    def form_valid(self, form):
+        questionnaire = Questionnaire.objects.get(questionnaire_id=self.kwargs['questionnaire_slug'])
+        form.instance.questionnaire = questionnaire
+        return super(QuestionCreate, self).form_valid(form)
+
+    def get_success_url(self):
+        return reverse("survey:questionnaire-summary", kwargs={'slug': self.kwargs['questionnaire_slug'] })

--- a/templates/survey/question_form.html
+++ b/templates/survey/question_form.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block base_body %}
+     <section class="row fullvh">
+        <div>
+            <h2>Add new question</h2>
+            <form action="" method="post">{% csrf_token %}
+            {{ form.as_p }}
+            <input type="submit" value="Create" />
+            </form>
+        </div>
+    </section>
+{% endblock base_body%}
+
+

--- a/templates/survey/questionnaire_detail.html
+++ b/templates/survey/questionnaire_detail.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block base_body %}
+     <section class="row fullvh">
+        <div>
+            <h1>{{ object.survey }}</h1>
+            <h2>{{ object.title }}</h2>
+            <p>{{ object.overview }}</p>
+            <p></p>
+            {%  for question in object.question_set.all %}
+                <li>{{ question.title }}</li>
+            {% endfor %}
+           <li>
+                <a href="{%  url 'survey:create-question' object.questionnaire_id %}">Add new question</a>
+            </li>
+        </div>
+    </section>
+{% endblock base_body%}
+
+

--- a/templates/survey/questionnaire_detail.html
+++ b/templates/survey/questionnaire_detail.html
@@ -2,15 +2,15 @@
 {% block base_body %}
      <section class="row fullvh">
         <div>
-            <h1>{{ object.survey }}</h1>
-            <h2>{{ object.title }}</h2>
-            <p>{{ object.overview }}</p>
+            <h1>{{ questionnaire.survey }}</h1>
+            <h2>{{ questionnaire.title }}</h2>
+            <p>{{ questionnaire.overview }}</p>
             <p></p>
-            {%  for question in object.question_set.all %}
+            {%  for question in questionnaire.question_set.all %}
                 <li>{{ question.title }}</li>
             {% endfor %}
            <li>
-                <a href="{%  url 'survey:create-question' object.questionnaire_id %}">Add new question</a>
+                <a href="{%  url 'survey:create-question' questionnaire.questionnaire_id %}">Add new question</a>
             </li>
         </div>
     </section>

--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -12,7 +12,7 @@
                         <li>{{ survey.title}}</li>
                             <ul>
                             {%  for questionnaire in survey.questionnaire_set.all %}
-                                <li>{{ questionnaire.title }}</li>
+                                <li><a href="{%  url 'survey:questionnaire-summary' questionnaire.questionnaire_id %}">{{ questionnaire.title }}</a></li>
                             {% endfor %}
                             <li>
                                 <a href="{%  url 'survey:create-questionnaire' survey.survey_id %}">Add new questionnaire</a>


### PR DESCRIPTION
**What**
This pull request delivers the functionality for DIGEQ-4 - Add question to questionnaire. It will allow an user to add a question to a questionnaire.

**Pre-requisites**
1. A user that can access the digital eq system
2. A user which has previously added a survey and created at least one questionnaire

**How to test**
1 Check out this branch: git checkout digeq-4-add-question-to-questionnaire
2 Run the database migrations python manage.py migrate
3 Run the server: python manage.py runserver
4 Browse to http://127.0.0.1:8000/login/ and login with valid credentials
5 Browse to http://127.0.0.1:8000/surveys/
6 Select the Questionnaire to add a question too
7 Click add question 

Who can review
Anyone on Digital EQ apart from @warren-methods and @weapdiv-david 