### PR TITLE
Fix 404 handling in survey review and publish

### DIFF
--- a/survey/views.py
+++ b/survey/views.py
@@ -94,18 +94,20 @@ class QuestionCreate(LoginRequiredMixin, CreateView):
         return result
 
     def get_success_url(self):
-        return reverse("survey:questionnaire-summary", kwargs={'slug': self.kwargs['questionnaire_slug'] })
+        return reverse("survey:questionnaire-summary", kwargs={'slug': self.kwargs['questionnaire_slug']})
 
 
 class QuestionnaireReview(LoginRequiredMixin, View):
     def get(self, *args, **kwargs):
-        questionnaire = Questionnaire.objects.get(questionnaire_id=self.kwargs['slug'])
-        if questionnaire is not None and not questionnaire.reviewed:
-            questionnaire.reviewed = True
-            questionnaire.save()
-            return redirect(reverse("survey:questionnaire-summary", kwargs={'slug': self.kwargs['slug'] }))
 
-        return Http404()
+        questionnaire = Questionnaire.objects.get(questionnaire_id=self.kwargs['slug'])
+        if questionnaire is not None:
+            if not questionnaire.reviewed:
+                questionnaire.reviewed = True
+                questionnaire.save()
+            return redirect(reverse("survey:questionnaire-summary", kwargs={'slug': self.kwargs['slug']}))
+
+        raise Http404
 
 
 class QuestionnairePublish(LoginRequiredMixin, View):
@@ -113,11 +115,11 @@ class QuestionnairePublish(LoginRequiredMixin, View):
         questionnaire = Questionnaire.objects.get(questionnaire_id=self.kwargs['slug'])
 
         if questionnaire is None:
-            return Http404()
+            raise Http404
 
         if questionnaire.reviewed:
             questionnaire.published = True
             questionnaire.save()
 
-            return redirect(reverse("survey:questionnaire-summary", kwargs={'slug': self.kwargs['slug'] }))
+            return redirect(reverse("survey:questionnaire-summary", kwargs={'slug': self.kwargs['slug']}))
 


### PR DESCRIPTION
**What**

Fixes the incorrectly implemented 404 handling on survey publish and survey review.

**How to test**

1) Login to the application
2) Visit a url such as `/surveys/questionnaire/12341254/review` where 12341254 is a non existing survey
3) Verify that you get a DoesNotExist exception (we need a better page)
4) Visit a url such as  `/surveys/questionnaire/12341254/publish` where 12341254 is a non existing survey
5) Verify we get a `DoesNotExist` exception

**Who**

Anybody except @weapdiv-david