### PR TITLE
DIGEQ-133 Adding survey id to the api method

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ survey-runner:
     - "8080:8080"
   volumes:
     - ../eq-survey-runner:/opt/eq-survey-runner
+    - ~/.aws:/root/.aws
   entrypoint:
     - /opt/eq-survey-runner/entrypoint.sh
   environment:

--- a/survey/views.py
+++ b/survey/views.py
@@ -51,6 +51,7 @@ class QuestionnaireAPIDetail(DetailView):
     def get_data(self, context):
         rtn_obj = {}
         rtn_obj['title'] = context['object'].survey.title
+        rtn_obj['survey_id'] = context['object'].survey.survey_id
         rtn_obj['questionnaire_id'] = context['object'].questionnaire_id
         rtn_obj['questionnaire_title'] = context['object'].title
         rtn_obj['overview'] = context['object'].overview


### PR DESCRIPTION
**What**
This supports the eq-survey-runner pull request: https://github.com/ONSdigital/eq-survey-runner/pull/60

1. Expose the survey id as part of the api method call
2. Map the ~/.aws directory as a docker volume

**How to test**
1. Checkout this branch
2. Run the author application
3. Create a survey/questionnaire with at least 1 question.
4. Browse to the api method: http://127.0.0.1:8000/surveys/api/questionnaire/1/
5. Check that the survey id is present in the JSON

To test the docker change (you need aws setup see the survey pull request):
1. `docker-compose up`
2. Connect to the survey runner container: `docker exec -it <container-id> bash`
3. Run `cat /root/.aws/credentials'
4. This should output for aws keys

**Who can review**
Anyone apart from @warren-methods