### PR TITLE
allow focus on CanvasSection with a click

### DIFF
--- a/src/components/QuestionnaireDesign/CanvasSection.js
+++ b/src/components/QuestionnaireDesign/CanvasSection.js
@@ -54,6 +54,7 @@ export default class CanvasSection extends Component {
 
     return (
       <StyledCanvasSection
+        onClick={this.handleFocus}
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
         focused={focused}

--- a/src/components/QuestionnaireDesign/CanvasSection.story.js
+++ b/src/components/QuestionnaireDesign/CanvasSection.story.js
@@ -9,7 +9,12 @@ import SeamlessInput from "./SeamlessInput";
 storiesOf("CanvasSection", module)
   .addDecorator(withKnobs)
   .add("Default", () =>
-    <CanvasSection id="foo" focused={boolean("focused", true)}>
+    <CanvasSection
+      id="foo"
+      focused={boolean("focused", true)}
+      onFocus={action("focused")}
+      onBlur={action("blurred")}
+    >
       <SeamlessInput id="foo" value="Hello World" onChange={action("change")} />
     </CanvasSection>
   )

--- a/src/components/QuestionnaireDesign/CanvasSection.test.js
+++ b/src/components/QuestionnaireDesign/CanvasSection.test.js
@@ -2,16 +2,17 @@ import React from "react";
 import { shallow } from "enzyme";
 import CanvasSection from "./CanvasSection";
 
-let component, handleFocus;
+let component, handleFocus, handleBlur;
 
 const Child = () => <div />;
 
 describe("CanvasSection", () => {
   beforeEach(() => {
     handleFocus = jest.fn();
+    handleBlur = jest.fn();
 
     component = shallow(
-      <CanvasSection id="foo" onFocus={handleFocus} focused>
+      <CanvasSection id="foo" onFocus={handleFocus} onBlur={handleBlur} focused>
         <Child />
       </CanvasSection>
     );
@@ -26,7 +27,17 @@ describe("CanvasSection", () => {
     expect(handleFocus).toHaveBeenCalledWith("foo");
   });
 
+  it("should allow focusing via click", () => {
+    component.simulate("click");
+    expect(handleFocus).toHaveBeenCalledWith("foo");
+  });
+
   it("should pass on its focused prop", () => {
     expect(component.find(Child).prop("focused")).toBe(true);
+  });
+
+  it("should handle blur", () => {
+    component.simulate("blur");
+    expect(handleBlur).toHaveBeenCalledWith(null);
   });
 });

--- a/src/components/QuestionnaireDesign/__snapshots__/CanvasSection.test.js.snap
+++ b/src/components/QuestionnaireDesign/__snapshots__/CanvasSection.test.js.snap
@@ -4,6 +4,7 @@ exports[`CanvasSection should render 1`] = `
 <CanvasSection__StyledCanvasSection
   focused={true}
   onBlur={[Function]}
+  onClick={[Function]}
   onFocus={[Function]}
 >
   <Child


### PR DESCRIPTION
### What is the context of this PR?
Clicking on a CanvasSection should be the same as tabbing into a field - optional && empty inputs become visible. Currently this is not the case. This PR fixes that.

### How to review 
Run tests. Inspect code. Test in browser:

1. go to QuestionnairDesign page
2. delete text from *section description field*
3. tab to another section
4. observe *section description field* is not visible
5. click anywhere in Section section (uh, naming)
6. observe that *section description field* is now visible, even if no field has focus



