### PR TITLE
DIGEQ-104 clear password on login failure

### DIFF
--- a/author/static/js/app.js
+++ b/author/static/js/app.js
@@ -38,11 +38,12 @@ $(function() { // dom is ready
     $.post('/login/', $('#dosignin').serialize(), function(response) {
       if (response.errors) {
         $('.pwd-container label').addClass("wrong");
+        $('#password').val("")
         $('.signin-error').fadeIn();
         setTimeout(function() {
           $('.pwd-container label').removeClass("wrong");
           $('.signin-error').fadeOut();
-          $('#password').val("").focus();
+          $('#password').focus();
         }, 4000);
       } else {
         $('.pwd-container').addClass("correct");


### PR DESCRIPTION
**What**
Fix for DIGEQ-104 Password Not Cleared on Fail. On the login screen the password field was not cleared immediately when an incorrect password was entered.

**How to test**
1. Checkout this branch and run the server
2. Browse to http://127.0.0.1:8000/login/
3. Attempt to login in with an invalid password

**Who can review**
Anyone on DigitalEQ apart from @warren-methods