### PR TITLE
digeq-127 drag and drop defect- li removed from list parameters and d…

### DIFF
--- a/templates/survey/questionnaire_builder.html
+++ b/templates/survey/questionnaire_builder.html
@@ -9,6 +9,13 @@
   {{ block.super }}
 {% include "includes/navigation.html" %}
 
+<style>
+    .questionContainer.empty{
+     background-color: pink;
+    }
+
+</style>
+
 <div class="wrapper" ng-app="QBuilder">
 
   <section class="application" ng-controller="BuilderController as builderCtrl">
@@ -21,7 +28,6 @@
   			dnd-drop="dropCallback(event, index, item)"
   			dnd-allowed-types="['item']"
         ng-class="{dragTarget: dragging && dragging.dndType == 'item'}">
-        <li class="start-panel" ng-show="list.length == 0"><i class="fa fa-file-o"></i>Questionnaire empty. Drag a question here to continue.</li>
         <li ng-repeat="item in list"
   				dnd-draggable="item"
   				dnd-effect-allowed="move"
@@ -169,7 +175,7 @@
 
           {% verbatim %}
 
-            <div ng-repeat="list in models.dropzones">
+             <div ng-class="{'empty': list.length == 0}" ng-repeat="list in models.dropzones" class="questionContainer" >
                 <div class="dropzone">
                     <div ng-include="'list.html'"></div>
                 </div>


### PR DESCRIPTION
__What__
The empty questionnaire message was causing the problem with the drag and drop. The li has been moved from inside the list and instead the background of the div is now controlling it

The pink background is just a place holder until Alex updates it

__How to test__
1. Open up the question builder and check that when a questionnaire is empty the drop zone is pink
2. That the pink disappears when an item is dragged in
3. That the question appears in the position it is drag to
4. That if a question is moved, it appears in the right place

__Who can test__ 
Anyone apart from @LJBabbage