### PR TITLE
Adding unique type of number questions

### DIFF
--- a/author/static/js/q_builder/controllers/BuilderController.js
+++ b/author/static/js/q_builder/controllers/BuilderController.js
@@ -238,7 +238,7 @@
             question.questionType = 'CheckBox';
             break;
           case 'number_question':
-            question.questionType = 'InputText';
+            question.questionType = 'InputNumber';
             question.validation.unshift({
                     condition: 'numeric',
                     value: true,


### PR DESCRIPTION
**What**
Number questions should have an unique QuestionType and not share it with Text questions.

This relates to the following pull request: https://github.com/ONSdigital/eq-survey-runner/pull/65