### PR TITLE
Adds Options to the Mock API

### DIFF
--- a/src/tests/utils/MockDataStore.js
+++ b/src/tests/utils/MockDataStore.js
@@ -151,7 +151,7 @@ class MockDataStore {
 
   createAnswer(answer) {
     const id = ++this.counter.answer;
-    this.answers[id] = merge(answer, { id }, { options: [] });
+    this.answers[id] = merge(answer, { id, options: [] });
 
     const answerType = this.answers[id].type;
     if (answerType === "Checkbox" || answerType === "Radio") {
@@ -165,7 +165,7 @@ class MockDataStore {
         defaultOptions.push(defaultOption);
       }
 
-      forEach(defaultOptions, o => this.createOption(merge({}, o)));
+      defaultOptions.forEach(it => this.createOption(merge({}, it)));
     }
 
     this.getPage(answer.pageId).answers.push(this.answers[id]);
@@ -200,8 +200,7 @@ class MockDataStore {
   }
 
   updateOption(option) {
-    this.options[option.id] = merge(this.options[option.id], option);
-    return this.options[option.id];
+    return merge(this.options[option.id], option);
   }
 
   deleteOption(option) {

--- a/src/tests/utils/MockDataStore.js
+++ b/src/tests/utils/MockDataStore.js
@@ -6,13 +6,15 @@ class MockDataStore {
       questionnaire: 0,
       section: 0,
       page: 0,
-      answer: 0
+      answer: 0,
+      option: 0
     };
 
     this.questionnaires = {};
     this.sections = {};
     this.pages = {};
     this.answers = {};
+    this.options = {};
 
     merge(this, seedData);
   }
@@ -35,6 +37,10 @@ class MockDataStore {
 
   getAnswer(id) {
     return this.answers[id];
+  }
+
+  getOption(id) {
+    return this.options[id];
   }
 
   createQuestionaire(questionnaire) {
@@ -145,7 +151,22 @@ class MockDataStore {
 
   createAnswer(answer) {
     const id = ++this.counter.answer;
-    this.answers[id] = merge(answer, { id });
+    this.answers[id] = merge(answer, { id }, { options: [] });
+
+    const answerType = this.answers[id].type;
+    if (answerType === "Checkbox" || answerType === "Radio") {
+      const defaultOptions = [];
+      const defaultOption = {
+        answerId: id
+      };
+
+      defaultOptions.push(defaultOption);
+      if (answerType === "Radio") {
+        defaultOptions.push(defaultOption);
+      }
+
+      forEach(defaultOptions, o => this.createOption(merge({}, o)));
+    }
 
     this.getPage(answer.pageId).answers.push(this.answers[id]);
     return this.answers[id];
@@ -166,6 +187,33 @@ class MockDataStore {
 
     delete this.answers[answer.id];
     return answer;
+  }
+
+  createOption(option) {
+    const id = ++this.counter.option;
+    this.options[id] = merge(option, { id });
+
+    if (option.answerId) {
+      this.getAnswer(option.answerId).options.push(this.options[id]);
+    }
+    return this.options[id];
+  }
+
+  updateOption(option) {
+    this.options[option.id] = merge(this.options[option.id], option);
+    return this.options[option.id];
+  }
+
+  deleteOption(option) {
+    const deletedOption = this.options[option.id];
+    if (deletedOption.answerId) {
+      remove(this.answers[deletedOption.answerId].options, {
+        id: deletedOption.id
+      });
+    }
+
+    delete this.options[option.id];
+    return deletedOption;
   }
 }
 

--- a/src/tests/utils/MockDataStore.test.js
+++ b/src/tests/utils/MockDataStore.test.js
@@ -278,7 +278,7 @@ describe("MockDataStore", () => {
     ];
 
     it("should be possible to create a new option", () => {
-      const option = store.createOption(options[0]);
+      store.createOption(options[0]);
       expect(store.getOption(1)).toMatchObject(options[0]);
     });
 

--- a/src/tests/utils/MockDataStore.test.js
+++ b/src/tests/utils/MockDataStore.test.js
@@ -255,4 +255,120 @@ describe("MockDataStore", () => {
       expect(store.getPage(1).answers).not.toContain(answer);
     });
   });
+
+  describe("options", () => {
+    let store;
+    beforeEach(() => {
+      store = new MockDataStore();
+    });
+
+    const options = [
+      {
+        label: "Option one",
+        description: "The first option"
+      },
+      {
+        label: "Option two",
+        description: "The second option"
+      },
+      {
+        label: "Option three",
+        description: "The third option"
+      }
+    ];
+
+    it("should be possible to create a new option", () => {
+      const option = store.createOption(options[0]);
+      expect(store.getOption(1)).toMatchObject(options[0]);
+    });
+
+    it("should assign a new id for each newly added option", () => {
+      store.createOption(options[0]);
+      store.createOption(options[1]);
+
+      expect(store.getOption(1).id).toEqual(1);
+      expect(store.getOption(2).id).toEqual(2);
+    });
+
+    it("should continue to increment Ids even if option deleted", () => {
+      store.createOption(options[0]);
+      store.createOption(options[1]);
+      store.deleteOption({ id: 1 });
+      store.deleteOption({ id: 2 });
+
+      store.createOption(options[2]);
+
+      expect(store.getOption(3).id).toEqual(3);
+    });
+
+    it("should add the new option to an answer if answerId specified", () => {
+      store.createQuestionaire({});
+      store.createAnswer({ label: "Checkbox answer", pageId: 1 });
+
+      const option = store.createOption(merge({}, options[0], { answerId: 1 }));
+
+      expect(store.getAnswer(1).options).toContain(option);
+    });
+
+    it("should be possible to update an option", () => {
+      store.createOption(options[0]);
+      store.updateOption(
+        merge({}, store.getOption(1), { description: "Updated description" })
+      );
+      expect(store.getOption(1).description).toEqual("Updated description");
+    });
+
+    it("should have 1 option in the store after adding a single option", () => {
+      store.createOption(options[0]);
+      expect(values(store.options)).toHaveLength(1);
+    });
+
+    it("should have 0 options in the store after removing an option", () => {
+      store.createOption(options[0]);
+      store.deleteOption({ id: 1 });
+
+      expect(values(store.options)).toHaveLength(0);
+    });
+
+    it("should return undefined when trying to retrieve a deleted option from the store", () => {
+      store.createOption(options[0]);
+      store.deleteOption({ id: 1 });
+
+      expect(store.getOption(1)).toBeUndefined();
+    });
+
+    it("should remove the option from the answer when option is deleted", () => {
+      store.createQuestionaire({});
+      store.createAnswer({ label: "Checkbox answer", pageId: 1 });
+      const option = store.createOption(merge({}, options[0], { answerId: 1 }));
+
+      store.deleteOption({ id: 1 });
+
+      expect(store.getAnswer(1).options).not.toContain(option);
+    });
+
+    describe("answer specific option behaviour", () => {
+      it("should create a single option by default for a checkbox answer", () => {
+        store.createQuestionaire({});
+        store.createAnswer({
+          label: "Checkbox answer",
+          type: "Checkbox",
+          pageId: 1
+        });
+
+        expect(store.getAnswer(1).options).toHaveLength(1);
+      });
+
+      it("should create two default options for a radio answer", () => {
+        store.createQuestionaire({});
+        store.createAnswer({
+          label: "Checkbox answer",
+          type: "Radio",
+          pageId: 1
+        });
+
+        expect(store.getAnswer(1).options).toHaveLength(2);
+      });
+    });
+  });
 });

--- a/src/tests/utils/MockResolvers.js
+++ b/src/tests/utils/MockResolvers.js
@@ -1,14 +1,16 @@
 import { merge } from "lodash";
 import MockDataStore from "./MockDataStore";
 
+const localStorageKey = "mockDataStore";
+
 const updateLocalStorage = dataStore => {
   if (typeof Storage !== "undefined") {
-    localStorage.setItem("mockDataStore", JSON.stringify(dataStore));
+    localStorage.setItem(localStorageKey, JSON.stringify(dataStore));
   }
 };
 
 const createMockDataStore = () => {
-  const seed = localStorage.getItem("mockDataStore");
+  const seed = localStorage.getItem(localStorageKey);
   return seed ? new MockDataStore(JSON.parse(seed)) : new MockDataStore();
 };
 
@@ -41,6 +43,9 @@ export default {
     },
     answer: (root, args, ctx) => {
       return DataStore.getAnswer(args.id);
+    },
+    option: (root, args, ctx) => {
+      return DataStore.getOption(args.id);
     }
   }),
   Mutation: () => ({
@@ -97,6 +102,15 @@ export default {
     },
     deleteAnswer: (root, args, ctx) => {
       return persistMutation(DataStore.deleteAnswer(merge({}, args)));
+    },
+    createOption: (root, args, ctx) => {
+      return persistMutation(DataStore.createOption(merge({}, args)));
+    },
+    updateOption: (root, args, ctx) => {
+      return persistMutation(DataStore.updateOption(merge({}, args)));
+    },
+    deleteOption: (root, args, ctx) => {
+      return persistMutation(DataStore.deleteOption(merge({}, args)));
     }
   })
 };


### PR DESCRIPTION
### What is the context of this PR?
This PR extends the Mock API and adds the ability to add/update/remove Options for a given Answer.
It also mimics the behaviour expected by the real API, by adding default options for Radio and Checkbox answers.

### How to review 
The Mock API yields the expected results when used by the application.
The Mock API has enough functionality concerning Options that development can continue on the Checkbox answer story.
