### PR TITLE
Add logging file support

### DIFF
--- a/qBuilder/project/settings.py
+++ b/qBuilder/project/settings.py
@@ -116,6 +116,17 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'file': {
+            'level': os.getenv('DJANGO_LOGGING_LEVEL', 'WARNING'),
+            'class': 'logging.FileHandler',
+            'filename': os.getenv('DJANGO_LOG_FILE', 'author.log')
+        }
+    }
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/


### PR DESCRIPTION
***What***

Adds support for logging to a file.  Two optional environment variables control this.

`DJANGO_LOG_LEVEL` defaults to `WARNING`

and 

`DJANGO_LOG_FILE` defaults to `django.log`

***How to test**
1) Download this branch
2) Spin up the server
3) Verify that the django.log file has been created

***Who can test***

Anyone except @weapdiv-david