### PR TITLE
DIGEQ-164 backing out connection settings change

### DIFF
--- a/author/settings.py
+++ b/author/settings.py
@@ -116,10 +116,6 @@ DATABASES['default'] = dj_database_url.config()
 # Enable Connection Pooling (if desired)
 DATABASES['default']['ENGINE'] = 'django_postgrespool'
 
-# Set a max connection age for heroku https://devcenter.heroku.com/articles/python-concurrency-and-database-connections
-DATABASES['default']['CONN_MAX_AGE'] = 500
-
-
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 


### PR DESCRIPTION
**What**
Backing out the connection settings change as it's causing an postgres error every 9 minutes

Original change:
https://github.com/ONSdigital/eq-author/pull/85/files

**How to test**
1. Deploy to heroku and check we don't get the postgres error

**Who can review**
Anyone apart from @warren-methods