### PR TITLE
Retrieved questions ordered by ID. Currently the questions are return…

### DIFF
--- a/survey/tests/test_questionnaire_api.py
+++ b/survey/tests/test_questionnaire_api.py
@@ -30,3 +30,14 @@ class QuestionnaireAPITestCase(TestCase):
             import json
             questionnaire = json.loads(response.content)
             self.assertEqual(3, len(questionnaire['questions']))
+
+        def test_questionnaire_ordering_correct(self):
+            ques_1 = Questionnaire.objects.get(questionnaire_id='1')
+            response = QuestionnaireAPITestCase.client.get(reverse("survey:questionnaire-api", kwargs={'slug': ques_1.pk}), follow=True)
+
+            self.assertEqual(200, response.status_code)
+            import json
+            questionnaire = json.loads(response.content)
+            self.assertEqual('Test Question 1', questionnaire['questions'][0]['title'])
+            self.assertEqual('Test Question 2', questionnaire['questions'][1]['title'])
+            self.assertEqual('Test Question 3', questionnaire['questions'][2]['title'])

--- a/survey/views.py
+++ b/survey/views.py
@@ -53,7 +53,7 @@ class QuestionnaireAPIDetail(DetailView):
         rtn_obj['questionnaire_title'] = context['object'].title
         rtn_obj['overview'] = context['object'].overview
         rtn_obj['questions'] = []
-        for question in context['object'].question_set.all():
+        for question in context['object'].question_set.all().order_by('id'):
             quest_obj = {'title':question.title,
                          'description':question.description,
                          'help_text': question.help_text}


### PR DESCRIPTION
**What**
Currently questions in a questionnaire are displayed in reversed order in the eq-survey running. This change orders the questions by ID so that they appear in the correct order.

**How to test**
1. Checkout this branch and run the server
2. Browse to http://127.0.0.1:8000/login
3. Create a questionnaire with at least two questions
4. Browse to http://127.0.0.1:8000/surveys/api/questionnaire/1/ and ensure the questions are in the correct order in the JSON data

**Who can test**
Anyone on eq-author apart from @warren-methods
