### PR TITLE
digeq-170 clear section header if it contains 'unnamed section' onclick

### DIFF
--- a/author/static/js/q_builder/directives/questionGroup.js
+++ b/author/static/js/q_builder/directives/questionGroup.js
@@ -6,12 +6,23 @@
         restrict: 'E',
         templateUrl: '/static/js/q_builder/templates/question_group.html',
          controller: function($scope) {
+
             /**
              *  Clear unnamed section title
              */
             $scope.initSection = function(item) {
+
                if (item.questionText =='Unnamed Section'){
                 item.questionText ='';
+                }
+            };
+
+             /**
+             *  insert placeholder if empty
+             */
+               $scope.emptyHeader = function(item) {
+               if (item.questionText ==''){
+                item.questionText ='Unnamed Section';
                 }
             };
         },

--- a/author/static/js/q_builder/directives/questionGroup.js
+++ b/author/static/js/q_builder/directives/questionGroup.js
@@ -4,7 +4,18 @@
   .directive("questionGroup", function() {
     return {
         restrict: 'E',
-        templateUrl: '/static/js/q_builder/templates/question_group.html'
+        templateUrl: '/static/js/q_builder/templates/question_group.html',
+         controller: function($scope) {
+            /**
+             *  Clear unnamed section title
+             */
+            $scope.initSection = function(item) {
+               if (item.questionText =='Unnamed Section'){
+                item.questionText ='';
+                }
+            };
+        },
+        controllerAs: 'ctrl'
         };
     });
 })();

--- a/author/static/js/q_builder/templates/question_group.html
+++ b/author/static/js/q_builder/templates/question_group.html
@@ -9,7 +9,7 @@
                 <!--<input ondrop="return false;" dnd-nodrag type="text" ng-model="item.questionText" placeholder="Section" ng-hide="models.preview || models.view == 'collapsed' || models.view == 'open'" >-->
 
                 <section class="section-heading-editable">
-                  <h4 ng-click="initSection(item)" class="q-title-editable" contenteditable ng-model="item.questionText" dnd-nodrag>{{ item.questionText }}</h4>
+                  <h4 ng-click="initSection(item)" ng-blur="emptyHeader(item)" class="q-title-editable" contenteditable ng-model="item.questionText" dnd-nodrag>{{ item.questionText }}</h4>
                 </section>
             </div>
             <div ng-hide="models.preview">

--- a/author/static/js/q_builder/templates/question_group.html
+++ b/author/static/js/q_builder/templates/question_group.html
@@ -9,7 +9,7 @@
                 <!--<input ondrop="return false;" dnd-nodrag type="text" ng-model="item.questionText" placeholder="Section" ng-hide="models.preview || models.view == 'collapsed' || models.view == 'open'" >-->
 
                 <section class="section-heading-editable">
-                  <h4 class="q-title-editable" contenteditable ng-model="item.questionText" dnd-nodrag>{{ item.questionText }}</h4>
+                  <h4 ng-click="initSection(item)" class="q-title-editable" contenteditable ng-model="item.questionText" dnd-nodrag>{{ item.questionText }}</h4>
                 </section>
             </div>
             <div ng-hide="models.preview">


### PR DESCRIPTION
__What__
Clear section header help text (e.g unnamed section) when first clicked on

__How to test__
1. Checkout branch
2. Create questionnaire
3. Create new section, notice that when you try to edit the section that the words unnamed section disappear
4. Confirm that if you are editing a section which doesn't have the words unnamed section it doesn't disappear.

__Who can test__
Anyone but @LJBabbage