### PR TITLE
Update schema validator to accept aliases and answers

### DIFF
--- a/qBuilder/apps/rest_api/tests.py
+++ b/qBuilder/apps/rest_api/tests.py
@@ -36,7 +36,7 @@ test_schema = {
                   "title": "Chewie",
                   "description": "Jedi",
                   "type": "Integer",
-                  "responses": [
+                  "answers": [
                     {
                       "id": "6cf5c72a-c1bf-4d0c-af6c-d0f07bc5b65b",
                       "q_code": "22",
@@ -45,6 +45,7 @@ test_schema = {
                       "type": "Integer",
                       "options": [],
                       "mandatory": True,
+                      "alias":"age",
                       "validation": {
                         "messages": {
                           "NOT_INTEGER": "Please enter your age.",

--- a/qBuilder/schema/schema-v1.json
+++ b/qBuilder/schema/schema-v1.json
@@ -81,7 +81,7 @@
                             "type": {
                               "type": "string"
                             },
-                            "responses": {
+                            "answers": {
                               "type": "array",
                               "items": {
                                 "type": "object",
@@ -107,6 +107,9 @@
                                   },
                                   "mandatory": {
                                     "type": "boolean"
+                                  },
+                                  "alias": {
+                                    "type": "string"
                                   },
                                   "display": {
                                     "type": "object",
@@ -136,7 +139,7 @@
                             "id",
                             "title",
                             "type",
-                            "responses"
+                            "answers"
                           ]
                         }
                       }


### PR DESCRIPTION
### What is the context of this PR?

Updates the JSON Schema used to validate questionnaire JSON files following the implementation of Piping answers into question text.  Allows the author to specify an "alias" property on the "answer" model which replaces the "response"

### How to review 

1) Checkout the app
2) Run the app and create a new schema
3) Paste the star_wars json into the text area, checking that the question about chewbaccas age has an "alias" property.
4) Check that there are no "responses" in the schema, but that they have been replaced with "answers"
5) Click save and verify that there are no error messages and that the file saves correctly

- [x] Do all commits have sensible commit messages?
- [x] Is all new code unit tested?
- [x] Are there integration tests if needed?
- [x] Is there sufficient logging?
- [x] Is there documentation or is the code self-describing?

### Who worked on the PR

@weapdiv-david worked on this

