### PR TITLE
DIGEQ 148 use the internal questionnaire ids

### DIFF
--- a/survey/tests/test_questionnaire.py
+++ b/survey/tests/test_questionnaire.py
@@ -91,7 +91,8 @@ class QuestionnaireTestCase(TestCase):
         self.assertFalse(questionnaire_set[0].reviewed)
         self.assertFalse(questionnaire_set[1].reviewed)
 
-        response = QuestionnaireTestCase.client.get(reverse("survey:review-questionnaire", kwargs={'slug': '1'}), follow=True, HTTP_REFERER=reverse('survey:index'))
+        questionnaire = Questionnaire.objects.get(questionnaire_id=1)
+        response = QuestionnaireTestCase.client.get(reverse("survey:review-questionnaire", kwargs={'slug': questionnaire.id}), follow=True, HTTP_REFERER=reverse('survey:index'))
 
         questionnaire = Questionnaire.objects.get(questionnaire_id='1')
         self.assertTrue(questionnaire.reviewed)
@@ -101,7 +102,8 @@ class QuestionnaireTestCase(TestCase):
         response = QuestionnaireTestCase.client.post(reverse("survey:create-questionnaire", kwargs={'survey_slug': '1'}), {'title' : 'Test Questionnaire 3', 'questionnaire_id': '3', 'overview': 'questionnaire overview 3'}, follow=True)
         self.assertEqual(200, response.status_code)
 
-        response = QuestionnaireTestCase.client.get(reverse("survey:review-questionnaire", kwargs={'slug': '3'}), follow=True, HTTP_REFERER=reverse('survey:index'))
+        questionnaire = Questionnaire.objects.get(questionnaire_id=3)
+        response = QuestionnaireTestCase.client.get(reverse("survey:review-questionnaire", kwargs={'slug': questionnaire.id}), follow=True, HTTP_REFERER=reverse('survey:index'))
         questionnaire = Questionnaire.objects.get(questionnaire_id='3')
         self.assertTrue(questionnaire.reviewed)
 
@@ -135,18 +137,18 @@ class QuestionnaireTestCase(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertContains(response,"Your questionnaire has been saved")
 
-        response = QuestionnaireTestCase.client.get(reverse("survey:questionnaire-summary", kwargs={'slug': '3'}),follow=True)
+        response = QuestionnaireTestCase.client.get(reverse("survey:questionnaire-summary", kwargs={'slug': questionnaire.id}),follow=True)
         # check we cannot make it live
         self.assertNotContains(response, 'publish')
 
-        response = QuestionnaireTestCase.client.get(reverse("survey:review-questionnaire", kwargs={'slug': '3'}), follow=True, HTTP_REFERER=reverse('survey:index'))
+        response = QuestionnaireTestCase.client.get(reverse("survey:review-questionnaire", kwargs={'slug': questionnaire.id}), follow=True, HTTP_REFERER=reverse('survey:index'))
         questionnaire = Questionnaire.objects.get(questionnaire_id='3')
         self.assertTrue(questionnaire.reviewed)
 
         # check we can publish
         self.assertContains(response, 'publish')
 
-        response = QuestionnaireTestCase.client.get(reverse("survey:publish-questionnaire", kwargs={'slug':'3'}), follow=True, HTTP_REFERER=reverse('survey:index'))
+        response = QuestionnaireTestCase.client.get(reverse("survey:publish-questionnaire", kwargs={'slug' :questionnaire.id}), follow=True, HTTP_REFERER=reverse('survey:index'))
 
         questionnaire = Questionnaire.objects.get(questionnaire_id='3')
         self.assertTrue(questionnaire.published)

--- a/survey/views.py
+++ b/survey/views.py
@@ -35,7 +35,7 @@ class SurveyCreate(LoginRequiredMixin, CreateView):
 
 class QuestionnaireDetail(LoginRequiredMixin, DetailView):
     model = Questionnaire
-    slug_field = 'questionnaire_id'
+    slug_field = 'id'
 
     def get_context_data(self, **kwargs):
         # Call the base implementation first to get a context
@@ -88,7 +88,7 @@ class QuestionnaireCreate(LoginRequiredMixin, CreateView):
 class QuestionnaireReview(LoginRequiredMixin, View):
     def get(self, *args, **kwargs):
 
-        questionnaire = Questionnaire.objects.get(questionnaire_id=self.kwargs['slug'])
+        questionnaire = Questionnaire.objects.get(id=self.kwargs['slug'])
         if questionnaire is not None:
             if not questionnaire.reviewed:
                 questionnaire.reviewed = True
@@ -100,7 +100,7 @@ class QuestionnaireReview(LoginRequiredMixin, View):
 
 class QuestionnairePublish(LoginRequiredMixin, View):
     def get(self, *args, **kwargs):
-        questionnaire = Questionnaire.objects.get(questionnaire_id=self.kwargs['slug'])
+        questionnaire = Questionnaire.objects.get(id=self.kwargs['slug'])
 
         if questionnaire is None:
             raise Http404

--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -46,7 +46,7 @@
                                     {% if not questionnaire.reviewed %}
                                     <li>
                                         <a class="tiny button secondary"
-                                           href="{% url 'survey:review-questionnaire' slug=questionnaire.questionnaire_id %}">Review</a>
+                                           href="{% url 'survey:review-questionnaire' slug=questionnaire.id %}">Review</a>
                                     </li>
                                     {% else %}
                                     <li class="tiny button secondary success">Reviewed</li>
@@ -66,7 +66,7 @@
                                     {% if questionnaire.reviewed and not questionnaire.published %}
                                     <li>
                                         <a class="tiny button secondary"
-                                           href="{% url 'survey:publish-questionnaire' slug=questionnaire.questionnaire_id %}">Publish</a>
+                                           href="{% url 'survey:publish-questionnaire' slug=questionnaire.id %}">Publish</a>
                                     </li>
                                     {% endif %}
 


### PR DESCRIPTION
**What**
Fix for DIGEQ 148. We need to use the internal ids for navigation and not the user entered ids.

**How to test**
1. Create a questionnaire with a space in the id field.
2. Browse to the dashboard page and check you can preview/view live

**Who can test**
Anyone apart from @warren-methods