### PR TITLE
Alter API to include more data fields to Survey view.

### DIFF
--- a/survey/views.py
+++ b/survey/views.py
@@ -48,11 +48,14 @@ class QuestionnaireAPIDetail(DetailView):
 
     def get_data(self, context):
         rtn_obj = {}
+        rtn_obj['title'] = context['object'].survey.title
+        rtn_obj['questionnaire_id'] = context['object'].questionnaire_id
         rtn_obj['questionnaire_title'] = context['object'].title
         rtn_obj['overview'] = context['object'].overview
         rtn_obj['questions'] = []
         for question in context['object'].question_set.all():
             quest_obj = {'title':question.title,
+                         'description':question.description,
                          'help_text': question.help_text}
             rtn_obj['questions'].append(quest_obj)
         return rtn_obj


### PR DESCRIPTION
__What?__

This PR adds extra fields to the JSON api representing a survey, adding in  help_text and some extra metadata that was missed in sprint 1. It is needed so that we can represent more of the entered data in the survey runner tool, which displays the survey to a respondent.

__How to test__

1. Spin up a new eq-author instance, either locally or on Heroku
2. View the json api for a created questionnaire:
   https://<HOSTNAME>/surveys/api/questionnaire/1/


__Who can test?__

Anyone but @dhilton
