### PR TITLE
DIGEQ-80 Remove forgotten password link

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -27,7 +27,7 @@
         </div>
         <div class="small-12 pwd-funcs">
           <p class="pwd-toggle"><i class="fa fa-eye"></i><span>Show</span> Password</p>
-          <p class="pwd-remind"><i class="fa fa-question"></i><a href="#">Forgotten Password?</a></p>
+          {% comment %}<p class="pwd-remind"><i class="fa fa-question"></i><a href="#">Forgotten Password?</a></p>{% endcomment %}
           <input type="submit" class="button small radius" value="Sign In">
         </div>
           <input type="hidden" name="next" value="{{ next }}" />


### PR DESCRIPTION
**What**
Remove the forgotten password link from the sign in screen

**How to test**
1. Checkout this branch digeq-80-forgotten-password
2. Run the server ./manage.py runserver
3. Browse to http://127.0.0.1:8000/login
4. Observe that the forgotten password link no longer exists

**Who can test**
Anyone apart from @warren-methods