### PR TITLE
Add snapshot serialiser to package.json config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,9 @@
       "tests/setup/throwOnConsole.js"
     ],
     "setupTestFrameworkScriptFile": "tests/setup/mockLocalStorage.js",
+    "snapshotSerializers": [
+      "<rootDir>/node_modules/enzyme-to-json/serializer"
+    ],
     "testPathIgnorePatterns": [
       "<rootDir>[/\\\\](build|docs|node_modules|scripts)[/\\\\]"
     ],

--- a/src/components/ButtonGroup/buttongroup.test.js
+++ b/src/components/ButtonGroup/buttongroup.test.js
@@ -1,13 +1,12 @@
 import React from "react";
 import ButtonGroup from "./index";
-import toJson from "enzyme-to-json";
 import { mount } from "enzyme";
 
 describe("button group component", () => {
   describe("snapshot", () => {
     it("Should not have changed inadvertently", () => {
       const wrapper = mount(<ButtonGroup />);
-      expect(toJson(wrapper)).toMatchSnapshot();
+      expect(wrapper).toMatchSnapshot();
     });
   });
 

--- a/src/components/Nav/nav.test.js
+++ b/src/components/Nav/nav.test.js
@@ -1,12 +1,11 @@
 import React from "react";
 import { mount, shallow } from "enzyme";
 import Nav, { StyledNav } from "components/Nav";
-import toJson from "enzyme-to-json";
 
 describe("components/Nav", function() {
   it("should render Nav", function() {
     const wrapper = shallow(<Nav />);
-    expect(toJson(wrapper)).toMatchSnapshot();
+    expect(wrapper).toMatchSnapshot();
   });
 
   it("should contain links", function() {

--- a/src/components/Title/title.test.js
+++ b/src/components/Title/title.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import Title from "components/Title";
-import toJson from "enzyme-to-json";
 import { shallow } from "enzyme";
 
 describe("prop types", () => {
@@ -16,7 +15,7 @@ describe("prop types", () => {
 
 describe("snapshot", () => {
   it("should not have changed inadvertently", () => {
-    const tree = shallow(<Title>eQ Author</Title>);
-    expect(toJson(tree)).toMatchSnapshot();
+    const wrapper = shallow(<Title>eQ Author</Title>);
+    expect(wrapper).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
Adds snapshot serialiser to the package.json config so that there is no need to call `toJson` manually on components when snapshot testing in Jest tests.

See the [trello card](https://trello.com/c/ruqTDweN/66-configure-default-snapshot-serialiser-in-packagejson) for more information.

### How to review 
All tests should continue to pass.
Functional tests should pass.
