### PR TITLE
Digeq 20 lock questionnaire

### DIFF
--- a/author/static/js/q_builder/app.js
+++ b/author/static/js/q_builder/app.js
@@ -18,3 +18,16 @@
 
   // See config.js, and controllers/*.js
 })();
+
+// unlock the questionnaire if the user leaves the page - not ideal but hey
+$(window).bind('beforeunload', function() {
+    var unlock = JSON.stringify({ unlock: "true" });
+    $.ajax({
+       url : window.location,
+       data : unlock,
+       contentType : 'application/json',
+       type : 'POST'
+    })
+});
+
+

--- a/author/static/js/q_builder/controllers/BuilderController.js
+++ b/author/static/js/q_builder/controllers/BuilderController.js
@@ -66,6 +66,15 @@
         });
       };
 
+      $scope.endEdit = function() {
+        $http.post(window.location, {
+          'unlock':'true'
+        }).success(function(data) {
+          $scope.messages = [];
+          $scope.messages.push(data);
+        });
+      };
+
       $scope.dropCallback = function(event, index, item) {
         // check whether we have dropped a new or existing item
         if (!item.hasOwnProperty('questionReference')) {

--- a/author/static/js/q_builder/controllers/BuilderController.js
+++ b/author/static/js/q_builder/controllers/BuilderController.js
@@ -52,8 +52,13 @@
 
       // Load the initial questionnaire state
       $http.get(window.location).success(function(data) {
-        $scope.models.dropzones.questionList = data.questionList;
-        $scope.models.questionnaire_meta = data.meta;
+        if (data.locked) {
+          $scope.messages = [];
+          $scope.messages.push(data);
+        } else {
+          $scope.models.dropzones.questionList = data.questionList;
+          $scope.models.questionnaire_meta = data.meta;
+        }
       });
 
       $scope.saveQuestionnaire = function() {

--- a/author/urls.py
+++ b/author/urls.py
@@ -1,12 +1,13 @@
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
-from author.views import WelcomeView
+from author.views import WelcomeView, LogoutView
 from django.views.generic import TemplateView
 from .views import login
 
 urlpatterns = patterns('',
     url(r'^surveys/', include("survey.urls", namespace='survey')),
+    url(r'^logout/$', LogoutView.as_view()),
     url(r'^login/$', login, {'template_name':'login.html'}),
     url(r'^create/$',  TemplateView.as_view(template_name='create.html'), name='create'),
     url(r'^home/$',  TemplateView.as_view(template_name='index.html'), name='home'),

--- a/author/views.py
+++ b/author/views.py
@@ -12,6 +12,7 @@ from django.contrib.auth import logout, REDIRECT_FIELD_NAME, login as auth_login
 from django.shortcuts import redirect, resolve_url
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from survey.models import Questionnaire
 
 class LoginRequiredMixin(object):
     @classmethod
@@ -29,8 +30,18 @@ class WelcomeView(LoginRequiredMixin, TemplateView):
 
 class LogoutView(TemplateView):
     def get(self, request):
+        print "here"
+        unlock(request)
         logout(request)
         return redirect(reverse('welcome'))
+
+
+def unlock(request):
+    questionnaires = Questionnaire.objects.all().filter(locked_by=request.user.username)
+    for questionnaire in questionnaires:
+        questionnaire.locked_by = None
+        questionnaire.locked_on = None
+        questionnaire.save()
 
 
 @sensitive_post_parameters()

--- a/author/views.py
+++ b/author/views.py
@@ -30,13 +30,12 @@ class WelcomeView(LoginRequiredMixin, TemplateView):
 
 class LogoutView(TemplateView):
     def get(self, request):
-        print "here"
-        unlock(request)
+        unlock_questionnaires(request)
         logout(request)
         return redirect(reverse('welcome'))
 
 
-def unlock(request):
+def unlock_questionnaires(request):
     questionnaires = Questionnaire.objects.all().filter(locked_by=request.user.username)
     for questionnaire in questionnaires:
         questionnaire.locked_by = None

--- a/survey/migrations/0010_lock_questionnaire.py
+++ b/survey/migrations/0010_lock_questionnaire.py
@@ -19,6 +19,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='questionnaire',
             name='locked_on',
-            field=models.DateField(default=None, null=True),
+            field=models.DateTimeField(default=None, null=True),
         ),
     ]

--- a/survey/migrations/0010_lock_questionnaire.py
+++ b/survey/migrations/0010_lock_questionnaire.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0009_remove_question'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='questionnaire',
+            name='locked_by',
+            field=models.TextField(default=None, max_length=120, null=True),
+        ),
+        migrations.AddField(
+            model_name='questionnaire',
+            name='locked_on',
+            field=models.DateField(default=None, null=True),
+        ),
+    ]

