### PR TITLE
Eq 429 django static asset fix

### DIFF
--- a/.ebextensions/02_python.config
+++ b/.ebextensions/02_python.config
@@ -10,7 +10,7 @@ option_settings:
     NumThreads: 20
   "aws:elasticbeanstalk:container:python:staticfiles":
     "/assets/": "qBuilder/assets/"
-    "/bundles/": "qBuilder/bundles/"
+    "/static/": "qBuilder/static/"
 
 container_commands:
   01_migrate:

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ target/
 *.db
 *.sqlite3
 .idea
-staticfiles
 
 
 .DS_STORE
@@ -68,10 +67,10 @@ staticfiles
 node_modules
 dist
 coverage
-webpack-stats.json
-staticfiles
-webpack-stats-prod.json
-bundles
+qBuilder/webpack-stats.json
+qBuilder/webpack-stats-prod.json
+qBuilder/bundles
+qBuilder/static
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -20,7 +20,7 @@ module.exports = require('./webpack.base.babel')({
   output: {
     filename: '[name].[chunkhash].js',
     chunkFilename: '[name].[chunkhash].chunk.js',
-    publicPath: '/bundles/'
+    publicPath: '/static/'
   },
 
   // We use ExtractTextPlugin so we get a seperate CSS file instead

--- a/qBuilder/apps/rest_api/models.py
+++ b/qBuilder/apps/rest_api/models.py
@@ -12,6 +12,8 @@ class SchemaMeta(models.Model):
     class Meta:
         ordering = ('created', 'eq_id')
 
+    def __str__(self):
+        return "{id}: {title}".format(id=self.eq_id, title=self.title)
 
 class Schema(object):
     data = {}

--- a/qBuilder/apps/rest_api/test_models.py
+++ b/qBuilder/apps/rest_api/test_models.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+
+from apps.rest_api.models import SchemaMeta
+
+class SchemaMetaTests(TestCase):
+
+    def test_str(self):
+        meta = SchemaMeta()
+        self.assertEquals(str(meta), "None: ")
+
+        meta.eq_id = 4
+        meta.title = "Test Title"
+        self.assertEquals(str(meta), "4: Test Title")

--- a/qBuilder/project/settings.py
+++ b/qBuilder/project/settings.py
@@ -170,15 +170,15 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
-STATIC_URL = '/bundles/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
+STATIC_URL = '/static/'
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'bundles'),
-    # We do this so that django's collectstatic copies or our bundles to the STATIC_ROOT or syncs them to whatever storage we use.
+    # We do this so that django's collectstatic copies our bundles to the STATIC_ROOT or syncs them to whatever storage we use.
 )
 
 WEBPACK_LOADER = {
   'DEFAULT': {
-    'BUNDLE_DIR_NAME': 'bundles/',
     'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json'),
     'IGNORE': ['.+\.hot-update.js', '.+\.map']
   }
@@ -187,7 +187,6 @@ WEBPACK_LOADER = {
 if PRODUCTION:
     WEBPACK_LOADER.update({
         'DEFAULT': {
-            'BUNDLE_DIR_NAME': 'bundles/',
             'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats-prod.json')
         }
     })

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -45,4 +45,5 @@ env | grep EQ_
 
 
 python qBuilder/manage.py migrate
+python qBuilder/manage.py collectstatic --no-input
 python qBuilder/manage.py runserver


### PR DESCRIPTION
### What is the context of this PR?
Fixed #43 

Reviewed with @dhilton yesterday but inconclusive as this can be difficult to reproduce locally because Django serves static assets when using it for development (i.e. no Apache involved). This needs testing in EB to confirm it works as expected and doesn't then break the React assets.

Also keeping this as WIP as it also isn't clear how the webpack hot-reload dev mode should work (didn't work for me following the instructions even on master) and whether this change would breaks it, assuming @hamishtaplin will need to confirm that.

### How to review 
Describe the steps required to test the changes.

- [ ] Do all commits have sensible commit messages?
- [ ] Is all new code unit tested?
- [ ] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [ ] Is there documentation or is the code self-describing?

### Who worked on the PR
@collisdigital