### PR TITLE
Renaming Question group to Section

### DIFF
--- a/author/static/js/q_builder/controllers/BuilderController.js
+++ b/author/static/js/q_builder/controllers/BuilderController.js
@@ -72,7 +72,7 @@
           show: ['open', 'single']
         }, {
           type: "group",
-          description: "Question Group",
+          description: "Section",
           icon: 'fa-th',
           id: 1,
           columns: [


### PR DESCRIPTION
**What**
Renaming 'Question Group' to 'Section' in the question builder tool bar.

**How to test**
1. Run a server and create a questionnaire
2. Browse to the questionnaire build page
3. Check that the tool bar says Section rather than Question Group

**Who can review**
Anyone apart from @warren-methods