--- a/survey/models.py
+++ b/survey/models.py
@@ -19,6 +19,11 @@ class Questionnaire(models.Model):
     reviewed = models.BooleanField(default=False)
     published = models.BooleanField(default=False)
     questionnaire_json = jsonfield.JSONField()
+    locked_on = models.DateField(null=True, default=None)
+    locked_by = models.TextField(max_length=120 , null=True, default=None)
+
+    def is_locked(self, username):
+        return self.locked_by and not self.locked_by == username
 
     def __unicode__(self):
         return self.title

--- a/survey/models.py
+++ b/survey/models.py
@@ -1,4 +1,6 @@
 from django.db import models
+from django.utils import timezone
+from datetime import timedelta
 import jsonfield
 
 
@@ -19,11 +21,40 @@ class Questionnaire(models.Model):
     reviewed = models.BooleanField(default=False)
     published = models.BooleanField(default=False)
     questionnaire_json = jsonfield.JSONField()
-    locked_on = models.DateField(null=True, default=None)
+    locked_on = models.DateTimeField(null=True, default=None)
     locked_by = models.TextField(max_length=120 , null=True, default=None)
 
+    @property
+    def locked(self):
+        self.check_locked_time()
+        return self.locked_by
+
     def is_locked(self, username):
-        return self.locked_by and not self.locked_by == username
+        locked = False
+        # if it's locked
+        if self.locked_by and not self.locked_by == username:
+            # check how long it's been locked for and unlock if necessary
+            self.check_locked_time()
+            # check if its still locked
+            if self.locked_by:
+                locked = True
+        return locked
+
+    def check_locked_time(self):
+        time_now = timezone.now()
+        locked_time = time_now - self.locked_on
+        if locked_time > timedelta(minutes=30):
+            self.unlock()
+
+    def lock(self, username):
+        self.locked_by = username
+        self.locked_on = timezone.now()
+        self.save()
+
+    def unlock(self):
+        self.locked_on = None
+        self.locked_by = None
+        self.save()
 
     def __unicode__(self):
         return self.title

--- a/survey/tests/resources/survey.json
+++ b/survey/tests/resources/survey.json
@@ -1,0 +1,34 @@
+{
+  "meta": {
+    "title": "title",
+    "overview": "overview",
+    "questionnaire_id": "id"
+  },
+  "questionList": [
+    {
+      "questionType": "MultipleChoice",
+      "questionError": "",
+      "questionText": "",
+      "displayConditions": [],
+      "questionReference": "",
+      "skipConditions": [],
+      "parts": [
+        {
+          "type": "option",
+          "name": "red",
+          "value": "trf",
+          "label": ""
+        }
+      ],
+      "dndType": "item",
+      "branchConditions": [],
+      "displayProperties": {},
+      "questionHelp": "",
+      "validation": {
+        "required": true
+      },
+      "type": "radio_question",
+      "children": []
+    }
+  ]
+}

--- a/survey/views.py
+++ b/survey/views.py
@@ -120,7 +120,6 @@ class QuestionnaireBuilder(LoginRequiredMixin, TemplateView):
         return super(QuestionnaireBuilder, self).dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        #import pdb; pdb.set_trace()
         if request.is_ajax():
             questionnaire = Questionnaire.objects.get(id=self.kwargs['pk'])
             if questionnaire.published:
@@ -130,17 +129,16 @@ class QuestionnaireBuilder(LoginRequiredMixin, TemplateView):
             if questionnaire.is_locked(request.user.username):
                 return JsonResponse({'error': 'Locked for editing!'})
             else:
