### PR TITLE
Create survey in database before schema

### DIFF
--- a/dahl/apps/rest_api/tests/test_schema.py
+++ b/dahl/apps/rest_api/tests/test_schema.py
@@ -103,6 +103,16 @@ class SchemaAPI(TestCase):
 
         self.assertEquals([], response.data)
 
+    def test_survey_is_created_if_it_doesnt_exist(self):
+        survey_id = '999'
+        response = self.client.get(reverse("survey-details", kwargs={'survey_id': survey_id}))
+        self.assertEquals(404, response.status_code)
+        self.valid_schema['survey_id'] = survey_id
+        response = self.client.post(reverse("schema"), json.dumps(self.valid_schema), content_type="application/json")
+        self.assertEquals(201, response.status_code)
+        response = self.client.get(reverse("survey-details", kwargs={'survey_id': survey_id}))
+        self.assertEquals(200, response.status_code)
+
     def test_invalid_schema_fails(self):
         response = self.client.post(reverse("schema"), json.dumps(self.invalid_schema), content_type="application/json")
         self.assertEquals(400, response.status_code)


### PR DESCRIPTION
### What is the context of this PR?
You can't currently add a questionnaire unless an associated survey exists in the survey table. This is because:
- It tries to save the schema before an associated survey is saved
- The survey id is being incorrectly set on the schema meta model

This pull request fixes issue #66

### How to review 
- Check out the code and run with a postgres database. 
- Try and create a new questionnaire without an associated survey existing

- [ ] Do all commits have sensible commit messages?
- [ ] Is all new code unit tested?
- [ ] Are there integration tests if needed?
- [ ] Is there sufficient logging?
- [ ] Is there documentation or is the code self-describing?

### Who worked on the PR

@ajmaddaford