### PR TITLE
Add codecov support for eq-author

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 75%
+        threshold: null
+        base: auto
+
+comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ cache:
   directories:
     - node_modules
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash) -e TRAVIS_NODE_VERSION
+
 deploy:
   local_dir: build
   provider: pages

--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
     "tinycolor2": "^1.4.1"
   },
   "jest": {
+    "coverageDirectory": "./coverage/",
+    "collectCoverage": true,
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}"
     ],


### PR DESCRIPTION
### What is the context of this PR?
This PR is all about enabling codecov.io to produce coverage reports for the eq-author application.

 - Enabled eq-author repository on codecov.io
 - Added Jest configuration to collect coverage report.
 - Added extra step into travis configuration after_success.

### How to review 
Check that codecov.io analyses the eq-author project and that relevant and helpful errors are displayed if coverage fails checks.
Appropriate rules have been set to help enforce a high level of test coverage.
Agree any additional coverage checks other than Jest if necessary.