-                 if 'unlock' in json_data:
+                if 'unlock' in json_data:
                     return self.unlock_questionnaire(json_data, questionnaire)
-                 else:
-                    question_meta = json_data['meta']
-                    questionnaire.title = question_meta['title']
-                    questionnaire.overview = question_meta['overview']
-
-                    questionnaire.questionnaire_json = json_data['questionList']
-                    questionnaire.reviewed = False
-                    questionnaire.save()
-                    return JsonResponse({'success': 'Your questionnaire has been saved!'})
+                else:
+                   question_meta = json_data['meta']
+                   questionnaire.title = question_meta['title']
+                   questionnaire.overview = question_meta['overview']
+                   questionnaire.questionnaire_json = json_data['questionList']
+                   questionnaire.reviewed = False
+                   questionnaire.save()
+                   return JsonResponse({'success': 'Your questionnaire has been saved!'})
         return JsonResponse({'error': 'Your questionnaire could not be saved!'})
 
     def unlock_questionnaire(self, json_data, questionnaire):

--- a/templates/survey/questionnaire_builder.html
+++ b/templates/survey/questionnaire_builder.html
@@ -130,7 +130,7 @@
           </div>-->
           {% endverbatim %}
           <input type="submit" class="button small radius save" id="" value="Save Questionnaire" ng-click="saveQuestionnaire(models.dropzones)">
-            <a href={%  url 'survey:index' %} class="button small radius preview">Back to Dashboard</a>
+          <a href={%  url 'survey:index' %} class="button small radius preview" ng-click="endEdit()">Back to Dashboard</a>
 
         {% verbatim %}
 

--- a/templates/survey/questionnaire_builder.html
+++ b/templates/survey/questionnaire_builder.html
@@ -49,7 +49,9 @@
   <!-- Radio button Question -->
 	<script type="text/ng-template" id="radio_question.html">
 		<div class="question-block">
+
 			<radio-question></radio-question>
+
 		</div>
 	</script>
 

--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -71,7 +71,7 @@
                                     {% endif %}
 
                                     {% if not questionnaire.published %}
-                                        {% if questionnaire.locked_by and questionnaire.locked_by != user.username%}
+                                        {% if questionnaire.locked %}
                                             <li>
                                                 <a class="tiny button secondary"
                                                    href="#" onclick="alert('Locked by {{ questionnaire.locked_by}}')"}>Locked</a>

--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -71,12 +71,18 @@
                                     {% endif %}
 
                                     {% if not questionnaire.published %}
-                                    <li>
-                                        <a class="tiny button secondary"
-                                           href="{% url 'survey:questionnaire-builder' questionnaire.id %}">Edit</a>
-                                    </li>
+                                        {% if questionnaire.locked_by and questionnaire.locked_by != user.username%}
+                                            <li>
+                                                <a class="tiny button secondary"
+                                                   href="#" onclick="alert('Locked by {{ questionnaire.locked_by}}')"}>Locked</a>
+                                            </li>
+                                        {% else %}
+                                            <li>
+                                                <a class="tiny button secondary"
+                                                   href="{% url 'survey:questionnaire-builder' questionnaire.id %}" >Edit</a>
+                                            </li>
+                                        {% endif %}
                                     {% endif %}
-
                                 </ul>
                                 </div>
                             </td>


### PR DESCRIPTION
**What**
a questionnaire is locked when the user starts an edit session (i.e. navigates to the questionnaire builder page). A locked questionnaire will become unlocked when one of the following conditions happen:
1. The user clicks on back to dashboard
2. The user navigates away from the questionnaire builder page
3. The user log outs of the system
4. The user has the lock longer than 30 minutes without any activity

**How to test**
1. Checkout this branch
2. Run the server
3. Create an additional user using the django admin screen
4. Open two browsers and log in as a different user on each
5. In one browser create and edit a questionnaire
6. In the other browser navigate to the survey list page and observe that the questionnaire is locked and you're unable to click edit
7. Using the above methods, log out the first user and check that the questionnaire is no longer locked

**Who can review**
Anyone apart from @warren-methods