### PR TITLE
Digeq 10 ux cleanup login screen

### DIFF
--- a/author/tests.py
+++ b/author/tests.py
@@ -42,4 +42,4 @@ class LoginTest(TestCase):
         self.assertTrue(login)
 
         response = self.client.get(reverse('welcome'), follow=True)
-        self.assertContains(response, 'welcome')
+        self.assertContains(response, 'Surveys')

--- a/author/views.py
+++ b/author/views.py
@@ -15,6 +15,9 @@ class LoginRequiredMixin(object):
 class WelcomeView(LoginRequiredMixin, TemplateView):
     template_name = 'welcome.html'
 
+    def get(self, request, *args, **kwargs):
+        return redirect(reverse("survey:index"))
+
 
 class LogoutView(TemplateView):
     def get(self, request):

--- a/installer/migrations/0001_initial.py
+++ b/installer/migrations/0001_initial.py
@@ -11,7 +11,9 @@ def create_superuser(apps, schema_editor):
         email='admin@example.com',
         password=make_password('password'),
         is_superuser=True,
-        is_staff=True
+        is_staff=True,
+        first_name='Admin',
+        last_name='User'
     )
 
     author = User.objects.create(
@@ -19,7 +21,9 @@ def create_superuser(apps, schema_editor):
         email='user@ons.gov.uk',
         password=make_password('password'),
         is_superuser=False,
-        is_staff=True
+        is_staff=True,
+        first_name='Example',
+        last_name='User'
     )
     
 

--- a/templates/includes/navigation.html
+++ b/templates/includes/navigation.html
@@ -7,7 +7,7 @@
       <a href="#" tabindex="4" title="support page">Support</a>
     </nav>
     <ul class="user-menu" title="Settings &amp; Sign Out">
-      <li class="open-settings"><a href="#" tabindex="5">Long User Name</a></li>
+      <li class="open-settings"><a href="#" tabindex="5">{{ user.get_full_name }}</a></li>
     </ul>
   </div>
   <div class="user-settings">

--- a/templates/includes/navigation.html
+++ b/templates/includes/navigation.html
@@ -12,8 +12,8 @@
   </div>
   <div class="user-settings">
     <ul>
-      <li><a href="#" tabindex="6" title="sign out">Sign Out</a></li>
-      <li><a href="#" tabindex="7" title="settings">Settings</a></li>
+      <li><a href="/logout/" tabindex="6" title="sign out">Sign Out</a></li>
+      <!--<li><a href="#" tabindex="7" title="settings">Settings</a></li>-->
     </ul>
   </div>
 </header>

--- a/templates/includes/navigation.html
+++ b/templates/includes/navigation.html
@@ -13,7 +13,7 @@
   <div class="user-settings">
     <ul>
       <li><a href="/logout/" tabindex="6" title="sign out">Sign Out</a></li>
-      <!--<li><a href="#" tabindex="7" title="settings">Settings</a></li>-->
+      {# <li><a href="#" tabindex="7" title="settings">Settings</a></li> #}
     </ul>
   </div>
 </header>

--- a/templates/login.html
+++ b/templates/login.html
@@ -41,3 +41,8 @@
   </section>
 
 {% endblock base_body%}
+
+{% block body_js %}
+  {{ block.super }}
+  <script src="{% static "js/hideShowPassword.min.js" %}"></script>
+{% endblock body_js %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -22,7 +22,7 @@
             <input type="password" name="password" placeholder="" class="pwd" id="password" />
           </label>
           {% if form.errors %}
-          <p class="error signin-error">Incorrect password, please try again</p>
+          <p class="error signin-error" style="display:block;">Incorrect password, please try again</p>
           {% endif %}
         </div>
         <div class="small-12 pwd-funcs">


### PR DESCRIPTION
**What**

- Adds sign-in error message on login screen
- Adds user full name to account dropdown
- Adds show-hide password on login screen
- Adds default logout link to account drop-down
- Hides settings link from account dropdown
- Redirects to /surveys/ as welcome page

**How to test**

1. Fill in the login form with invalid credentials, but **DO NOT SUBMIT**
2. Click show hide password and verify the toggle works
3. Submit the invalid login response
4. Verify the error message appears
5. Login with correct credentials
6. Verify you are taken to the surveys page
7. Click "Add a survey"
8. Verify the name appears in the top right of the screen.
9. Click the name
10. Verify Settings does not appear
11. Click logout
12. Marvel at the ugliness of the default logout page and consult Alex about page flow

**Who can test**

Anybody except @LJBabbage or @weapdiv-david