### PR TITLE
Fix Tab rendering in prod

### DIFF
--- a/src/components/Sidebar/SidebarSection.js
+++ b/src/components/Sidebar/SidebarSection.js
@@ -2,7 +2,8 @@ import React from "react";
 import styled from "styled-components";
 
 import AddIcon from "components/TreeMenu/AddIcon";
-const AddBtn = styled(AddIcon)`
+
+const AddBtn = styled.div`
   position: absolute;
   width: 2em;
   right: 0;
@@ -10,6 +11,9 @@ const AddBtn = styled(AddIcon)`
   bottom: 0;
   height: 3em;
   margin: auto;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
 `;
 
 const Header = styled.header`
@@ -38,7 +42,9 @@ export default ({ title, children, onAddClick }) => (
   <SidebarSection>
     <Header>
       <Title>{title}</Title>
-      <AddBtn onClick={onAddClick} />
+      <AddBtn onClick={onAddClick}>
+        <AddIcon />
+      </AddBtn>
     </Header>
     <Section>
       {children}

--- a/src/components/Tabs/TabList.js
+++ b/src/components/Tabs/TabList.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import styled, {css} from 'styled-components';
+import React from "react";
+import styled, { css } from "styled-components";
 
 const CompactTabList = css`
   background: #f9f9f9;
@@ -16,20 +16,23 @@ const TabListStyle = styled.ul`
   ${props => props.compact && CompactTabList}
 `;
 
-const TabList = ({children, selectedTab, handleTabSelected, ...otherProps}) => (
+const TabList = ({
+  children,
+  selectedTab,
+  handleTabSelected,
+  ...otherProps
+}) => (
   <TabListStyle {...otherProps}>
     {children.map((child, index) =>
       React.cloneElement(child, {
         selected: selectedTab === index,
         onClick: handleTabSelected.bind(this, index),
-        key: index,
+        key: index
       })
     )}
   </TabListStyle>
 );
 
-TabList.defaultProps = {
-  displayName: 'TabList',
-};
+TabList.displayName = "TabList";
 
 export default TabList;

--- a/src/components/Tabs/TabPanel.js
+++ b/src/components/Tabs/TabPanel.js
@@ -1,23 +1,21 @@
-import React from 'react';
-import styled from 'styled-components';
+import React from "react";
+import styled from "styled-components";
 
 const TabPanelStyle = styled.div`
   background: white;
   width: 100%;
-  padding: ${props => (props.compact ? '1' : '2')}em;
+  padding: ${props => (props.compact ? "1" : "2")}em;
   &[aria-hidden=true] {
     display: none;
   }
 `;
 
-const TabPanel = ({children, visible = true, ...otherProps}) => (
+const TabPanel = ({ children, visible = true, ...otherProps }) => (
   <TabPanelStyle aria-hidden={!visible} {...otherProps}>
     {children}
   </TabPanelStyle>
 );
 
-TabPanel.defaultProps = {
-  displayName: 'TabPanel',
-};
+TabPanel.displayName = "TabPanel";
 
 export default TabPanel;

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -1,53 +1,53 @@
-import React, {Component} from 'react';
-import styled from 'styled-components';
+import React, { Component } from "react";
+import styled from "styled-components";
 
-import {flattenDeep} from 'lodash';
+import { flattenDeep } from "lodash";
 
-import TabPanel from './TabPanel';
-import TabList from './TabList';
+import TabPanel from "./TabPanel";
+import TabList from "./TabList";
 
 const Tabs = styled.div`
-
+  display: block;
 `;
 
 const TabsContent = styled.div`
-  border: ${({compact, theme}) => (compact ? `none` : `1px solid ${theme.colorBorders}`)};
+  border: ${({ compact, theme }) => (compact ? `none` : `1px solid ${theme.colorBorders}`)};
   overflow: hidden;
 `;
 
 export default class extends Component {
   state = {
-    selected: this.props.selected || 0,
+    selected: this.props.selected || 0
   };
   getComponentWithProps = (child, index) => {
     const props = {
       [TabList]: {
         selectedTab: this.state.selected,
         handleTabSelected: index => {
-          this.setState({selected: index});
-        },
+          this.setState({ selected: index });
+        }
       },
       [TabPanel]: {
-        visible: this.state.selected === index,
-      },
+        visible: this.state.selected === index
+      }
     };
     return React.cloneElement(child, {
       ...props[child.type],
-      key: index,
+      key: index
     });
   };
   render() {
-    const {children, compact} = this.props;
+    const { children, compact } = this.props;
     // flatten in case arrays of children
     const flattenedChildren = flattenDeep(children);
     return (
       <Tabs compact={compact}>
         {flattenedChildren
-          .filter(child => child.type.displayName === 'TabList')
+          .filter(child => child.type.displayName === TabList.displayName)
           .map(this.getComponentWithProps)}
         <TabsContent compact={compact}>
           {flattenedChildren
-            .filter(child => child.type.displayName === 'TabPanel')
+            .filter(child => child.type.displayName === TabPanel.displayName)
             .map(this.getComponentWithProps)}
         </TabsContent>
       </Tabs>

--- a/src/components/TreeMenu/AddIcon.js
+++ b/src/components/TreeMenu/AddIcon.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
+import React from "react";
+import styled from "styled-components";
 
 const Icon = styled.div`
   width: 1em;
@@ -10,19 +10,20 @@ const Icon = styled.div`
   :hover {
     opacity: 1;
   }
-  svg {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    margin: auto;
-  }
+`;
+
+const SVG = styled.svg`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
 `;
 
 export default props => (
   <Icon {...props}>
-    <svg width="11px" height="11px" viewBox="180 16 11 11" version="1.1">
+    <SVG width="11px" height="11px" viewBox="180 16 11 11" version="1.1">
       <path
         d="M185.501279,20.5262273 L185.501279,16.4736198 C185.501279,16.211959 185.288101,16 185.025126,16 C184.76215,16 184.548972,16.211959 184.548972,16.4736198 L184.548972,20.5262273 L180.476,20.5262273 C180.213024,20.5262273 180,20.7383392 180,21 C180,21.2616608 180.213024,21.4737727 180.476,21.4737727 L184.548972,21.4737727 L184.548972,25.5263802 C184.548972,25.788041 184.76215,26 185.025126,26 C185.288101,26 185.501279,25.788041 185.501279,25.5263802 L185.501279,21.4737727 L189.574251,21.4737727 C189.837227,21.4737727 190.050251,21.2616608 190.050251,21 C190.050251,20.7383392 189.837688,20.5262273 189.574251,20.5262273 L185.501279,20.5262273 Z"
         id="button"
@@ -30,6 +31,6 @@ export default props => (
         fill="#61BDE0"
         fillRule="evenodd"
       />
-    </svg>
+    </SVG>
   </Icon>
 );


### PR DESCRIPTION
## Changes

Fixes issue with non-rendering tabs in production build.

- better usage of displayName property to check child component type
- fixed styling issue with sidebar

## How to test

- run `yarn build`
- cd into `build` folder
- `python -m SimpleHTTPServer 8000` to spin up a server
- check tabs render as expected