### PR TITLE
Adding bundles to the static assets

### DIFF
--- a/.ebextensions/02_python.config
+++ b/.ebextensions/02_python.config
@@ -10,6 +10,7 @@ option_settings:
     NumThreads: 20
   "aws:elasticbeanstalk:container:python:staticfiles":
     "/assets/": "qBuilder/assets/"
+    "/bundles/": "qBuilder/bundles/"
 
 container_commands:
   01_migrate:


### PR DESCRIPTION
### Changes
Fixes the elastic beanstalk deployment for the author application by adding the node generated assets to the static config

### How to test
1. Deploy into elastic beanstalk
2. Check all calls to /bundles are return a 200OK

(or visit preprod where I've manually fix it)

### Who can test
Anyone apart from @warrenbailey

