### PR TITLE
Change target coverage to auto.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 75%
+        target: auto
         threshold: null
         base: auto
 


### PR DESCRIPTION
### What is the context of this PR?
In an attempt to avoid failing PR branches while the test coverage is low, this PR has been raised to change the codecov configuration to set the target coverave for the project to `auto`.
This should help to ensure that project coverage must increase from parent commit or pull request base.

### How to review 
Codecov analysis should be a bit more forgiving during the early stages of the project.