### PR TITLE
Re-work of Breadcrumb component to match the new design.

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,5 +133,11 @@
     "moduleNameMapper": {
       "^react-native$": "react-native-web"
     }
-  }
+  },
+  "babel": {
+    "presets": [
+      "react-app"
+    ]
+  },
+  "moduleRoots": [ "./src" ]
 }

--- a/package.json
+++ b/package.json
@@ -139,5 +139,7 @@
       "react-app"
     ]
   },
-  "moduleRoots": [ "./src" ]
+  "moduleRoots": [
+    "./src"
+  ]
 }

--- a/src/components/Breadcrumb/breadcrumb.test.js
+++ b/src/components/Breadcrumb/breadcrumb.test.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { concat } from "lodash";
+import Link from "components/Link";
+import Breadcrumb from "components/Breadcrumb";
+import Chevron from "./chevron";
+import { mount } from "enzyme";
+
+describe("Breadcrumb", () => {
+  describe("links", () => {
+    const stubOnClick = jest.fn();
+    const twoLinks = [
+      <Link text="Home" data="home" onClick={stubOnClick} />,
+      <Link text="Survey title" data="surveyTitle" onClick={stubOnClick} />
+    ];
+
+    const threeLinks = concat(twoLinks, [
+      <Link text="Third link" data="thirdLink" onClick={stubOnClick} />
+    ]);
+
+    it("should should display links", () => {
+      const wrapper = mount(<Breadcrumb links={twoLinks} />);
+      expect(wrapper.find("a")).toHaveLength(2);
+    });
+
+    it("should have 1 chevron when two links", () => {
+      const breadcrumbWithTwoLinks = mount(<Breadcrumb links={twoLinks} />);
+      expect(breadcrumbWithTwoLinks.find(Chevron)).toHaveLength(1);
+    });
+
+    it("should have 2 chevrons when three links", () => {
+      const breadcrumbWithThreeLinks = mount(<Breadcrumb links={threeLinks} />);
+      expect(breadcrumbWithThreeLinks.find(Chevron)).toHaveLength(2);
+    });
+  });
+});

