### PR TITLE
Fixing locked and published questionaires

### DIFF
--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -40,7 +40,14 @@
                         </tr>
                         {% for questionnaire in survey.questionnaire_set.all %}
                         <tr>
-                        <td class="q-title"><a href="{% url 'survey:questionnaire-builder' questionnaire.id %}" title="edit {{ questionnaire.title }}">{{ questionnaire.title }}</a> ( <span class="q-id">{{ questionnaire.questionnaire_id }}</span> )</td>
+                        <td class="q-title">
+                            {% if questionnaire.locked or questionnaire.published %}
+                              {{ questionnaire.title }}</a> ( <span class="q-id">{{ questionnaire.questionnaire_id }}</span> )
+                            {% else %}
+                              <a href="{% url 'survey:questionnaire-builder' questionnaire.id %}" title="edit {{ questionnaire.title }}">{{ questionnaire.title }}</a> ( <span class="q-id">{{ questionnaire.questionnaire_id }}</span> )
+                            {% endif %}
+                        </td>
+
                         <td class="action-btns">
                                 <ul class="survey-actions">
                                     {% if not questionnaire.reviewed %}


### PR DESCRIPTION
**What**
The user should not be able to navigate to the questionnaire builder if a questionnaire is locked or publish. 

**How to test**
1. Create a questionnaire and navigate to the questionnaire builder
2. Open another browser, log in with a different user and check you cannot navigate to the questionnaire builder for the same questionnaire.
3. Publish the questionnaire
4. Check you can no longer navigate to the questionnaire builder

**Who can test**
Anyone apart from @warren-methods