### PR TITLE
fix bug where only page in section could not be deleted. fix #181

### DIFF
--- a/src/containers/QuestionnaireDesignPage/index.js
+++ b/src/containers/QuestionnaireDesignPage/index.js
@@ -65,7 +65,7 @@ export default compose(
   withUpdateAnswer,
   withCreateSection,
   withUpdatePage,
-  withDeletePage,
   withCreatePage,
+  withDeletePage, // NOTE: this *must* come after withCreatePage
   withCreateAnswer
 )(QuestionnaireDesign);

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "globals": {
+    "browser": false
+  }
+}

--- a/tests/pages/DesignQuestionnaire.page.js
+++ b/tests/pages/DesignQuestionnaire.page.js
@@ -1,7 +1,7 @@
 export const onDesignQuestionnairePage = () => {
   const pageTitle = browser.getText("h2");
 
-  return pageTitle == "QUESTIONNAIRE STRUCTURE";
+  return pageTitle === "QUESTIONNAIRE STRUCTURE";
 };
 
 export const navigationHasDefaultSectionTitle = () => {

--- a/tests/spec/smoketest-author-spec.js
+++ b/tests/spec/smoketest-author-spec.js
@@ -78,5 +78,16 @@ describe("eQ Author Smoketest", () => {
 
       expect(getFirstSectionTitle()).toEqual("My Section Title");
     });
+
+    it("should create a new page when deleting only page in section", () => {
+      const prevUrl = browser.getUrl();
+      browser.click("[aria-label='Delete page']");
+
+      browser.waitUntil(
+        () => prevUrl !== browser.getUrl(),
+        1000,
+        "expected navigation to new page after 1s"
+      );
+    });
   });
 });


### PR DESCRIPTION
### What is the context of this PR?
This fixes #181 where the only page of a section could be deleted, but a new page would not get added.

### How to review 
delete only page in a section, observe that new page is added
