### PR TITLE
DIGEQ-230 fixing locking issue

### DIFF
--- a/survey/models.py
+++ b/survey/models.py
@@ -28,7 +28,7 @@ class Questionnaire(models.Model):
     @property
     def locked(self):
         self.check_locked_time()
-        return self.locked_by
+        return self.locked_by is not None
 
     def is_locked(self, username):
         locked = False

--- a/survey/views.py
+++ b/survey/views.py
@@ -22,6 +22,7 @@ class SurveyList(LoginRequiredMixin, ListView):
         # Call the base implementation first to get a context
         context = super(SurveyList, self).get_context_data(**kwargs)
         context['survey_runner_url'] = settings.SURVEY_RUNNER_URL
+        context['username'] = self.request.user.username
         return context
 
 

--- a/templates/survey/survey_list.html
+++ b/templates/survey/survey_list.html
@@ -41,7 +41,7 @@
                         {% for questionnaire in survey.questionnaire_set.all %}
                         <tr>
                         <td class="q-title">
-                            {% if questionnaire.locked or questionnaire.published %}
+                            {% if questionnaire.locked and questionnaire.locked_by != username or questionnaire.published %}
                               {{ questionnaire.title }}</a> ( <span class="q-id">{{ questionnaire.questionnaire_id }}</span> )
                             {% else %}
                               <a href="{% url 'survey:questionnaire-builder' questionnaire.id %}" title="edit {{ questionnaire.title }}">{{ questionnaire.title }}</a> ( <span class="q-id">{{ questionnaire.questionnaire_id }}</span> )
@@ -75,9 +75,8 @@
                                            href="{% url 'survey:publish-questionnaire' slug=questionnaire.id %}">Publish</a>
                                     </li>
                                     {% endif %}
-
                                     {% if not questionnaire.published %}
-                                        {% if questionnaire.locked %}
+                                        {% if questionnaire.locked and questionnaire.locked_by != username %}
                                             <li>
                                               <a class="" href="#" onclick="alert('Locked by {{ questionnaire.locked_by}}')"}><i class="fa fa-lock"></i>  Locked</a>
                                             </li>


### PR DESCRIPTION
**What**
Fixes the issue where a user can lock themselves out of the question. See DIGEQ-230 for steps to reproduce.

**How to test**
1. Edit a questionnaire
2. Exit to dashboard via various means
3. The questionnaire should never be marked as locked for this user
4. Confirm the questionnaire is still locked by using a different browser with another user signed in

**Who can review**
Anyone apart from @warren-methods