### PR TITLE
DIGEQ-57 add enable justification checkbox

### DIFF
--- a/author/static/js/q_builder/controllers/BuilderController.js
+++ b/author/static/js/q_builder/controllers/BuilderController.js
@@ -163,6 +163,12 @@
         $scope.models.section = section.questionReference;
       };
 
+      $scope.justification = function(condition) {
+        if (condition.type == 'error') {
+            condition.justification = false
+        }
+      }
+
       $scope.$watch('models.section', function(model) {
         var questionList = $scope.models.dropzones.questionList;
         $scope.models.position = 0;

--- a/author/static/js/q_builder/templates/number_question.html
+++ b/author/static/js/q_builder/templates/number_question.html
@@ -26,9 +26,10 @@
 									</span>
 								</div>
 								<div ng-if="condition.condition != 'numeric' && condition.condition != 'required'">
+
 									<label>Condition</label>
-									<select value="condition" ng-model="condition.condition" >
-										<option value="lessthan" selected>less than (&lt;)</option>
+									<select value="condition" ng-model="condition.condition" ng-change="justification(condition)">
+										<option value="lessthan" selected="selected">less than (&lt;)</option>
 										<option value="greaterthan">greater than (&gt;)</option>
 										<option value="equal">equal to (==)</option>
 										<option value="notequal">not equal to (!=)</option>
@@ -42,9 +43,13 @@
 									</select>
 									<label>Error Text for Respondent</label>
 									<input dnd-nodrag type="text" ng-model="condition.message" placeholder="E.g - Please ensure your answer contains only numbers">
+									<label>Enable Justification</label>
+									<input type="checkbox" ng-model="condition.justification" ng-checked="condition.justification" ng-disabled="condition.type == 'error'"/>
+									<div>
 										<span class="list-actions">
-										<i class="fa fa-trash removeitem" ng-click="child.validation.splice($index, 1)" title="remove this item"></i>
-									</span>
+											<i class="fa fa-trash removeitem" ng-click="child.validation.splice($index, 1)" title="remove this item"></i>
+										</span>
+									</div>
 								</div>
 						</li>
 					</ul>

--- a/author/static/js/q_builder/templates/text_question.html
+++ b/author/static/js/q_builder/templates/text_question.html
@@ -29,12 +29,15 @@
 									<label>Please enter the maximum number of characters the user can enter</label>
 									<input dnd-nodrag type="text" ng-model="condition.value" placeholder="E.g - 500 ">
 									<label>Validation Type</label>
-									<select value="errortype" ng-model="condition.type">
-										<option value="error" selected>Error - (Hard check)</option>
+									<select value="errortype" ng-model="condition.type" ng-change="justification(condition)">
+										<option value="error" selected="selected">Error - (Hard check)</option>
 										<option value="warning">Warning - (Soft check)</option>
 									</select>
 									<label>Text for Respondent</label>
 									<input dnd-nodrag type="text" ng-model="condition.message" placeholder="E.g - Please ensure your answer contains only numbers">
+									<label>Enable Justification</label>
+									<input type="checkbox" ng-model="condition.justification" ng-checked="condition.justification" ng-disabled="condition.type == 'error'"/>
+
 								</div>
 
 						</li>


### PR DESCRIPTION
**What**
Add a checkbox in enable justification of answers in the survey runner. A justification can only be provided if a warning message is shown. Therefore this field is disabled if the user selects 'error' as the 'validation failure type'. By default the checkbox is unchecked even if the user selects 'warning' as the 'validation failure type'.

**How to test**
1. Check out this branch
2. Add a new survey and add a questionnaire to that survey
3. On the questionnaire builder page add a text question and numeric question
4. In the validation rules, set the error type to 'warning'
5. Enable the justification checkbox
6. Set the error type to 'error'
7 Check that the justification checkbox is unchecked.

**Who can review**
Anyone apart from @warren-methods