### PR TITLE
Add production build step back into travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
   - yarn test
   - yarn lint -- --max-warnings=0
   - yarn coverage
+  - yarn build
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) -e TRAVIS_NODE_VERSION


### PR DESCRIPTION
### What is the context of this PR?
Adds the production build step back into Travis build so that compilation errors don't go unnoticed.
The travis build won't deploy this build anywhere right now, but at least this change should help us catch any build compilation errors.

### How to review 
Production build is performed as part of travis CI.
