### PR TITLE
DIG-EQ 67 redesign of the questionnaire builder sections. 

### DIFF
--- a/author/static/js/q_builder/controllers/BuilderController.js
+++ b/author/static/js/q_builder/controllers/BuilderController.js
@@ -9,7 +9,7 @@
     .controller("BuilderController", function($scope, $http) {
 
       var startItem = {
-          questionText: '',
+          questionText: 'Unnamed Section',
           questionHelp: '',
           questionError: '',
           questionReference: 'start',
@@ -24,43 +24,52 @@
           displayConditions: [],
           skipConditions: [],
           branchConditions: [],
+          id : 0,
           parts: []
         };
 
       $scope.messages = [];
       $scope.models = {
         selected: null,
+        section: "0",
+        position: 1,
+        view: 'single',
 
         templates: [{
           type: "text_question",
           description: "Text Question",
           id: 1,
           icon: 'fa-font',
-          dndType: 'item'
+          dndType: 'item',
+          show: ['open', 'single']
         }, {
           type: "number_question",
           description: "Numeric Question",
           id: 1,
           icon: 'fa-list-ol',
-          dndType: 'item'
+          dndType: 'item',
+          show: ['open', 'single']
         }, {
           type: "check_box_question",
           description: "Check Box Question",
           id: 1,
           icon: 'fa-check-square-o',
-          dndType: 'item'
+          dndType: 'item',
+          show: ['open', 'single']
         }, {
           type: "radio_question",
           description: "Multiple Choice Single Answer",
           id: 1,
           icon: 'fa-dot-circle-o',
-          dndType: 'item'
+          dndType: 'item',
+          show: ['open', 'single']
         }, {
           type: "rich_text_block",
           description: "Rich text field",
           id: 1,
           icon: 'fa-pencil-square-o',
-          dndType: 'item'
+          dndType: 'item',
+          show: ['open', 'single']
         }, {
           type: "group",
           description: "Question Group",
@@ -69,7 +78,8 @@
           columns: [
             []
           ],
-          dndType: 'group'
+          dndType: 'group',
+          show: ['open', 'collapsed']
         }, ],
         dropzones: {
            questionList: []
@@ -83,7 +93,8 @@
           $scope.messages.push(data);
         } else {
           if (data.questionList.length != 0) {
-           $scope.models.dropzones.questionList = data.questionList;
+            $scope.models.dropzones.questionList = data.questionList;
+            $scope.models.section = data.questionList[0].id.toString();
           } else {
             $scope.models.dropzones.questionList = [startItem];
           }
@@ -119,9 +130,44 @@
         }
       };
 
+     $scope.next = function() {
+        if ($scope.models.position < $scope.models.dropzones.questionList.length) {
+            $scope.models.position = $scope.models.position + 1;
+            $scope.models.section = $scope.models.dropzones.questionList[$scope.models.position-1].id;
+        }
+     };
+
+     $scope.previous = function() {
+        if ($scope.models.position > 0) {
+            $scope.models.position = $scope.models.position - 1;
+            //position in the array is 1 less than the position recorded (we started at 1)
+            $scope.models.section = $scope.models.dropzones.questionList[$scope.models.position-1].id;
+        }
+     };
+
+
+     $scope.viewSection = function(section) {
+        $scope.models.view = 'single';
+        $scope.models.selected = section;
+        $scope.models.section = section.id.toString();
+     };
+
+     $scope.$watch('models.section', function(model) {
+        var questionList = $scope.models.dropzones.questionList;
+        $scope.models.position = 1;
+        if (questionList.length != 0) {
+            for (i = 0; i < questionList.length; i++) {
+                var questionGroup = questionList[i];
+                if (questionGroup.id == $scope.models.section) {
+                    $scope.models.position = i+1;
+                }
+            }
+        }
+      }, true);
+
       $scope.newItem = function(item) {
 
-        question = {
+       question = {
           questionText: '',
           questionHelp: '',
           questionError: '',
@@ -164,6 +210,9 @@
           case 'group':
             question.questionType = 'QuestionGroup';
             question.dndType = 'group';
+            question.questionText = 'Unnamed Section';
+            question.id = $scope.models.questionnaire_meta.last_used_id + 1;
+            $scope.models.questionnaire_meta.last_used_id += 1;
             break;
         }
 

--- a/author/static/js/q_builder/templates/question_group.html
+++ b/author/static/js/q_builder/templates/question_group.html
@@ -3,8 +3,12 @@
 <script type="text/ng-template" id="group.html">
     <i class="fa fa-times deleteitem" ng-click="list.splice($index, 1)"
        ng-confirm-click="This section and all items will be permanently deleted."></i>
+
+    <input type="button" value="view" ng-click="viewSection(item);" ng-show="models.view == 'collapsed'">
+
     <div class="group-element box box-blue">
         <div class="group-element box box-blue">
+            <!--<p ng-hide="models.view != 'single'">{{$index+1}} of {{list.length}}</p>-->
             <div ng-hide="models.preview">
                 <h3>Question Group</h3>
                 <input ondrop="return false;" dnd-nodrag type="text" ng-model="item.questionText" placeholder="Section">
@@ -13,7 +17,7 @@
 				<h3><b>{{ item.questionText }}<span ng-if="!item.questionText.length">Switch to edit to add a section title</span></b></h3>
 			</div>
 
-            <div>
+            <div ng-hide="models.view == 'collapsed'">
                 <div class="dropzone">
                     <ul class="question-list" dnd-list="item.children"
                         dnd-drop="dropCallback(event, index, item)"
@@ -34,4 +38,5 @@
             <div class="column" ng-repeat="list in item.columns" ng-include="'list.html'"></div>
             <div class="clearfix"></div>
         </div>
+    </div>
 </script>

--- a/survey/migrations/0011_last_used_id.py
+++ b/survey/migrations/0011_last_used_id.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0010_lock_questionnaire'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='questionnaire',
+            name='last_used_id',
+            field=models.IntegerField(default=0),
+        ),
+    ]

--- a/survey/models.py
+++ b/survey/models.py
@@ -21,6 +21,7 @@ class Questionnaire(models.Model):
     reviewed = models.BooleanField(default=False)
     published = models.BooleanField(default=False)
     questionnaire_json = jsonfield.JSONField()
+    last_used_id = models.IntegerField(default=0)
     locked_on = models.DateTimeField(null=True, default=None)
     locked_by = models.TextField(max_length=120 , null=True, default=None)
 

--- a/survey/tests/resources/survey.json
+++ b/survey/tests/resources/survey.json
@@ -2,7 +2,8 @@
   "meta": {
     "title": "title",
     "overview": "overview",
-    "questionnaire_id": "id"
+    "questionnaire_id": "id",
+    "last_used_id": "0"
   },
   "questionList": [
     {

--- a/survey/views.py
+++ b/survey/views.py
@@ -136,6 +136,7 @@ class QuestionnaireBuilder(LoginRequiredMixin, TemplateView):
                    question_meta = json_data['meta']
                    questionnaire.title = question_meta['title']
                    questionnaire.overview = question_meta['overview']
+                   questionnaire.last_used_id = question_meta['last_used_id']
                    questionnaire.questionnaire_json = json_data['questionList']
                    questionnaire.reviewed = False
                    questionnaire.lock(request.user.username)
@@ -162,7 +163,8 @@ class QuestionnaireBuilder(LoginRequiredMixin, TemplateView):
                     'meta': {
                         'title': questionnaire.title,
                         'overview': questionnaire.overview,
-                        'questionnaire_id' : questionnaire.questionnaire_id
+                        'questionnaire_id' : questionnaire.questionnaire_id,
+                        'last_used_id': questionnaire.last_used_id
                     },
                     'questionList' : questionList
                 }

--- a/templates/survey/questionnaire_builder.html
+++ b/templates/survey/questionnaire_builder.html
@@ -18,15 +18,15 @@
        <!-- section view toggle -->
        <ul class="viewswitch button-group radius toggle" data-toggle="buttons-radio">
           <li>
-            <input type="radio" id="r1" name="r-group" data-toggle="button" checked>
+            <input type="radio" id="r1" name="r-group" data-toggle="button" checked value="single" ng-model="models.view" >
             <label class="button tiny" for="r1"><i class="fa fa-square-o"></i>&nbsp; Single Section View</label>
           </li>
           <li>
-            <input type="radio" id="r2" name="r-group" data-toggle="button">
+            <input type="radio" id="r2" name="r-group" data-toggle="button" value="collapsed" ng-model="models.view" >
             <label class="button tiny" for="r2"><i class="fa fa-list"></i>&nbsp; List of Sections</label>
           </li>
           <li>
-            <input type="radio" id="r3" name="r-group" data-toggle="button">
+            <input type="radio" id="r3" name="r-group" data-toggle="button" value="open" ng-model="models.view" >
             <label class="button tiny" for="r3"><i class="fa fa-th-list"></i> &nbsp;Expanded View</label>
           </li>
         </ul>
@@ -36,7 +36,7 @@
        {% verbatim %}
        <span class="mini-label">Questionnaire Preview</span>
        <div class="onoffswitch">
-         <input type="checkbox" name="onoffswitch" class="onoffswitch-checkbox" id="myonoffswitch" ns-checked="models.preview" ng-model="models.preview">
+         <input type="checkbox" name="onoffswitch" class="onoffswitch-checkbox" id="myonoffswitch" ng-model="models.preview">
            <label class="onoffswitch-label" for="myonoffswitch">
              <span class="onoffswitch-inner"></span>
              <span class="onoffswitch-switch"></span>
@@ -50,10 +50,12 @@
 
   <section class="application" >
 
+
     {# This template represents a dnd list and is used by other templates. #}
       {# Changing this can cause pain #}
       {% verbatim %}
   	<script type="text/ng-template" id="list.html">
+
   		<ul class="question-list" dnd-list="list"
   			dnd-drop="dropCallback(event, index, item)"
   			dnd-allowed-types="['group']"
@@ -65,7 +67,10 @@
   				dnd-selected="models.selected = item"
   				ng-class="{selected: models.selected === item}"
   				ng-include="item.type + '.html'"
-          dnd-type="item.dndType" class="my-repeat-animation">
+                dnd-type="item.dndType"
+                class="my-repeat-animation"  id="section-{{item.id}}"
+                ng-hide="models.view == 'single' && models.section != {{item.id}}">
+
   			</li>
   		</ul>
   	</script>
@@ -107,6 +112,7 @@
 
           <div class="large-12 column">
 
+
             <ul class="breadcrumb">
                 <li><a href="{%  url 'survey:index' %}" title="">Home</a></li>
                 <li><a href="{%  url 'survey:index' %}" title="">Surveys</a></li>
@@ -119,6 +125,16 @@
           </div>
 
           {% verbatim %}
+
+            <select ng-hide="models.view != 'single'" ng-model="models.section" >
+                <option ng-repeat="section in models.dropzones.questionList" value="{{section.id}}" ng-selected="models.section == {{section.id}}">{{section.questionText}}</option>
+            </select>
+
+              <div ng-hide="models.view != 'single'">
+                <a href="#" ng-click="previous()" ng-hide="models.position == 1">Previous</a>
+                <p>{{models.position}} of {{ models.dropzones.questionList.length}}</p>
+                <a href="#" ng-click="next()" ng-hide="models.position >= models.dropzones.questionList.length">Next</a>
+              </div>
 
              <div ng-class="{'empty': list.length == 0}" ng-repeat="list in models.dropzones" class="questionContainer" >
                 <div class="dropzone">
@@ -146,12 +162,14 @@
                 dnd-copied="item.id = item.id + 1"
                 dnd-type="item.dndType"
                 dnd-dragstart="dragStartCallback(item)"
-                dnd-dragend="dragEndCallback(item)">
+                dnd-dragend="dragEndCallback(item)"
+                ng-hide="item.show.indexOf(models.view) == -1">
                 <!--<img ng-src="{{ item.icon }}"/>-->
                 <i class="fa {{ item.icon }}"></i>
                 <span ng-bind="item.description">Loading...</span>
             </li>
           </ul>
+
           <!-- hide til can figure out how to make this friendly :D <div class="trashcan"
               If you use [] as referenced list, the dropped elements will be lost
               <ul dnd-list="[]">
@@ -188,6 +206,7 @@
     {% verbatim %}
     <div class="debug">
       <pre>{{ models.dropzones | json }}</pre>
+      <pre>{{ models.questionnaire_meta | json }}</pre>
     </div>
     {% endverbatim %}
   </section>


### PR DESCRIPTION
**What**
There are now 3 view states - open, collapsed and single.  Open is the original view, collapsed shows section titles only and single shows one section at a time.

**How to test**
1. Checkout this branch
2. Run database migrations (not previously created questionnaire may no longer work)
3. Add a questionnaire
4. Using the questionnaire builder add multiple sections each with different questions
5. Toggle the various view states

**Who can test**
Anyone apart from @warren-methods and @LJBabbage

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/onsdigital/eq-author/67)
<!-- Reviewable:end -->
