### PR TITLE
Prevents contenteditable from being used as drop taregt

### DIFF
--- a/author/static/js/q_builder/directives.js
+++ b/author/static/js/q_builder/directives.js
@@ -11,6 +11,9 @@
               }
 
               ngModel.$render = function() {
+                // Do not allow drag and drop into contenteditable
+                element.attr("ondragenter", "event.preventDefault(); event.dataTransfer.dropEffect = 'none'");
+                element.attr("ondragover", "event.preventDefault(); event.dataTransfer.dropEffect = 'none'");
                 element.html(ngModel.$viewValue || "");
               };
 


### PR DESCRIPTION
**What**

Fixes an issue whereby the question type icons can be dragged into the title and overview editable fields.

**How to test**

1) Edit a questionnaire
2) Drag a new question into the title field or overview field
3) Verify that the actions did not succeed

**Who can test**

Anybody except @weapdiv-david