### PR TITLE
angular-cloak a fix for angular so the code isn't shown for a split s…

### DIFF
--- a/templates/survey/questionnaire_builder.html
+++ b/templates/survey/questionnaire_builder.html
@@ -9,7 +9,7 @@
   {{ block.super }}
 {% include "includes/navigation.html" %}
 
-<div class="wrapper" ng-app="QBuilder" ng-controller="BuilderController as builderCtrl">
+<div class="wrapper" ng-app="QBuilder" ng-controller="BuilderController as builderCtrl" ng-cloak>
 
   <section class="page-tools">
     <div class="row large-collapse">


### PR DESCRIPTION
__What__
A fix for angular to stop code appearing to the user

__How to test__
1. Create a survey and questionnaire
2. On questionnaire builder make sure no angular code is visible when loading

__Who can test__
Anyone but @LJBabbage