### PR TITLE
Refactor all basic answers to reuse same base component.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
 
 install:
  - yarn install
+ - yarn upgrade eq-author-graphql-schema
 
 before_script:
  - yarn global add chimp

--- a/src/components/AnswerEditor/__snapshots__/answereditor.test.js.snap
+++ b/src/components/AnswerEditor/__snapshots__/answereditor.test.js.snap
@@ -20,6 +20,7 @@ exports[`Answer Editor should render Checkbox 1`] = `
     }
     minOptions={1}
     onAddOption={[Function]}
+    onChange={[Function]}
     onDeleteAnswer={[Function]}
     onDeleteOption={[Function]}
     onUpdate={[Function]}
@@ -57,6 +58,7 @@ exports[`Answer Editor should render Radio 1`] = `
     }
     minOptions={2}
     onAddOption={[Function]}
+    onChange={[Function]}
     onDeleteAnswer={[Function]}
     onDeleteOption={[Function]}
     onUpdate={[Function]}
@@ -76,7 +78,7 @@ exports[`Answer Editor should render Radio 1`] = `
 
 exports[`Answer Editor should render TextField 1`] = `
 <div>
-  <withEntityEditor(StatelessTextAnswer)
+  <TextAnswer
     answer={
       Object {
         "description": "",
@@ -86,6 +88,7 @@ exports[`Answer Editor should render TextField 1`] = `
       }
     }
     onAddOption={[Function]}
+    onChange={[Function]}
     onDeleteAnswer={[Function]}
     onDeleteOption={[Function]}
     onUpdate={[Function]}

--- a/src/components/AnswerEditor/answereditor.test.js
+++ b/src/components/AnswerEditor/answereditor.test.js
@@ -16,6 +16,7 @@ describe("Answer Editor", () => {
   beforeEach(() => {
     mockMutations = {
       onDeleteAnswer: jest.fn(),
+      onChange: jest.fn(),
       onUpdate: jest.fn(),
       onAddOption: jest.fn(),
       onUpdateOption: jest.fn(),

--- a/src/components/Answers/BasicAnswer/BasicAnswer.test.js
+++ b/src/components/Answers/BasicAnswer/BasicAnswer.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
-import { BasicAnswerFields } from "components/Answers/BasicAnswer";
+import { StatelessBasicAnswer } from "components/Answers/BasicAnswer";
 import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
 import SeamlessInput from "components/SeamlessInput/SeamlessInput";
 
@@ -13,9 +13,9 @@ describe("BasicAnswer", () => {
 
   const createWrapper = (props, children, render = shallow) => {
     return render(
-      <BasicAnswerFields {...props}>
+      <StatelessBasicAnswer {...props}>
         {children}
-      </BasicAnswerFields>
+      </StatelessBasicAnswer>
     );
   };
 

--- a/src/components/Answers/BasicAnswer/BasicAnswer.test.js
+++ b/src/components/Answers/BasicAnswer/BasicAnswer.test.js
@@ -1,0 +1,65 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import { BasicAnswerFields } from "components/Answers/BasicAnswer";
+import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
+import SeamlessInput from "components/SeamlessInput/SeamlessInput";
+
+describe("BasicAnswer", () => {
+  let answer;
+  let onChange;
+  let onUpdate;
+  let children;
+  let props;
+
+  const createWrapper = (props, children, render = shallow) => {
+    return render(
+      <BasicAnswerFields {...props}>
+        {children}
+      </BasicAnswerFields>
+    );
+  };
+
+  beforeEach(() => {
+    answer = {
+      title: "Answer title",
+      description: "Answer description",
+      type: "TextField"
+    };
+    onChange = jest.fn();
+    onUpdate = jest.fn();
+
+    props = {
+      answer,
+      onChange,
+      onUpdate
+    };
+
+    children = <div>This is the child component</div>;
+  });
+
+  it("should render", () => {
+    expect(createWrapper(props, children)).toMatchSnapshot();
+  });
+
+  describe("event handling behaviour", () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = createWrapper(props, children, mount);
+    });
+
+    it("should invoke update callback onBlur", () => {
+      wrapper.find(SeamlessInput).simulate("blur");
+      wrapper.find(SeamlessTextArea).simulate("blur");
+
+      expect(onUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it("should invoke change callback onChange", () => {
+      wrapper.find(SeamlessInput).simulate("change");
+      wrapper.find(SeamlessTextArea).simulate("change");
+
+      expect(onChange).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/components/Answers/BasicAnswer/__snapshots__/BasicAnswer.test.js.snap
+++ b/src/components/Answers/BasicAnswer/__snapshots__/BasicAnswer.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BasicAnswer should render 1`] = `
+<div>
+  <Field
+    id="label"
+  >
+    <withSeamlessness(withChangeHandler(Input))
+      data-autoFocus={true}
+      onBlur={[Function]}
+      onChange={[Function]}
+      placeholder="Label"
+      size="medium"
+    />
+  </Field>
+  <Field
+    id="description"
+  >
+    <withSeamlessness(withChangeHandler(SeamlessTextArea__TextArea))
+      cols="30"
+      onBlur={[Function]}
+      onChange={[Function]}
+      placeholder="Enter a description (optional)…"
+      rows="5"
+      size="small"
+      value="Answer description"
+    />
+  </Field>
+  <div>
+    This is the child component
+  </div>
+</div>
+`;

--- a/src/components/Answers/BasicAnswer/index.js
+++ b/src/components/Answers/BasicAnswer/index.js
@@ -6,12 +6,6 @@ import SeamlessInput from "components/SeamlessInput/SeamlessInput";
 import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
 import withEntityEditor from "components/withEntityEditor";
 
-const BasicAnswerPropTypes = {
-  answer: CustomPropTypes.answer.isRequired,
-  onChange: PropTypes.func.isRequired,
-  onUpdate: PropTypes.func.isRequired
-};
-
 export const StatelessBasicAnswer = ({
   answer,
   onChange,
@@ -43,7 +37,9 @@ export const StatelessBasicAnswer = ({
   </div>;
 
 StatelessBasicAnswer.propTypes = {
-  ...BasicAnswerPropTypes,
+  answer: CustomPropTypes.answer.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired,
   children: PropTypes.element.isRequired
 };
 

--- a/src/components/Answers/BasicAnswer/index.js
+++ b/src/components/Answers/BasicAnswer/index.js
@@ -12,7 +12,12 @@ const BasicAnswerPropTypes = {
   onUpdate: PropTypes.func.isRequired
 };
 
-export const BasicAnswerFields = ({ answer, onChange, onUpdate, children }) =>
+export const StatelessBasicAnswer = ({
+  answer,
+  onChange,
+  onUpdate,
+  children
+}) =>
   <div>
     <Field id="label">
       <SeamlessInput
@@ -37,9 +42,9 @@ export const BasicAnswerFields = ({ answer, onChange, onUpdate, children }) =>
     {children}
   </div>;
 
-BasicAnswerFields.propTypes = {
+StatelessBasicAnswer.propTypes = {
   ...BasicAnswerPropTypes,
   children: PropTypes.element.isRequired
 };
 
-export default withEntityEditor("answer")(BasicAnswerFields);
+export default withEntityEditor("answer")(StatelessBasicAnswer);

--- a/src/components/Answers/BasicAnswer/index.js
+++ b/src/components/Answers/BasicAnswer/index.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { Field } from "components/Forms";
+import PropTypes from "prop-types";
+import CustomPropTypes from "custom-prop-types";
+import SeamlessInput from "components/SeamlessInput/SeamlessInput";
+import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
+import withEntityEditor from "components/withEntityEditor";
+
+export const BasicAnswerPropTypes = {
+  answer: CustomPropTypes.answer.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired
+};
+
+export const BasicAnswerFields = ({ answer, onChange, onUpdate, children }) =>
+  <div>
+    <Field id="label">
+      <SeamlessInput
+        placeholder="Label"
+        size="medium"
+        onChange={onChange}
+        onBlur={onUpdate}
+        value={answer.label}
+        data-autoFocus
+      />
+    </Field>
+    <Field id="description">
+      <SeamlessTextArea
+        cols="30"
+        rows="5"
+        placeholder="Enter a description (optional)…"
+        onChange={onChange}
+        onBlur={onUpdate}
+        value={answer.description}
+      />
+    </Field>
+    {children}
+  </div>;
+
+BasicAnswerFields.propTypes = {
+  ...BasicAnswerPropTypes,
+  children: PropTypes.element.isRequired
+};
+
+export default withEntityEditor("answer")(BasicAnswerFields);

--- a/src/components/Answers/BasicAnswer/index.js
+++ b/src/components/Answers/BasicAnswer/index.js
@@ -6,7 +6,7 @@ import SeamlessInput from "components/SeamlessInput/SeamlessInput";
 import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
 import withEntityEditor from "components/withEntityEditor";
 
-export const BasicAnswerPropTypes = {
+const BasicAnswerPropTypes = {
   answer: CustomPropTypes.answer.isRequired,
   onChange: PropTypes.func.isRequired,
   onUpdate: PropTypes.func.isRequired

--- a/src/components/Answers/CurrencyAnswer/CurrencyAnswer.story.js
+++ b/src/components/Answers/CurrencyAnswer/CurrencyAnswer.story.js
@@ -24,9 +24,14 @@ storiesOf("AnswerTypes/CurrencyAnswer", module)
   .add("Empty", () =>
     <CurrencyAnswer
       answer={{ label: "", description: "" }}
+      onChange={action("changed")}
       onUpdate={action("updated")}
     />
   )
   .add("Prefilled", () =>
-    <CurrencyAnswer answer={answer} onUpdate={action("updated")} />
+    <CurrencyAnswer
+      answer={answer}
+      onChange={action("changed")}
+      onUpdate={action("updated")}
+    />
   );

--- a/src/components/Answers/CurrencyAnswer/CurrencyAnswer.test.js
+++ b/src/components/Answers/CurrencyAnswer/CurrencyAnswer.test.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { StatelessCurrencyAnswer } from "components/Answers/CurrencyAnswer";
-import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
-import SeamlessInput from "components/SeamlessInput/SeamlessInput";
+import CurrencyAnswer from "components/Answers/CurrencyAnswer";
 
 const answer = {
   title: "Lorem ipsum",
@@ -19,7 +17,7 @@ describe("CurrencyAnswer", () => {
     handleUpdate = jest.fn();
 
     component = shallow(
-      <StatelessCurrencyAnswer
+      <CurrencyAnswer
         onChange={handleChange}
         onUpdate={handleUpdate}
         answer={answer}
@@ -29,19 +27,5 @@ describe("CurrencyAnswer", () => {
 
   it("should render", () => {
     expect(component).toMatchSnapshot();
-  });
-
-  it("should invoke callback on change", () => {
-    component.find(SeamlessTextArea).simulate("change");
-    component.find(SeamlessInput).simulate("change");
-
-    expect(handleChange).toHaveBeenCalledTimes(2);
-  });
-
-  it("should invoke update callback on blur", () => {
-    component.find(SeamlessTextArea).simulate("blur");
-    component.find(SeamlessInput).simulate("blur");
-
-    expect(handleUpdate).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/Answers/CurrencyAnswer/__snapshots__/CurrencyAnswer.test.js.snap
+++ b/src/components/Answers/CurrencyAnswer/__snapshots__/CurrencyAnswer.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CurrencyAnswer should render 1`] = `
-<withEntityEditor(BasicAnswerFields)
+<withEntityEditor(StatelessBasicAnswer)
   answer={
     Object {
       "description": "Nullam id dolor id nibh ultricies.",
@@ -17,5 +17,5 @@ exports[`CurrencyAnswer should render 1`] = `
     />
     <TextInput__DummyTextInput />
   </CurrencyAnswer__FieldWrapper>
-</withEntityEditor(BasicAnswerFields)>
+</withEntityEditor(StatelessBasicAnswer)>
 `;

--- a/src/components/Answers/CurrencyAnswer/__snapshots__/CurrencyAnswer.test.js.snap
+++ b/src/components/Answers/CurrencyAnswer/__snapshots__/CurrencyAnswer.test.js.snap
@@ -1,38 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CurrencyAnswer should render 1`] = `
-<div>
-  <Field
-    id="label"
-  >
-    <withSeamlessness(withChangeHandler(Input))
-      data-autoFocus={true}
-      onBlur={[Function]}
-      onChange={[Function]}
-      placeholder="Label"
-      size="medium"
-    />
-  </Field>
-  <Field
-    id="description"
-  >
-    <withSeamlessness(withChangeHandler(SeamlessTextArea__TextArea))
-      cols="30"
-      onBlur={[Function]}
-      onChange={[Function]}
-      placeholder="Enter a description (optional)…"
-      rows="5"
-      size="small"
-      value="Nullam id dolor id nibh ultricies."
-    />
-  </Field>
+<withEntityEditor(BasicAnswerFields)
+  answer={
+    Object {
+      "description": "Nullam id dolor id nibh ultricies.",
+      "title": "Lorem ipsum",
+    }
+  }
+  onChange={[Function]}
+  onUpdate={[Function]}
+>
   <CurrencyAnswer__FieldWrapper>
     <CurrencyComponent
       currencyUnit="£"
     />
-    <CurrencyAnswer__StyledInput
-      disabled={true}
-    />
+    <TextInput__DummyTextInput />
   </CurrencyAnswer__FieldWrapper>
-</div>
+</withEntityEditor(BasicAnswerFields)>
 `;

--- a/src/components/Answers/CurrencyAnswer/index.js
+++ b/src/components/Answers/CurrencyAnswer/index.js
@@ -1,19 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
-import CustomPropTypes from "custom-prop-types";
-import { Field, Input } from "components/Forms";
-import SeamlessInput from "components/SeamlessInput/SeamlessInput";
-import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
 import styled from "styled-components";
 import { colors, radius } from "constants/theme";
-import withEntityEditor from "components/withEntityEditor";
-
-const StyledInput = styled(Input)`
-  padding-left: 2em;
-  position: relative;
-  background-color: transparent;
-  z-index: 2;
-`;
+import BasicAnswer, {
+  BasicAnswerPropTypes
+} from "components/Answers/BasicAnswer";
+import DummyTextInput from "components/Answers/Dummy/TextInput";
 
 const StyledSpan = styled.span`
   display: inline-block;
@@ -51,38 +43,14 @@ CurrencyComponent.defaultProps = {
   currencyUnit: "£"
 };
 
-export const StatelessCurrencyAnswer = ({ answer, onChange, onUpdate }) =>
-  <div>
-    <Field id="label">
-      <SeamlessInput
-        placeholder="Label"
-        size="medium"
-        onChange={onChange}
-        onBlur={onUpdate}
-        value={answer.label}
-        data-autoFocus
-      />
-    </Field>
-    <Field id="description">
-      <SeamlessTextArea
-        cols="30"
-        rows="5"
-        placeholder="Enter a description (optional)…"
-        onChange={onChange}
-        onBlur={onUpdate}
-        value={answer.description}
-      />
-    </Field>
+const CurrencyAnswer = props =>
+  <BasicAnswer {...props}>
     <FieldWrapper>
       <CurrencyComponent />
-      <StyledInput disabled />
+      <DummyTextInput />
     </FieldWrapper>
-  </div>;
+  </BasicAnswer>;
 
-StatelessCurrencyAnswer.propTypes = {
-  answer: CustomPropTypes.answer.isRequired,
-  onChange: PropTypes.func.isRequired,
-  onUpdate: PropTypes.func.isRequired
-};
+CurrencyAnswer.propTypes = BasicAnswerPropTypes;
 
-export default withEntityEditor("answer")(StatelessCurrencyAnswer);
+export default CurrencyAnswer;

--- a/src/components/Answers/CurrencyAnswer/index.js
+++ b/src/components/Answers/CurrencyAnswer/index.js
@@ -2,9 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { colors, radius } from "constants/theme";
-import BasicAnswer, {
-  BasicAnswerPropTypes
-} from "components/Answers/BasicAnswer";
+import BasicAnswer from "components/Answers/BasicAnswer";
 import DummyTextInput from "components/Answers/Dummy/TextInput";
 
 const StyledSpan = styled.span`
@@ -50,7 +48,5 @@ const CurrencyAnswer = props =>
       <DummyTextInput />
     </FieldWrapper>
   </BasicAnswer>;
-
-CurrencyAnswer.propTypes = BasicAnswerPropTypes;
 
 export default CurrencyAnswer;

--- a/src/components/Answers/Dummy/TextArea/index.js
+++ b/src/components/Answers/Dummy/TextArea/index.js
@@ -3,7 +3,8 @@ import PropTypes from "prop-types";
 import { sharedStyles } from "components/Forms/css";
 
 const DummyTextArea = styled.div`
-  ${sharedStyles} padding: 1.2em 1.2em 1.2em 2em;
+  ${sharedStyles};
+  padding: 1.2em 1.2em 1.2em 2em;
   position: relative;
   background-color: transparent;
   z-index: 2;

--- a/src/components/Answers/Dummy/TextArea/index.js
+++ b/src/components/Answers/Dummy/TextArea/index.js
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import { sharedStyles } from "components/Forms/css";
+
+const DummyTextArea = styled.div`
+  ${sharedStyles} padding: 1.2em 1.2em 1.2em 2em;
+  position: relative;
+  background-color: transparent;
+  z-index: 2;
+  height: ${props => props.rows + 2}em;
+`;
+
+DummyTextArea.propTypes = {
+  rows: PropTypes.number
+};
+
+DummyTextArea.defaultPropTypes = {
+  rows: 1
+};
+
+export default DummyTextArea;

--- a/src/components/Answers/Dummy/TextInput/index.js
+++ b/src/components/Answers/Dummy/TextInput/index.js
@@ -2,7 +2,8 @@ import styled from "styled-components";
 import { sharedStyles } from "components/Forms/css";
 
 const DummyTextInput = styled.div`
-  ${sharedStyles} padding: 1.2em 1.2em 1.2em 2em;
+  ${sharedStyles};
+  padding: 1.2em 1.2em 1.2em 2em;
   position: relative;
   background-color: transparent;
   z-index: 2;

--- a/src/components/Answers/Dummy/TextInput/index.js
+++ b/src/components/Answers/Dummy/TextInput/index.js
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+import { sharedStyles } from "components/Forms/css";
+
+const DummyTextInput = styled.div`
+  ${sharedStyles} padding: 1.2em 1.2em 1.2em 2em;
+  position: relative;
+  background-color: transparent;
+  z-index: 2;
+`;
+
+export default DummyTextInput;

--- a/src/components/Answers/NumberAnswer/NumberAnswer.story.js
+++ b/src/components/Answers/NumberAnswer/NumberAnswer.story.js
@@ -1,8 +1,8 @@
 import React from "react";
-import { storiesOf } from "@storybook/react";
 import NumberAnswer from "components/Answers/NumberAnswer";
-import styled from "styled-components";
+import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
+import styled from "styled-components";
 
 const Background = styled.div`
   padding: 1em;
@@ -24,9 +24,14 @@ storiesOf("AnswerTypes/NumberAnswer", module)
   .add("Empty", () =>
     <NumberAnswer
       answer={{ label: "", description: "" }}
+      onChange={action("changed")}
       onUpdate={action("updated")}
     />
   )
   .add("Prefilled", () =>
-    <NumberAnswer answer={answer} onUpdate={action("updated")} />
+    <NumberAnswer
+      answer={answer}
+      onChange={action("changed")}
+      onUpdate={action("updated")}
+    />
   );

--- a/src/components/Answers/NumberAnswer/NumberAnswer.test.js
+++ b/src/components/Answers/NumberAnswer/NumberAnswer.test.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { StatelessNumberAnswer } from "components/Answers/NumberAnswer";
-import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
-import SeamlessInput from "components/SeamlessInput/SeamlessInput";
+import NumberAnswer from "components/Answers/NumberAnswer";
 
 const answer = {
   label: "Lorem ipsum",
@@ -19,7 +17,7 @@ describe("NumberAnswer", () => {
     handleUpdate = jest.fn();
 
     component = shallow(
-      <StatelessNumberAnswer
+      <NumberAnswer
         onChange={handleChange}
         onUpdate={handleUpdate}
         answer={answer}
@@ -29,19 +27,5 @@ describe("NumberAnswer", () => {
 
   it("should render", () => {
     expect(component).toMatchSnapshot();
-  });
-
-  it("should invoke callback on change", () => {
-    component.find(SeamlessTextArea).simulate("change");
-    component.find(SeamlessInput).simulate("change");
-
-    expect(handleChange).toHaveBeenCalledTimes(2);
-  });
-
-  it("should invoke update callback on blur", () => {
-    component.find(SeamlessTextArea).simulate("blur");
-    component.find(SeamlessInput).simulate("blur");
-
-    expect(handleUpdate).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/Answers/NumberAnswer/__snapshots__/NumberAnswer.test.js.snap
+++ b/src/components/Answers/NumberAnswer/__snapshots__/NumberAnswer.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NumberAnswer should render 1`] = `
-<withEntityEditor(BasicAnswerFields)
+<withEntityEditor(StatelessBasicAnswer)
   answer={
     Object {
       "description": "Nullam id dolor id nibh ultricies.",
@@ -14,5 +14,5 @@ exports[`NumberAnswer should render 1`] = `
   <div>
     <TextInput__DummyTextInput />
   </div>
-</withEntityEditor(BasicAnswerFields)>
+</withEntityEditor(StatelessBasicAnswer)>
 `;

--- a/src/components/Answers/NumberAnswer/__snapshots__/NumberAnswer.test.js.snap
+++ b/src/components/Answers/NumberAnswer/__snapshots__/NumberAnswer.test.js.snap
@@ -1,36 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NumberAnswer should render 1`] = `
-<div>
-  <Field
-    id="label"
-  >
-    <withSeamlessness(withChangeHandler(Input))
-      data-autoFocus={true}
-      onBlur={[Function]}
-      onChange={[Function]}
-      placeholder="Label"
-      size="medium"
-      value="Lorem ipsum"
-    />
-  </Field>
-  <Field
-    id="description"
-  >
-    <withSeamlessness(withChangeHandler(SeamlessTextArea__TextArea))
-      cols="30"
-      onBlur={[Function]}
-      onChange={[Function]}
-      placeholder="Enter a description (optional)…"
-      rows="5"
-      size="small"
-      value="Nullam id dolor id nibh ultricies."
-    />
-  </Field>
+<withEntityEditor(BasicAnswerFields)
+  answer={
+    Object {
+      "description": "Nullam id dolor id nibh ultricies.",
+      "label": "Lorem ipsum",
+    }
+  }
+  onChange={[Function]}
+  onUpdate={[Function]}
+>
   <div>
-    <withChangeHandler(Input)
-      disabled={true}
-    />
+    <TextInput__DummyTextInput />
   </div>
-</div>
+</withEntityEditor(BasicAnswerFields)>
 `;

--- a/src/components/Answers/NumberAnswer/index.js
+++ b/src/components/Answers/NumberAnswer/index.js
@@ -1,7 +1,5 @@
 import React from "react";
-import BasicAnswer, {
-  BasicAnswerPropTypes
-} from "components/Answers/BasicAnswer";
+import BasicAnswer from "components/Answers/BasicAnswer";
 import DummyTextInput from "components/Answers/Dummy/TextInput";
 
 const NumberAnswer = props =>
@@ -10,7 +8,5 @@ const NumberAnswer = props =>
       <DummyTextInput />
     </div>
   </BasicAnswer>;
-
-NumberAnswer.propTypes = BasicAnswerPropTypes;
 
 export default NumberAnswer;

--- a/src/components/Answers/NumberAnswer/index.js
+++ b/src/components/Answers/NumberAnswer/index.js
@@ -1,42 +1,16 @@
 import React from "react";
-import PropTypes from "prop-types";
-import CustomPropTypes from "custom-prop-types";
-import { Field, Input } from "components/Forms";
-import SeamlessInput from "components/SeamlessInput/SeamlessInput";
-import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
-import withEntityEditor from "components/withEntityEditor";
+import BasicAnswer, {
+  BasicAnswerPropTypes
+} from "components/Answers/BasicAnswer";
+import DummyTextInput from "components/Answers/Dummy/TextInput";
 
-export const StatelessNumberAnswer = ({ answer, onUpdate, onChange }) =>
-  <div>
-    <Field id="label">
-      <SeamlessInput
-        placeholder="Label"
-        size="medium"
-        onChange={onChange}
-        onBlur={onUpdate}
-        value={answer.label}
-        data-autoFocus
-      />
-    </Field>
-    <Field id="description">
-      <SeamlessTextArea
-        cols="30"
-        rows="5"
-        placeholder="Enter a description (optional)…"
-        onChange={onChange}
-        onBlur={onUpdate}
-        value={answer.description}
-      />
-    </Field>
+const NumberAnswer = props =>
+  <BasicAnswer {...props}>
     <div>
-      <Input disabled />
+      <DummyTextInput />
     </div>
-  </div>;
+  </BasicAnswer>;
 
-StatelessNumberAnswer.propTypes = {
-  answer: CustomPropTypes.answer.isRequired,
-  onChange: PropTypes.func.isRequired,
-  onUpdate: PropTypes.func.isRequired
-};
+NumberAnswer.propTypes = BasicAnswerPropTypes;
 
-export default withEntityEditor("answer")(StatelessNumberAnswer);
+export default NumberAnswer;

--- a/src/components/Answers/TextAnswer/TextAnswer.story.js
+++ b/src/components/Answers/TextAnswer/TextAnswer.story.js
@@ -24,9 +24,14 @@ storiesOf("AnswerTypes/TextAnswer", module)
   .add("Empty", () =>
     <TextAnswer
       answer={{ label: "", description: "" }}
+      onChange={action("changed")}
       onUpdate={action("updated")}
     />
   )
   .add("Prefilled", () =>
-    <TextAnswer answer={answer} onUpdate={action("updated")} />
+    <TextAnswer
+      answer={answer}
+      onChange={action("changed")}
+      onUpdate={action("updated")}
+    />
   );

--- a/src/components/Answers/TextAnswer/TextAnswer.test.js
+++ b/src/components/Answers/TextAnswer/TextAnswer.test.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { StatelessTextAnswer } from "components/Answers/TextAnswer";
-import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
-import SeamlessInput from "components/SeamlessInput/SeamlessInput";
+import TextAnswer from "components/Answers/TextAnswer";
 
 const answer = {
   title: "Lorem ipsum",
@@ -18,29 +16,15 @@ describe("TextAnswer", () => {
     handleChange = jest.fn();
     handleUpdate = jest.fn();
     wrapper = shallow(
-      <StatelessTextAnswer
+      <TextAnswer
+        answer={answer}
         onChange={handleChange}
         onUpdate={handleUpdate}
-        answer={answer}
       />
     );
   });
 
   it("should render", () => {
     expect(wrapper).toMatchSnapshot();
-  });
-
-  it("should invoke update callback onBlur", () => {
-    wrapper.find(SeamlessInput).simulate("blur");
-    wrapper.find(SeamlessTextArea).simulate("blur");
-
-    expect(handleUpdate).toHaveBeenCalledTimes(2);
-  });
-
-  it("should invoke change callback onChange", () => {
-    wrapper.find(SeamlessInput).simulate("change");
-    wrapper.find(SeamlessTextArea).simulate("change");
-
-    expect(handleChange).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/Answers/TextAnswer/__snapshots__/TextAnswer.test.js.snap
+++ b/src/components/Answers/TextAnswer/__snapshots__/TextAnswer.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextAnswer should render 1`] = `
-<withEntityEditor(BasicAnswerFields)
+<withEntityEditor(StatelessBasicAnswer)
   answer={
     Object {
       "description": "Nullam id dolor id nibh ultricies.",
@@ -12,5 +12,5 @@ exports[`TextAnswer should render 1`] = `
   onUpdate={[Function]}
 >
   <TextInput__DummyTextInput />
-</withEntityEditor(BasicAnswerFields)>
+</withEntityEditor(StatelessBasicAnswer)>
 `;

--- a/src/components/Answers/TextAnswer/__snapshots__/TextAnswer.test.js.snap
+++ b/src/components/Answers/TextAnswer/__snapshots__/TextAnswer.test.js.snap
@@ -1,33 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextAnswer should render 1`] = `
-<div>
-  <Field
-    id="label"
-  >
-    <withSeamlessness(withChangeHandler(Input))
-      data-autoFocus={true}
-      onBlur={[Function]}
-      onChange={[Function]}
-      placeholder="Label"
-      size="medium"
-    />
-  </Field>
-  <Field
-    id="description"
-  >
-    <withSeamlessness(withChangeHandler(SeamlessTextArea__TextArea))
-      cols="30"
-      onBlur={[Function]}
-      onChange={[Function]}
-      placeholder="Enter a description (optional)…"
-      rows="5"
-      size="small"
-      value="Nullam id dolor id nibh ultricies."
-    />
-  </Field>
-  <withChangeHandler(Input)
-    disabled={true}
-  />
-</div>
+<withEntityEditor(BasicAnswerFields)
+  answer={
+    Object {
+      "description": "Nullam id dolor id nibh ultricies.",
+      "title": "Lorem ipsum",
+    }
+  }
+  onChange={[Function]}
+  onUpdate={[Function]}
+>
+  <TextInput__DummyTextInput />
+</withEntityEditor(BasicAnswerFields)>
 `;

--- a/src/components/Answers/TextAnswer/index.js
+++ b/src/components/Answers/TextAnswer/index.js
@@ -1,47 +1,14 @@
 import React from "react";
-import PropTypes from "prop-types";
-import CustomPropTypes from "custom-prop-types";
-import { Field, Input } from "components/Forms";
-import SeamlessInput from "components/SeamlessInput/SeamlessInput";
-import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
-import withEntityEditor from "components/withEntityEditor";
+import BasicAnswer, {
+  BasicAnswerPropTypes
+} from "components/Answers/BasicAnswer";
+import DummyTextInput from "components/Answers/Dummy/TextInput";
 
-export class StatelessTextAnswer extends React.Component {
-  render() {
-    const { answer, onChange, onUpdate } = this.props;
+const TextAnswer = props =>
+  <BasicAnswer {...props}>
+    <DummyTextInput />
+  </BasicAnswer>;
 
-    return (
-      <div>
-        <Field id="label">
-          <SeamlessInput
-            placeholder="Label"
-            size="medium"
-            onChange={onChange}
-            onBlur={onUpdate}
-            value={answer.label}
-            data-autoFocus
-          />
-        </Field>
-        <Field id="description">
-          <SeamlessTextArea
-            cols="30"
-            rows="5"
-            placeholder="Enter a description (optional)…"
-            onChange={onChange}
-            onBlur={onUpdate}
-            value={answer.description}
-          />
-        </Field>
-        <Input disabled />
-      </div>
-    );
-  }
-}
+TextAnswer.propTypes = BasicAnswerPropTypes;
 
-StatelessTextAnswer.propTypes = {
-  answer: CustomPropTypes.answer.isRequired,
-  onChange: PropTypes.func.isRequired,
-  onUpdate: PropTypes.func.isRequired
-};
-
-export default withEntityEditor("answer")(StatelessTextAnswer);
+export default TextAnswer;

--- a/src/components/Answers/TextAnswer/index.js
+++ b/src/components/Answers/TextAnswer/index.js
@@ -1,14 +1,10 @@
 import React from "react";
-import BasicAnswer, {
-  BasicAnswerPropTypes
-} from "components/Answers/BasicAnswer";
+import BasicAnswer from "components/Answers/BasicAnswer";
 import DummyTextInput from "components/Answers/Dummy/TextInput";
 
 const TextAnswer = props =>
   <BasicAnswer {...props}>
     <DummyTextInput />
   </BasicAnswer>;
-
-TextAnswer.propTypes = BasicAnswerPropTypes;
 
 export default TextAnswer;

--- a/src/components/Answers/TextAreaAnswer/TextAreaAnswer.story.js
+++ b/src/components/Answers/TextAreaAnswer/TextAreaAnswer.story.js
@@ -24,9 +24,14 @@ storiesOf("AnswerTypes/TextAreaAnswer", module)
   .add("Empty", () =>
     <TextAreaAnswer
       answer={{ label: "", description: "" }}
+      onChange={action("changed")}
       onUpdate={action("updated")}
     />
   )
   .add("Prefilled", () =>
-    <TextAreaAnswer answer={answer} onUpdate={action("updated")} />
+    <TextAreaAnswer
+      answer={answer}
+      onChange={action("changed")}
+      onUpdate={action("updated")}
+    />
   );

--- a/src/components/Answers/TextAreaAnswer/TextAreaAnswer.test.js
+++ b/src/components/Answers/TextAreaAnswer/TextAreaAnswer.test.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { StatelessTextAreaAnswer } from "components/Answers/TextAreaAnswer";
-import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
-import SeamlessInput from "components/SeamlessInput/SeamlessInput";
+import TextAreaAnswer from "components/Answers/TextAreaAnswer";
 
 const answer = {
   title: "Lorem ipsum",
@@ -19,7 +17,7 @@ describe("TextAreaAnswer", () => {
     handleUpdate = jest.fn();
 
     component = shallow(
-      <StatelessTextAreaAnswer
+      <TextAreaAnswer
         onChange={handleChange}
         onUpdate={handleUpdate}
         answer={answer}
@@ -29,19 +27,5 @@ describe("TextAreaAnswer", () => {
 
   it("should render", () => {
     expect(component).toMatchSnapshot();
-  });
-
-  it("should invoke callback on change", () => {
-    component.find(SeamlessTextArea).simulate("change");
-    component.find(SeamlessInput).simulate("change");
-
-    expect(handleChange).toHaveBeenCalledTimes(2);
-  });
-
-  it("should invoke update callback on blur", () => {
-    component.find(SeamlessTextArea).simulate("blur");
-    component.find(SeamlessInput).simulate("blur");
-
-    expect(handleUpdate).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/Answers/TextAreaAnswer/__snapshots__/TextAreaAnswer.test.js.snap
+++ b/src/components/Answers/TextAreaAnswer/__snapshots__/TextAreaAnswer.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextAreaAnswer should render 1`] = `
-<withEntityEditor(BasicAnswerFields)
+<withEntityEditor(StatelessBasicAnswer)
   answer={
     Object {
       "description": "Nullam id dolor id nibh ultricies.",
@@ -16,5 +16,5 @@ exports[`TextAreaAnswer should render 1`] = `
       rows={5}
     />
   </div>
-</withEntityEditor(BasicAnswerFields)>
+</withEntityEditor(StatelessBasicAnswer)>
 `;

--- a/src/components/Answers/TextAreaAnswer/__snapshots__/TextAreaAnswer.test.js.snap
+++ b/src/components/Answers/TextAreaAnswer/__snapshots__/TextAreaAnswer.test.js.snap
@@ -1,37 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextAreaAnswer should render 1`] = `
-<div>
-  <Field
-    id="label"
-  >
-    <withSeamlessness(withChangeHandler(Input))
-      data-autoFocus={true}
-      onBlur={[Function]}
-      onChange={[Function]}
-      placeholder="Label"
-      size="medium"
-    />
-  </Field>
-  <Field
-    id="description"
-  >
-    <withSeamlessness(withChangeHandler(SeamlessTextArea__TextArea))
-      cols="30"
-      onBlur={[Function]}
-      onChange={[Function]}
-      placeholder="Enter a description (optional)…"
-      rows="5"
-      size="small"
-      value="Nullam id dolor id nibh ultricies."
-    />
-  </Field>
+<withEntityEditor(BasicAnswerFields)
+  answer={
+    Object {
+      "description": "Nullam id dolor id nibh ultricies.",
+      "title": "Lorem ipsum",
+    }
+  }
+  onChange={[Function]}
+  onUpdate={[Function]}
+>
   <div>
-    <withChangeHandler(TextArea)
-      disabled={true}
-      id="dummy"
+    <TextArea__DummyTextArea
       rows={5}
     />
   </div>
-</div>
+</withEntityEditor(BasicAnswerFields)>
 `;

--- a/src/components/Answers/TextAreaAnswer/index.js
+++ b/src/components/Answers/TextAreaAnswer/index.js
@@ -1,7 +1,5 @@
 import React from "react";
-import BasicAnswer, {
-  BasicAnswerPropTypes
-} from "components/Answers/BasicAnswer";
+import BasicAnswer from "components/Answers/BasicAnswer";
 import DummyTextArea from "components/Answers/Dummy/TextArea";
 
 const TextAreaAnswer = props =>
@@ -10,7 +8,5 @@ const TextAreaAnswer = props =>
       <DummyTextArea rows={5} />
     </div>
   </BasicAnswer>;
-
-TextAreaAnswer.propTypes = BasicAnswerPropTypes;
 
 export default TextAreaAnswer;

--- a/src/components/Answers/TextAreaAnswer/index.js
+++ b/src/components/Answers/TextAreaAnswer/index.js
@@ -1,42 +1,16 @@
 import React from "react";
-import PropTypes from "prop-types";
-import CustomPropTypes from "custom-prop-types";
-import { Field, TextArea } from "components/Forms";
-import SeamlessInput from "components/SeamlessInput/SeamlessInput";
-import SeamlessTextArea from "components/SeamlessTextArea/SeamlessTextArea";
-import withEntityEditor from "components/withEntityEditor";
+import BasicAnswer, {
+  BasicAnswerPropTypes
+} from "components/Answers/BasicAnswer";
+import DummyTextArea from "components/Answers/Dummy/TextArea";
 
-export const StatelessTextAreaAnswer = ({ answer, onUpdate, onChange }) =>
-  <div>
-    <Field id="label">
-      <SeamlessInput
-        placeholder="Label"
-        size="medium"
-        onChange={onChange}
-        onBlur={onUpdate}
-        value={answer.label}
-        data-autoFocus
-      />
-    </Field>
-    <Field id="description">
-      <SeamlessTextArea
-        cols="30"
-        rows="5"
-        placeholder="Enter a description (optional)…"
-        onChange={onChange}
-        onBlur={onUpdate}
-        value={answer.description}
-      />
-    </Field>
+const TextAreaAnswer = props =>
+  <BasicAnswer {...props}>
     <div>
-      <TextArea rows={5} disabled id="dummy" />
+      <DummyTextArea rows={5} />
     </div>
-  </div>;
+  </BasicAnswer>;
 
-StatelessTextAreaAnswer.propTypes = {
-  answer: CustomPropTypes.answer.isRequired,
-  onChange: PropTypes.func.isRequired,
-  onUpdate: PropTypes.func.isRequired
-};
+TextAreaAnswer.propTypes = BasicAnswerPropTypes;
 
-export default withEntityEditor("answer")(StatelessTextAreaAnswer);
+export default TextAreaAnswer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3087,9 +3087,13 @@ enzyme@^2.8.2:
     prop-types "^15.5.10"
     uuid "^3.0.1"
 
-eq-author-graphql-schema@ONSDigital/eq-author-graphql-schema#16132f5, eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#4620141:
+eq-author-graphql-schema@ONSDigital/eq-author-graphql-schema#16132f5:
   version "1.0.0"
   resolved "https://codeload.github.com/ONSDigital/eq-author-graphql-schema/tar.gz/16132f5"
+
+eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#4620141:
+  version "1.0.0"
+  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/4620141"
 
 eq-author-mock-api@ONSDigital/eq-author-mock-api#204e37f:
   version "1.0.0"


### PR DESCRIPTION
### What is the context of this PR?
Introduced a new component called `BasicAnswer` which encapsulates all of the common fields used in all the basic answer types.
Refactored `TextAnswer`, `TextAreaAnswer`, `CurrencyAnswer` and `NumberAnswer` to use the `BasicAnswer` type.
Updated all affected snapshot and unit tests.

### How to review 
All tests should pass.
Components should still render correctly in storybook.
