### PR TITLE
set code coverage off by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 
 script:
   - yarn lint
-  - yarn test
+  - yarn test -- --coverage
   - yarn build
 
 env:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Lints the `src` directory using the rules defined in `.eslintrc`. Run `yarn lint
 Launches the test runner in the interactive watch mode.<br>
 See the section about [running tests](#running-tests) for more information.
 
+If you would like to collect code coverage run `yarn test -- --coverage`.
+
 ### `yarn build`
 
 Builds the app for production to the `build` folder.<br>

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "jest": {
     "coverageDirectory": "./coverage/",
-    "collectCoverage": true,
+    "collectCoverage": false,
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}"
     ],


### PR DESCRIPTION
### What is the context of this PR?
We should only collect code coverage on CI server, to speed up local test runs.

### How to review 
1. Run `yarn test`
2. Observe no code coverage reported
3. Ensure code coverage reported on Travis build log
