### PR TITLE
Routing

### DIFF
--- a/qBuilder/apps/app/urls.py
+++ b/qBuilder/apps/app/urls.py
@@ -3,5 +3,5 @@ from django.views.generic import TemplateView
 
 urlpatterns = [
     url(r'^healthcheck/', TemplateView.as_view(template_name="healthcheck.html"), name='healthcheck'),
-    url(r'^$', TemplateView.as_view(template_name="index.html"), name='index'),
+    url(r'^.*$', TemplateView.as_view(template_name="index.html"), name='index'),
 ]

--- a/qBuilder/assets/containers/Editor/actions.js
+++ b/qBuilder/assets/containers/Editor/actions.js
@@ -39,7 +39,7 @@ export function saveSchemaRequest() {
 export function fetchSchema(schemaID) {
   return function(dispatch) {
     dispatch(fetchSchemaRequest())
-    return fetch(`/schema/${schemaID}/`, {
+    return fetch(`/api/v1/schema/${schemaID}/`, {
       method: 'GET'
     }).then(response => response.text())
       .then(json => beautify(json, { indent_size: 2 }))
@@ -56,7 +56,7 @@ export function saveSchemaSuccess() {
 export function saveSchema(schemaID) {
   return function(dispatch, getState) {
     dispatch(saveSchemaRequest())
-    return fetch(`/schema/${schemaID}/`, {
+    return fetch(`/api/v1/schema/${schemaID}/`, {
       method: 'PUT',
       headers: DEFAULT_HEADERS,
       body: getState().get('editor').get('value')

--- a/qBuilder/assets/containers/Editor/tests/actions.test.js
+++ b/qBuilder/assets/containers/Editor/tests/actions.test.js
@@ -73,7 +73,7 @@ describe('Editor async actions', () => {
     const value = beautify('{ success: true }', { indent_size: 2 })
     const schemaID = 'blah'
 
-    fetchMock.mock(`/schema/${schemaID}/`, { body: value })
+    fetchMock.mock(`/api/v1/schema/${schemaID}/`, { body: value })
 
     const expectedActions = [
       { type: types.FETCH_SCHEMA_REQUEST, value: '//fetching schema...' },

--- a/qBuilder/assets/containers/Schemas/actions.js
+++ b/qBuilder/assets/containers/Schemas/actions.js
@@ -37,7 +37,7 @@ export function fetchSchemas() {
     }
 
     dispatch(fetchSchemasRequest())
-    return fetch('/schema/', {
+    return fetch('/api/v1/schema/', {
       mode: 'cors',
       method: 'GET',
       headers: DEFAULT_HEADERS

--- a/qBuilder/assets/containers/Schemas/tests/actions.test.js
+++ b/qBuilder/assets/containers/Schemas/tests/actions.test.js
@@ -37,7 +37,7 @@ describe('Schemas async actions', () => {
   })
 
   it('creates FETCH_SCHEMAS_SUCCESS when fetching schemas', () => {
-    fetchMock.mock('/schema/', { body: { foo: 'bar' } })
+    fetchMock.mock('/api/v1/schema/', { body: { foo: 'bar' } })
 
     const expectedActions = [
       { type: types.FETCH_SCHEMAS_REQUEST },

--- a/qBuilder/project/urls.py
+++ b/qBuilder/project/urls.py
@@ -5,6 +5,6 @@ from django.contrib import admin
 urlpatterns = [
 
     url(r'^admin/', admin.site.urls),
+    url(r'^api/v1/', include('apps.rest_api.urls')),
     url(r'', include('apps.app.urls')),
-    url(r'', include('apps.rest_api.urls')),
 ]


### PR DESCRIPTION
### Changes

Changes the URL strutures to allow the react app to handle all urls *except* for the admin, healthcheck and api endpoints.  Api endpoints are now accessed under `/api/v1`

### How to test
1) Checkout the branch
2) Run tests
3) Check you can access the admin at `/admin`
4) Check you can access the api at `/api/v1/schemas/`

### Who can test

@hamishtaplin 