### PR TITLE
Docker compose file for eq-author

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:2.7.10
+
+RUN mkdir /opt/eq-author
+ADD . /opt/eq-author
+RUN pip install -r /opt/eq-author/requirements.txt
+WORKDIR /opt/eq-author
+
+ENV SURVEY_RUNNER_URL=http://127.0.0.1:8080/
+ENV USERNAME=author
+ENV PASSWORD=password
+ENV DB_HOST=127.0.0.1
+ENV DB_PORT=5432
+ENV DB_NAME=author
+ENV DATABASE_URL=postgres://$USERNAME:$PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME
+
+EXPOSE 8000
+
+ENTRYPOINT sleep 10 && python manage.py migrate && python manage.py runserver 0.0.0.0:8000

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ the procfile and run your django wsgi application.
 
     $ heroku run python manage.py migrate
 
+
+## Deployment via Docker compose
+1. docker-compose build
+2. docker-compose up
+
 ## Further Reading
 
 - [Gunicorn](https://warehouse.python.org/project/gunicorn/)

--- a/create_database.sql
+++ b/create_database.sql
@@ -1,0 +1,4 @@
+
+CREATE USER author WITH PASSWORD 'password';
+CREATE DATABASE author;
+GRANT ALL PRIVILEGES ON DATABASE author TO author;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+author:
+  build: .
+  ports:
+   - "8000:8000"
+  volumes:
+   - .:/opt/eq-author
+  environment:
+    - SURVEY_RUNNER_URL=http://localhost:8080/
+    - DATABASE_URL=postgres://author:password@postgres:5432/author
+  links:
+    - postgres
+postgres:
+  image: postgres:9.3.10
+  volumes:
+    - ./create_database.sql:/docker-entrypoint-initdb.d/create_database.sql
+survey-runner:
+  image: onsdigital/eq-survey-runner:latest
+  ports:
+    - "8080:8080"
+  environment:
+    - SURVEY_REGISTRY_URL=http://author:8000
+  links:
+   - cassandra
+   - author
+cassandra:
+  image: spotify/cassandra


### PR DESCRIPTION
**What**
Dockerfile for building eq-author.  I've also created a docker-compose file which allows you to run eq-author, eq-survey-runner, postgres and cassandra in separate docker containers but linked together. Which means the whole application can be run locally with a single command.

**How to test**
1. checkout this branch
2. Run `docker-compose build`
3. Run `docker-compose up`

**Who can test**
Anyone apart from @warren-methods