### PR TITLE
Create Makefile to handle local dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+UNAME_S := $(shell uname -s)
+.PHONY : docker-machine-setup run-docker-compose
+
+all: docker-machine-setup run-docker-compose
+
+define colourecho
+      @tput setaf 6
+      @echo $1
+      @tput sgr0
+endef
+
+
+docker-machine-setup:
+ifeq ($(UNAME_S),Darwin)                 
+	$(call colourecho, ": It just works ")
+	docker-machine start default && eval "$(docker-machine env default)"
+endif
+        
+run-docker-compose: 
+	docker-compose build && docker-compose up
+

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-UNAME_S := $(shell uname -s)
-.PHONY : docker-machine-setup run-docker-compose
+UNAME_S    := $(shell uname -s)
+CONTAINERS := $(shell docker ps -a -q)
+IMAGES     := $(shell docker images -q)
+
+.PHONY : docker-machine-setup run-docker-compose clean
 
 all: docker-machine-setup run-docker-compose
 
@@ -13,8 +16,13 @@ endef
 docker-machine-setup:
 ifeq ($(UNAME_S),Darwin)                 
 	$(call colourecho, ": It just works ")
-	docker-machine start default && eval "$(docker-machine env default)"
+	-docker-machine start default && eval "$(docker-machine env default)"
 endif
+
+
+clean:  
+	docker rm $(CONTAINERS)
+	docker rmi $(IMAGES)
         
 run-docker-compose: 
 	docker-compose build && docker-compose up

--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ the procfile and run your django wsgi application.
 1. docker-compose build
 2. docker-compose up
 
+
+## Development environment using docker compose
+
+The makefile provides a simple one step docker compose based dev setup.
+
+```make ````
+
+On a mac this command will start docker-machine and populate your environment with the correct variables and then start the docker-compose `build` and `up` commands.
+On linux this will just run the docker-compose commands.
+
+
+
+
 ## Further Reading
 
 - [Gunicorn](https://warehouse.python.org/project/gunicorn/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ postgres:
   volumes:
     - ./create_database.sql:/docker-entrypoint-initdb.d/create_database.sql
 survey-runner:
-  image: onsdigital/eq-survey-runner:latest
+  build: ../eq-survey-runner/.
   ports:
     - "8080:8080"
   environment:


### PR DESCRIPTION
__What__

This PR is designed to fix the issues experienced by @alexmorris and others in running a local dev environment, specifically around docker and linking between the containers. The proposed solution is a cross platform Makefile that provides the same interface regardless of computer architecture.

__How to test__

Ensure you're running the latest version of Docker (1.9) or the latest version of the Docker toolbelt: https://www.docker.com/docker-toolbox - you shouldn't need to update Docker Compose  but there is a new version (1.5) out yesterday.

1. Clone repo and checkout branch 
2. Activate your virtualenv for `eq-author`
3. Type `make`

You should then have a fully functional eq environment running by docker-compose, running either on 127.0.0.1:8000 & 8080 on an Ubuntu box and 192.168.99.100 or 192.168.99.101 on a Mac (via docker-machine).

The PR also creates a `clean` target that deletes all images and containers from docker but rebuilding from a clean state can take a while as everything is downloaded.

__Who can test__
Anyone who does development work ( @alexmorris @warren-methods @weapdiv-david @LJBabbage ) needs to check that this meets their dev needs, so that we can align on a dev environment setup process.