--- a/src/components/Breadcrumb/breadcrumb.test.js
+++ b/src/components/Breadcrumb/breadcrumb.test.js
@@ -9,26 +9,43 @@ describe("Breadcrumb", () => {
   describe("links", () => {
     const stubOnClick = jest.fn();
     const twoLinks = [
-      <Link text="Home" data="home" onClick={stubOnClick} />,
-      <Link text="Survey title" data="surveyTitle" onClick={stubOnClick} />
+      <Link key="1" text="Home" data="home" onClick={stubOnClick} />,
+      <Link
+        key="2"
+        text="Survey title"
+        data="surveyTitle"
+        onClick={stubOnClick}
+      />
     ];
 
     const threeLinks = concat(twoLinks, [
-      <Link text="Third link" data="thirdLink" onClick={stubOnClick} />
+      <Link key="3" text="Third link" data="thirdLink" onClick={stubOnClick} />
     ]);
 
-    it("should should display links", () => {
-      const wrapper = mount(<Breadcrumb links={twoLinks} />);
+    const BreadcrumbWithTwoLinks = props => (
+      <Breadcrumb>
+        {twoLinks}
+      </Breadcrumb>
+    );
+
+    const BreadcrumbWithThreeLinks = props => (
+      <Breadcrumb>
+        {threeLinks}
+      </Breadcrumb>
+    );
+
+    it("should display links", () => {
+      const wrapper = mount(<BreadcrumbWithTwoLinks />);
       expect(wrapper.find("a")).toHaveLength(2);
     });
 
     it("should have 1 chevron when two links", () => {
-      const breadcrumbWithTwoLinks = mount(<Breadcrumb links={twoLinks} />);
+      const breadcrumbWithTwoLinks = mount(<BreadcrumbWithTwoLinks />);
       expect(breadcrumbWithTwoLinks.find(Chevron)).toHaveLength(1);
     });
 
     it("should have 2 chevrons when three links", () => {
-      const breadcrumbWithThreeLinks = mount(<Breadcrumb links={threeLinks} />);
+      const breadcrumbWithThreeLinks = mount(<BreadcrumbWithThreeLinks />);
       expect(breadcrumbWithThreeLinks.find(Chevron)).toHaveLength(2);
     });
   });

--- a/src/components/Breadcrumb/chevron.js
+++ b/src/components/Breadcrumb/chevron.js
@@ -1,37 +1,13 @@
 import React from "react";
-import PropTypes from "prop-types";
 import styled from "styled-components";
+import ChevronSvg from "./chevron.svg";
 
-const ChevronSvg = props => (
-  <svg width="10px" height="12px" viewBox="47 10 5 7" version="1.1">
-    <polyline
-      id="Combined-Shape"
-      stroke={props.chevronColor}
-      strokeWidth="1"
-      fill="none"
-      opacity="0.521338619"
-      transform="translate(49.153996, 13.750000) rotate(-270.000000) translate(-49.153996, -13.750000) "
-      points="51.8986355 15 49.1539961 12.5 46.4093567 15"
-    />
-  </svg>
-);
-
-ChevronSvg.propTypes = {
-  chevronColor: PropTypes.string
-};
-
-ChevronSvg.defaultProps = {
-  chevronColor: "#000"
-};
-
-const StyledSpan = styled.span`
-  margin: 16px;
+const ChevronIcon = styled.span`
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  padding: 0 1em;
+  background: url('${ChevronSvg}') center center no-repeat;
 `;
 
-export default props => {
-  return (
-    <StyledSpan>
-      <ChevronSvg {...props} />
-    </StyledSpan>
-  );
-};
+export default props => <ChevronIcon {...props} />;

--- a/src/components/Breadcrumb/chevron.js
+++ b/src/components/Breadcrumb/chevron.js
@@ -1,16 +1,37 @@
 import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
 
-export default (props) =>
-  <span {...props}>
-    <svg width="5px" height="7px" viewBox="47 10 5 7" version="1.1">
-      <polyline
-        id="Combined-Shape"
-        stroke="#979797"
-        strokeWidth="1"
-        fill="none"
-        opacity="0.521338619"
-        transform="translate(49.153996, 13.750000) rotate(-270.000000) translate(-49.153996, -13.750000) "
-        points="51.8986355 15 49.1539961 12.5 46.4093567 15"
-      />
-    </svg>
-  </span>;
+const ChevronSvg = props => (
+  <svg width="10px" height="12px" viewBox="47 10 5 7" version="1.1">
+    <polyline
+      id="Combined-Shape"
+      stroke={props.chevronColor}
+      strokeWidth="1"
+      fill="none"
+      opacity="0.521338619"
+      transform="translate(49.153996, 13.750000) rotate(-270.000000) translate(-49.153996, -13.750000) "
+      points="51.8986355 15 49.1539961 12.5 46.4093567 15"
+    />
+  </svg>
+);
+
+ChevronSvg.propTypes = {
+  chevronColor: PropTypes.string
+};
+
+ChevronSvg.defaultProps = {
+  chevronColor: "#000"
+};
+
+const StyledSpan = styled.span`
+  margin: 16px;
+`;
+
+export default props => {
+  return (
+    <StyledSpan>
+      <ChevronSvg {...props} />
+    </StyledSpan>
+  );
+};

--- a/src/components/Breadcrumb/chevron.js
+++ b/src/components/Breadcrumb/chevron.js
@@ -6,7 +6,7 @@ const ChevronIcon = styled.span`
   display: inline-block;
   width: 1em;
   height: 1em;
-  padding: 0 1em;
+  margin: 0 0.5em;
   background: url('${ChevronSvg}') center center no-repeat;
 `;
 

--- a/src/components/Breadcrumb/chevron.svg
+++ b/src/components/Breadcrumb/chevron.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="7px" height="12px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 7 12" version="1.1">
+  <polyline points="2,4 6,8 2,12"
+    stroke="white"
+    fill="none"
+    stroke-opacity="0.6" />
+</svg>

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -42,18 +42,18 @@ const StyledBreadcrumb = styled.div`
   padding: 1em 1em;
   a {
     text-decoration: none;
+    color: white;
   }
 `;
 
-const Breadcrumb = props => (
+const Breadcrumb = props =>
   <StyledBreadcrumb>
-    {props.children.map((child, index) => (
+    {props.children.map((child, index) =>
       <BreadcrumbLink key={index} isLast={index === props.children.length - 1}>
         {child}
       </BreadcrumbLink>
-    ))}
-  </StyledBreadcrumb>
-);
+    )}
+  </StyledBreadcrumb>;
 
 Breadcrumb.propTypes = {
   children: PropTypes.arrayOf(BreadcrumbLinkPropType).isRequired

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -14,11 +14,8 @@ const ChevronIcon = styled(Chevron)`
 `;
 
 const StyledBreadcrumb = styled.div`
-  background-color: ${colors.grey};
-  font-size: 0.7em;
-  display: flex;
-  align-items: center;
-  padding: 1em 1em;
+  font-size: 16px;
+  padding: 16px;
   a {
     text-decoration: none;
     color: ${colors.text}
@@ -28,7 +25,7 @@ const StyledBreadcrumb = styled.div`
 const BreadcrumbLink = props => (
   <span>
     {props.link}
-    {!props.isLast && <ChevronIcon />}
+    {!props.isLast && <Chevron chevronColor={props.theme.textColor} />}
   </span>
 );
 

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -9,10 +9,6 @@ const BreadcrumbLinkPropType = PropTypes.oneOfType([
   PropTypes.object
 ]);
 
-const ChevronIcon = styled(Chevron)`
-  margin: 0 0.5em 0 0.5em;
-`;
-
 const BreadcrumbLink = props =>
   <span>
     {props.children}

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -25,7 +25,7 @@ const StyledBreadcrumb = styled.div`
 const BreadcrumbLink = props => (
   <span>
     {props.link}
-    {!props.isLast && <Chevron chevronColor={props.theme.textColor} />}
+    {!props.isLast && <Chevron />}
   </span>
 );
 

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -24,13 +24,13 @@ const StyledBreadcrumb = styled.div`
 
 const BreadcrumbLink = props => (
   <span>
-    {props.link}
+    {props.children}
     {!props.isLast && <Chevron />}
   </span>
 );
 
 BreadcrumbLink.propTypes = {
-  link: BreadcrumbLinkPropType,
+  children: BreadcrumbLinkPropType.isRequired,
   isLast: PropTypes.bool
 };
 
@@ -38,25 +38,25 @@ BreadcrumbLink.defaultProps = {
   isLast: false
 };
 
-BreadcrumbLink.propTypes = {
-  link: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
-  isLast: PropTypes.bool
-};
+const StyledBreadcrumb = styled.div`
+  padding: 1em 1em;
+  a {
+    text-decoration: none;
+  }
+`;
 
 const Breadcrumb = props => (
-  <StyledBreadcrumb {...props}>
-    {props.links.map((link, index) => (
-      <BreadcrumbLink
-        key={index}
-        link={link}
-        isLast={index === props.links.length - 1}
-      />
+  <StyledBreadcrumb>
+    {props.children.map((child, index) => (
+      <BreadcrumbLink key={index} isLast={index === props.children.length - 1}>
+        {child}
+      </BreadcrumbLink>
     ))}
   </StyledBreadcrumb>
 );
 
 Breadcrumb.propTypes = {
-  links: PropTypes.arrayOf(BreadcrumbLinkPropType).isRequired
+  children: PropTypes.arrayOf(BreadcrumbLinkPropType).isRequired
 };
 
 export default Breadcrumb;

--- a/src/components/Breadcrumb/index.js
+++ b/src/components/Breadcrumb/index.js
@@ -13,21 +13,11 @@ const ChevronIcon = styled(Chevron)`
   margin: 0 0.5em 0 0.5em;
 `;
 
-const StyledBreadcrumb = styled.div`
-  font-size: 16px;
-  padding: 16px;
-  a {
-    text-decoration: none;
-    color: ${colors.text}
-  }
-`;
-
-const BreadcrumbLink = props => (
+const BreadcrumbLink = props =>
   <span>
     {props.children}
     {!props.isLast && <Chevron />}
-  </span>
-);
+  </span>;
 
 BreadcrumbLink.propTypes = {
   children: BreadcrumbLinkPropType.isRequired,
@@ -42,7 +32,7 @@ const StyledBreadcrumb = styled.div`
   padding: 1em 1em;
   a {
     text-decoration: none;
-    color: white;
+    color: ${colors.text};
   }
 `;
 

--- a/src/components/Breadcrumb/story.js
+++ b/src/components/Breadcrumb/story.js
@@ -15,14 +15,14 @@ const Background = styled.div`
 `;
 
 const links = [
-  <Link href="#">Home</Link>,
-  <Link href="#">Quarterly Business Survey</Link>
+  <Link key="1" href="#">Home</Link>,
+  <Link key="2" href="#">Quarterly Business Survey</Link>
 ];
 
-storiesOf("Breadcrumb", module).add("Default", () => (
+storiesOf("Breadcrumb", module).add("Default", () =>
   <Background>
     <Breadcrumb>
       {links}
     </Breadcrumb>
   </Background>
-));
+);

--- a/src/components/Breadcrumb/story.js
+++ b/src/components/Breadcrumb/story.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import Breadcrumb from "components/Breadcrumb";
 
 const Link = styled.a`
+  color: white;
   &:hover {
     text-decoration: underline;
   }
@@ -14,6 +15,17 @@ const links = [
   <Link href="#" key="world">World</Link>
 ];
 
+const StyledDiv = styled.div`
+  background: #35415D;
+`;
+
+const links = [
+  <Link href="#">Home</Link>,
+  <Link href="#">Quarterly Business Survey</Link>
+];
+
 storiesOf("Breadcrumb", module).add("Default", () => (
-  <Breadcrumb links={links} />
+  <StyledDiv>
+    <Breadcrumb links={links} />
+  </StyledDiv>
 ));

--- a/src/components/Breadcrumb/story.js
+++ b/src/components/Breadcrumb/story.js
@@ -10,7 +10,7 @@ const Link = styled.a`
   }
 `;
 
-const StyledDiv = styled.div`
+const Background = styled.div`
   background: #35415D;
 `;
 
@@ -20,7 +20,9 @@ const links = [
 ];
 
 storiesOf("Breadcrumb", module).add("Default", () => (
-  <StyledDiv>
-    <Breadcrumb links={links} />
-  </StyledDiv>
+  <Background>
+    <Breadcrumb>
+      {links}
+    </Breadcrumb>
+  </Background>
 ));

--- a/src/components/Breadcrumb/story.js
+++ b/src/components/Breadcrumb/story.js
@@ -4,9 +4,6 @@ import styled from "styled-components";
 import Breadcrumb from "components/Breadcrumb";
 
 const Link = styled.a`
-  color: #4A4A4A;
-  text-decoration: none;
-
   &:hover {
     text-decoration: underline;
   }

--- a/src/components/Breadcrumb/story.js
+++ b/src/components/Breadcrumb/story.js
@@ -10,11 +10,6 @@ const Link = styled.a`
   }
 `;
 
-const links = [
-  <Link href="#" key="hello">Hello</Link>,
-  <Link href="#" key="world">World</Link>
-];
-
 const StyledDiv = styled.div`
   background: #35415D;
 `;

--- a/src/components/ButtonGroup/__snapshots__/buttongroup.test.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/buttongroup.test.js.snap
@@ -1,8 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`button group component snapshot Should not have changed inadvertently 1`] = `
 <ButtonGroup>
   <ButtonGroup__StyledButtonGroup>
     <div
-      className="ButtonGroup__StyledButtonGroup-bdkEkm iKFOjv" />
+      className="ButtonGroup__StyledButtonGroup-bdkEkm iKFOjv"
+    />
   </ButtonGroup__StyledButtonGroup>
 </ButtonGroup>
 `;

--- a/src/components/ButtonGroup/__snapshots__/buttongroup.test.js.snap
+++ b/src/components/ButtonGroup/__snapshots__/buttongroup.test.js.snap
@@ -1,11 +1,8 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
 exports[`button group component snapshot Should not have changed inadvertently 1`] = `
 <ButtonGroup>
   <ButtonGroup__StyledButtonGroup>
     <div
-      className="ButtonGroup__StyledButtonGroup-bdkEkm iKFOjv"
-    />
+      className="ButtonGroup__StyledButtonGroup-bdkEkm iKFOjv" />
   </ButtonGroup__StyledButtonGroup>
 </ButtonGroup>
 `;

--- a/src/layouts/WithSideBar.js
+++ b/src/layouts/WithSideBar.js
@@ -17,7 +17,10 @@ const SidebarPageLayout = props => {
   return (
     <BaseLayout>
       <Nav />
-      <Breadcrumb links={Links} />
+      <Breadcrumb>
+        {Links}
+      </Breadcrumb>
+
       <Grid>
         <Column cols="3" gutters={false}>
           <SurveySidebar />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,7 +2490,7 @@ ctype@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/ctype/-/ctype-0.5.3.tgz#82c18c2461f74114ef16c135224ad0b9144ca12f"
 
-"cucumber@github:xolvio/cucumber-js#v1.3.0-chimp.6":
+cucumber@xolvio/cucumber-js#v1.3.0-chimp.6:
   version "1.3.0"
   resolved "https://codeload.github.com/xolvio/cucumber-js/tar.gz/cf953cb5b5de30dbcc279f59e4ebff3aa040071c"
   dependencies:
@@ -3822,7 +3822,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@~7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-"glob@github:lucetius/node-glob#chimp":
+glob@lucetius/node-glob#chimp:
   version "7.1.1"
   resolved "https://codeload.github.com/lucetius/node-glob/tar.gz/51c7ca6e69bfbd17db5f1ea710e3f2a7a457d9ce"
   dependencies:
@@ -5587,17 +5587,13 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.x.x, "mime-db@>= 1.27.0 < 2":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.28.0.tgz#fedd349be06d2865b7fc57d837c6de4f17d7ac3c"
+mime-db@1.x.x, "mime-db@>= 1.27.0 < 2", mime-db@~1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
 mime-db@~1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.12.0.tgz#3d0c63180f458eb10d325aaa37d7c58ae312e9d7"
-
-mime-db@~1.27.0:
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
 mime-types@^2.1.11, mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
   version "2.1.15"
@@ -5650,7 +5646,7 @@ minimatch@3.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@~3.0.2:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5650,7 +5650,7 @@ minimatch@3.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -6046,11 +6046,11 @@ on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
-once@1.3.0:
+once@1.3.0, once@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.3.0.tgz#151af86bfc1f08c4b9f07d06ab250ffcbeb56581"
 
-once@^1.3.0, once@^1.3.3, once@^1.4.0:
+once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:


### PR DESCRIPTION
### What is the context of this PR?
Refactor the breadcrumb component so that it more closely matches the new design.
Mostly stylistic updates, functionally should behave the same as before when an array of links is passed to it.
The breadcrumb defaults to the Dark theme (as per the design). But you can switch it (see the story for an example of a Light theme).
I added some additional Jest tests to cover some of the breadcrumb functionality.
Since the breadcrumb sits within the Header, some additional tweaking may be required to get it looking as expected.

### How to review 
All tests should pass.
Existing behaviour should continue to work.
Style of breadcrumb should match the designs.
