### PR TITLE
Wire survey meta up to state

### DIFF
--- a/src/actions/survey.js
+++ b/src/actions/survey.js
@@ -10,6 +10,8 @@ export const SURVEY_LOAD_FAILURE = "SURVEY_LOAD_FAILURE";
 export const SURVEY_SAVE = "SURVEY_SAVE";
 export const SURVEY_CLEAR = "SURVEY_CLEAR";
 
+export const META_UPDATE = "META_UPDATE";
+
 export function loadSurveySuccess(surveyData) {
   const { entities, result } = normalize(surveyData, surveySchema);
   const { groups, blocks, sections, questions, answers } = entities;
@@ -36,7 +38,7 @@ export function clearSurvey() {
 export function loadSurveyFailure(error) {
   return {
     type: SURVEY_LOAD_FAILURE,
-    payload : error
+    payload: error
   };
 }
 
@@ -59,5 +61,15 @@ export function loadSurvey(file) {
       .then(data => dispatch(loadSurveySuccess(data)))
       .then(() => dispatch(push("/create")))
       .catch(error => dispatch(loadSurveyFailure(error)));
+  };
+}
+
+export function updateMeta(key, value) {
+  return {
+    type: META_UPDATE,
+    payload: {
+      key,
+      value
+    }
   };
 }

--- a/src/actions/survey.test.js
+++ b/src/actions/survey.test.js
@@ -6,15 +6,16 @@ import {
   SURVEY_LOAD_SUCCESS,
   SURVEY_LOADING,
   SURVEY_CLEAR,
+  META_UPDATE,
   loadSurvey,
   loadingSurvey,
   loadSurveyFailure,
   loadSurveySuccess,
-  clearSurvey
+  clearSurvey,
+  updateMeta
 } from "actions/survey";
 
 describe("actions/survey", () => {
-
   describe("loadSurvey", () => {
     let dispatch;
 
@@ -25,7 +26,9 @@ describe("actions/survey", () => {
     it("dispatches error if no file supplied", () => {
       loadSurvey()(dispatch);
 
-      expect(dispatch).toHaveBeenCalledWith(actionMatching(SURVEY_LOAD_FAILURE));
+      expect(dispatch).toHaveBeenCalledWith(
+        actionMatching(SURVEY_LOAD_FAILURE)
+      );
       expect(dispatch).not.toHaveBeenCalledWith(actionMatching(SURVEY_LOADING));
     });
 
@@ -34,7 +37,9 @@ describe("actions/survey", () => {
 
       return loadSurvey(createTextFile("LOL"))(dispatch).then(() => {
         expect(dispatch).toHaveBeenCalledWith(actionMatching(SURVEY_LOADING));
-        expect(dispatch).toHaveBeenCalledWith(actionMatching(SURVEY_LOAD_FAILURE));
+        expect(dispatch).toHaveBeenCalledWith(
+          actionMatching(SURVEY_LOAD_FAILURE)
+        );
       });
     });
 
@@ -45,7 +50,9 @@ describe("actions/survey", () => {
 
       return loadSurvey(file)(dispatch).then(() => {
         expect(dispatch).toHaveBeenCalledWith(actionMatching(SURVEY_LOADING));
-        expect(dispatch).toHaveBeenCalledWith(actionMatching(SURVEY_LOAD_SUCCESS));
+        expect(dispatch).toHaveBeenCalledWith(
+          actionMatching(SURVEY_LOAD_SUCCESS)
+        );
       });
     });
 
@@ -56,8 +63,12 @@ describe("actions/survey", () => {
 
       return loadSurvey(file)(dispatch).then(() => {
         expect(dispatch).toHaveBeenCalledWith(actionMatching(SURVEY_LOADING));
-        expect(dispatch).toHaveBeenCalledWith(actionMatching(SURVEY_LOAD_SUCCESS));
-        expect(dispatch).toHaveBeenCalledWith(actionMatching(CALL_HISTORY_METHOD));
+        expect(dispatch).toHaveBeenCalledWith(
+          actionMatching(SURVEY_LOAD_SUCCESS)
+        );
+        expect(dispatch).toHaveBeenCalledWith(
+          actionMatching(CALL_HISTORY_METHOD)
+        );
       });
     });
   });
@@ -88,6 +99,14 @@ describe("actions/survey", () => {
   describe("clearSurvey", () => {
     it("dispatches the correct action", () => {
       expect(clearSurvey()).toEqual(actionMatching(SURVEY_CLEAR));
+    });
+  });
+
+  describe("updateMeta", () => {
+    it("should pass 'key' and 'value' payload", () => {
+      const payload = { key: "foo", value: "bar" };
+      const result = updateMeta(payload.key, payload.value);
+      expect(result).toEqual(actionMatching(META_UPDATE, payload));
     });
   });
 });

--- a/src/actions/surveyItems.js
+++ b/src/actions/surveyItems.js
@@ -1,6 +1,6 @@
 import { replace } from "lodash";
 
-export const CHANGE = "CHANGE";
+export const UPDATE_ITEM = "UPDATE_ITEM";
 export const ADD_ITEM = "ADD_ITEM";
 export const ADD_ITEM_COMPLETE = "ADD_ITEM_COMPLETE";
 export const REMOVE_ITEM = "REMOVE_ITEM";
@@ -27,10 +27,10 @@ export const getParentItemType = type => {
   }
 };
 
-export function change(key, value) {
+export function updateItem(key, value) {
   const [type, id, field] = key.split(".");
   return {
-    type: CHANGE,
+    type: UPDATE_ITEM,
     payload: {
       key,
       value,

--- a/src/containers/CreateSurvey.js
+++ b/src/containers/CreateSurvey.js
@@ -1,11 +1,24 @@
 import { connect } from "react-redux";
+import { updateMeta } from "actions/survey";
+
 import CreateSurveyPage from "pages/CreateSurvey";
 
-const mapStateToProps = ({ survey }) => ({
-  survey,
-  guidance: {
-    informationToProvide: survey.blocks.introduction.information_to_provide,
-  }
-});
+const mapStateToProps = (state, ownProps) => {
+  return {
+    meta: state.survey.meta,
+    guidance: {
+      informationToProvide: state.survey.blocks.introduction
+        .information_to_provide
+    }
+  };
+};
 
-export default connect(mapStateToProps)(CreateSurveyPage);
+const mapDispatchToProps = (dispatch, { history }) => {
+  return {
+    onChange: e => {
+      dispatch(updateMeta(e.target.name, e.target.value));
+    }
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(CreateSurveyPage);

--- a/src/containers/DesignSurvey.js
+++ b/src/containers/DesignSurvey.js
@@ -1,6 +1,6 @@
 import { connect } from "react-redux";
 import { clearSurvey } from "actions/survey";
-import { change, removeItem } from "actions/surveyItems";
+import { updateItem, removeItem } from "actions/surveyItems";
 import { push } from "react-router-redux";
 import DesignSurveyPage from "pages/DesignSurvey";
 
@@ -34,10 +34,10 @@ const mapDispatchToProps = (dispatch, { history }) => {
   return {
     onChange: e => {
       var value = e.target.value;
-      if(e.target.type === "checkbox"){
+      if (e.target.type === "checkbox") {
         value = e.target.checked;
       }
-      dispatch(change(e.target.name, value));
+      dispatch(updateItem(e.target.name, value));
     },
     deleteItem: (type, id) => {
       dispatch(removeItem(type, id));

--- a/src/pages/CreateSurvey.js
+++ b/src/pages/CreateSurvey.js
@@ -12,35 +12,39 @@ import { Tabs, TabPanel, TabList, TabTitle } from "components/Tabs";
 
 const ActionButtonGroup = styled(ButtonGroup)`
   padding: 1em;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
 `;
 
-const SurveyCreatePage = ({ survey }) => {
-  const { title, description, theme, legal_basis, informationToProvide } = survey;
+const SurveyCreatePage = ({ meta, onChange }) => {
+  const { title, description, theme, legal_basis, informationToProvide } = meta;
   return (
     <TabbedPageLayout title={"Create a survey"}>
-      <div>
+      <form onChange={onChange}>
         <Tabs>
           <TabList>
-            <TabTitle>Survey Settings</TabTitle>
-            <TabTitle>Guidance</TabTitle>
+            <TabTitle>Survey Meta</TabTitle>
+            <TabTitle>Landing Page</TabTitle>
           </TabList>
 
           <TabPanel>
             <Field id="title">
               <Label>Title</Label>
-              <Input name="id" value={title} />
+              <Input name="title" value={title} />
             </Field>
             <Field id="description">
               <Label>Description</Label>
-              <Input name="number" value={description} />
+              <Input name="description" value={description} />
             </Field>
             <Grid>
               <Column>
                 <Field id="theme">
                   <Label>Theme</Label>
                   <Select
-                    name="number"
-                    options={["Default", "census", "starwars"]}
+                    name="theme"
+                    options={["default", "census", "starwars"]}
                     value={theme}
                   />
                 </Field>
@@ -49,7 +53,7 @@ const SurveyCreatePage = ({ survey }) => {
                 <Field>
                   <Label>Legal Basis</Label>
                   <Select
-                    name="number"
+                    name="legal_basis"
                     options={["StatisticsOfTradeAct"]}
                     value={legal_basis}
                   />
@@ -67,7 +71,7 @@ const SurveyCreatePage = ({ survey }) => {
             </Field>
           </TabPanel>
         </Tabs>
-      </div>
+      </form>
       <ActionButtonGroup horizontal>
         <LinkButton to="/design" primary>Create survey</LinkButton>
         <LinkButton to="/" secondary>Cancel</LinkButton>

--- a/src/pages/CreateSurvey.test.js
+++ b/src/pages/CreateSurvey.test.js
@@ -1,0 +1,25 @@
+import React from "react";
+
+import { defaultState } from "reducers/survey";
+import CreateSurveyPage from "./CreateSurvey";
+
+import { mountWithRouter } from "tests/utils/mountWithRouter";
+
+describe("CreateSurveyPage", () => {
+  it("should render", () => {
+    const Page = mountWithRouter(<CreateSurveyPage meta={defaultState.meta} />);
+    expect(Page.length).not.toBe(0);
+  });
+
+  it("should call onChange handler when a field is changed", () => {
+    const changeHandler = jest.fn();
+    const Page = mountWithRouter(
+      <CreateSurveyPage meta={defaultState.meta} onChange={changeHandler} />
+    );
+
+    const titleField = Page.find("#title");
+    titleField.simulate("change", { target: { value: "Hello" } });
+
+    expect(changeHandler).toHaveBeenCalled();
+  });
+});

--- a/src/reducers/survey.js
+++ b/src/reducers/survey.js
@@ -1,8 +1,7 @@
 /* eslint-disable camelcase */
-import { SURVEY_LOAD_SUCCESS, SURVEY_CLEAR } from "actions/survey";
-
+import { SURVEY_LOAD_SUCCESS, SURVEY_CLEAR, META_UPDATE } from "actions/survey";
 import {
-  CHANGE,
+  UPDATE_ITEM,
   ADD_ITEM,
   ADD_ITEM_COMPLETE,
   REMOVE_ITEM
@@ -10,17 +9,18 @@ import {
 
 import { merge, omit, includes, find } from "lodash";
 
-const defaultState = {
-  data_version: "0.0.1",
-  description: "",
-  groups: {},
-  legal_basis: "StatisticsOfTradeAct",
-  mime_type: "application/json/ons/eq",
-  questionnaire_id: "0001",
-  schema_version: "0.0.1",
-  id: "000",
-  theme: "default",
-  title: "",
+export const defaultState = {
+  meta: {
+    data_version: "0.0.1",
+    description: "",
+    legal_basis: "StatisticsOfTradeAct",
+    mime_type: "application/json/ons/eq",
+    questionnaire_id: "0001",
+    schema_version: "0.0.1",
+    id: "000",
+    theme: "default",
+    title: ""
+  },
   blocks: {
     introduction: {
       type: "Introduction",
@@ -30,7 +30,8 @@ const defaultState = {
   },
   sections: {},
   questions: {},
-  answers: {}
+  answers: {},
+  groups: {}
 };
 
 const getItemByType = (type, name) => {
@@ -69,7 +70,7 @@ const survey = (state = defaultState, action) => {
     case SURVEY_CLEAR:
       return defaultState;
 
-    case CHANGE:
+    case UPDATE_ITEM:
       return merge({}, state, {
         [payload.type]: {
           [payload.id]: {
@@ -136,6 +137,13 @@ const survey = (state = defaultState, action) => {
           ...omit(state[payload.type], payload.id)
         }
       };
+
+    case META_UPDATE:
+      return merge({}, state, {
+        meta: {
+          [payload.key]: payload.value
+        }
+      });
 
     default:
       return state;

--- a/src/reducers/survey.test.js
+++ b/src/reducers/survey.test.js
@@ -1,0 +1,14 @@
+import reducer, { defaultState } from "reducers/survey";
+import { META_UPDATE, updateMeta } from "actions/survey";
+
+describe("survey reducer", () => {
+  it("should return the initial state", () => {
+    expect(reducer(undefined, {})).toEqual(defaultState);
+  });
+
+  it("should handle META_UPDATE with key/value merged into survey meta", () => {
+    expect(reducer([], updateMeta("title", "My title"))).toEqual({
+      meta: { title: "My title" }
+    });
+  });
+});

--- a/src/tests/utils/mountWithRouter.js
+++ b/src/tests/utils/mountWithRouter.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+import { mount } from "enzyme";
+import { MemoryRouter } from "react-router-dom";
+
+export const mountWithRouter = child =>
+  mount(<MemoryRouter>{child}</MemoryRouter>);


### PR DESCRIPTION
### What is the context of this PR?

Fixes #101 

Changes elsewhere in the application surfaced a bug whereby the survey meta (title, etc) was no longer being stored in state.

I have moved the survey meta into it's own piece of state and wired things up accordingly via an action.

### How to review 

- Visit `/create`
- Enter value in fields on the "survey meta" tab and check that those changes are persisted in state via the Redux dev tools
