### PR TITLE
fixes wrong style code pushed from last request

### DIFF
--- a/src/components/Forms/Input/index.js
+++ b/src/components/Forms/Input/index.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 const Input = styled.input`
   padding: 1em;
-  width: auto;
+  width: 100%;
   display: block;
   border-radius: 2px;
   border: 1px solid ${props => props.theme.colorBorders};
@@ -13,6 +13,7 @@ const Input = styled.input`
   }
   &[type = "checkbox"]{
     display: inline-block;
+    width: auto;
   }
 `;
 

--- a/src/containers/DesignSurvey.js
+++ b/src/containers/DesignSurvey.js
@@ -18,14 +18,7 @@ const mapDispatchToProps = (dispatch, {history}) => {
     onChange: e => {
       var value = e.target.value;
       if(e.target.type === "checkbox"){
-        // console.log("value = "+e.target.value);
-        // console.log("checked = "+e.target.checked);
-        if(e.target.checked === true){
-          value = Boolean(true);
-        }
-        else{
-          value = Boolean(false);
-        }
+        value = e.target.checked
       }
       dispatch(change(e.target.name, value));
     },


### PR DESCRIPTION
# What is the context of this PR?

Fixed style code that was missing due to the rebasing and squashing from the last commit #93. This caused the input fields to be at auto sizing rather than 100%. 

Also missed code to do with the if statement refactor in the "designsurvey.js" 

# How to review

Check to see if the text fields are the normal size they should be 