### PR TITLE
boot.sh added

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+platform='unknown'
+
+OS="`uname`"
+case $OS in
+  'Linux')
+    platform='Linux'
+    ;;
+  'Darwin')
+    platform='Mac'
+    ;;
+  'WindowsNT'|*'CYGWIN'*)
+    platform='Windows'
+    ;;
+  *) ;;
+esac
+
+echo "Running on $platform"
+
+if (( "$platform" == "Windows" || "$platform" == "Mac" )); then
+    echo "Starting docker-machine..."
+    docker-machine start default
+    eval "$(docker-machine env default)"
+    echo "DOCKER_MACHINE_NAME=$DOCKER_MACHINE_NAME"
+    echo "DOCKER_HOST=$DOCKER_HOST"
+fi
+
+if [ $? -eq 0 ]; then
+    echo "Building docker containers..."
+    docker-compose build
+fi
+
+if [ $? -eq 0 ]; then
+    echo "Starting docker containers..."
+    docker-compose up
+fi


### PR DESCRIPTION
**What**

boot.sh shell script added to replace the makefile

**How to test**

1) ensure boot.sh is executable with `chmod +x boot.sh`
2) run `./boot.sh` and see the environment startup
3) Note the IP address at the beginning of the output, this is used to access both the runner and the author application.  The runner is accessed via port 8080, while the author is on port 8000

