### PR TITLE
Webpack configuration

### DIFF
--- a/config/_base.js
+++ b/config/_base.js
@@ -65,6 +65,8 @@ Edit at Your Own Risk
 -------------------------------------------------
 ************************************************/
 
+
+
 // ------------------------------------
 // Environment
 // ------------------------------------
@@ -79,6 +81,7 @@ config.globals = {
   '__TEST__'     : config.env === 'test',
   '__DEBUG__'    : config.env === 'development' && !argv.no_debug,
   '__DEBUG_NEW_WINDOW__' : !!argv.nw,
+  '__COMPILE__': !!argv.compile,
   '__BASENAME__' : JSON.stringify(process.env.BASENAME || '')
 };
 

--- a/config/_development.js
+++ b/config/_development.js
@@ -1,6 +1,9 @@
 // We use an explicit public path when the assets are served by webpack
 // to fix this issue:
 // http://stackoverflow.com/questions/34133808/webpack-ots-parsing-error-loading-fonts/34133809#34133809
-export default (config) => ({
-  compiler_public_path: `http://${config.server_host}:${config.server_port}/`
-});
+export default (config) => {
+  let host = (config.globals['__COMPILE__']) ? '' : `http://${config.server_host}:${config.server_port}`;
+  return {
+    compiler_public_path: `${host}/bundles/`
+  };
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "compile": "node -r dotenv/config --harmony bin/compile",
+    "compile": "node -r dotenv/config --harmony bin/compile --compile",
     "lint": "eslint . ./",
     "lint:fix": "npm run lint -- --fix",
     "start": "better-npm-run start",

--- a/qBuilder/assets/components/Block.jsx
+++ b/qBuilder/assets/components/Block.jsx
@@ -2,10 +2,6 @@ import React, {PropTypes} from 'react';
 import {block} from './Block.scss';
 
 export default class Block extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
   render() {
     return (<div className={block}>{this.props.title}</div>);
   }

--- a/qBuilder/assets/components/Question.jsx
+++ b/qBuilder/assets/components/Question.jsx
@@ -1,11 +1,8 @@
-import React, {PropTypes, Component} from 'react';
+import React, {PropTypes} from 'react';
 import {question} from './Question.scss';
 
-export default class Question extends Component {
-  render() {
-    return (<div className={question} id={this.props.id} style={this.props.style}>{this.props.title}</div>);
-  }
-}
+const Question = (props) =>
+  <div className={question} style={props.style}>{props.title}</div>;
 
 Question.propTypes = {
   style: PropTypes.object,

--- a/qBuilder/assets/components/Question.jsx
+++ b/qBuilder/assets/components/Question.jsx
@@ -1,12 +1,14 @@
 import React, {PropTypes, Component} from 'react';
 import {question} from './Question.scss';
 
-const Question = (props, context) => {
-  <div className={question} id={this.props.id} style={this.props.style}>{this.props.title}</div>;
-};
+export default class Question extends Component {
+  render() {
+    return (<div className={question} id={this.props.id} style={this.props.style}>{this.props.title}</div>);
+  }
+}
 
 Question.propTypes = {
-  id: PropTypes.number.isRequired,
+  style: PropTypes.object,
   title: PropTypes.string.isRequired
 };
 

--- a/qBuilder/assets/components/Section.jsx
+++ b/qBuilder/assets/components/Section.jsx
@@ -13,5 +13,6 @@ export default class Section extends React.Component {
 }
 
 Section.propTypes = {
+  children: PropTypes.node,
   isActive: PropTypes.bool
 };

--- a/qBuilder/assets/containers/DraggableBlock.jsx
+++ b/qBuilder/assets/containers/DraggableBlock.jsx
@@ -2,8 +2,6 @@ import React, {PropTypes} from 'react';
 import { compose } from 'redux';
 import { DragSource } from 'react-dnd';
 import Block from 'components/Block';
-import Question from 'components/Question';
-import { DRAGGABLE_BLOCK } from 'constants/ItemTypes';
 
 const blockSource = {
   beginDrag(props) {

--- a/qBuilder/assets/containers/DraggableQuestion.jsx
+++ b/qBuilder/assets/containers/DraggableQuestion.jsx
@@ -5,7 +5,6 @@ import { compose } from 'redux';
 import { DragSource, DropTarget } from 'react-dnd';
 import { swapBlocks } from 'redux/modules/blocks';
 import Question from 'components/Question';
-import { DRAGGABLE_QUESTION } from 'constants/ItemTypes';
 
 const style = {};
 
@@ -74,8 +73,6 @@ const dropTargetOpts = {
     monitor.getItem().index = hoverIndex;
   }
 };
-
-console.log(DRAGGABLE_QUESTION);
 
 export default compose(
   connect((state) => state),

--- a/qBuilder/assets/containers/DropSection.jsx
+++ b/qBuilder/assets/containers/DropSection.jsx
@@ -5,7 +5,6 @@ import { DropTarget } from 'react-dnd';
 import { addBlock } from 'redux/modules/blocks';
 import Section from 'components/Section';
 import DraggableQuestion from 'containers/DraggableQuestion';
-import { DRAGGABLE_BLOCK, DROP_SECTION } from 'constants/ItemTypes';
 
 const sectionTarget = {
   drop(props, monitor, component) {
@@ -30,7 +29,6 @@ class DropSection extends React.Component {
 
   render() {
     const { canDrop, isOver, connectDropTarget, blocks } = this.props;
-    console.log(blocks);
     return connectDropTarget(
       <div>
         <Section isActive={canDrop && isOver}>

--- a/qBuilder/assets/containers/Main.jsx
+++ b/qBuilder/assets/containers/Main.jsx
@@ -1,16 +1,12 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import DropSection from './DropSection';
-import Button from 'components/Button';
-
-import { saveData, fetchData } from 'redux/modules/blocks';
 
 class Main extends React.Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired
   };
   render() {
-    const { dispatch } = this.props;
     return (
       <div className='main'>
         <h2>Survey Name</h2>

--- a/qBuilder/project/settings.py
+++ b/qBuilder/project/settings.py
@@ -134,9 +134,10 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = '/bundles/'
 STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, 'assets'), # We do this so that django's collectstatic copies or our bundles to the STATIC_ROOT or syncs them to whatever storage we use.
+    os.path.join(BASE_DIR, 'bundles'),
+    # We do this so that django's collectstatic copies or our bundles to the STATIC_ROOT or syncs them to whatever storage we use.
 )
 
 WEBPACK_LOADER = {


### PR DESCRIPTION
## Changes

- Removes need for `npm run dev` task when developing locally. Bundles can be built with just `npm run compile`
- Fixed a few issues with React components.

## How to test

- `npm run compile`
- confirm app works