### PR TITLE
drop usage of newId

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "connected-react-router": "^4.2.1",
     "draft-js": "^0.10.1",
     "enzyme": "^2.8.2",
-    "eq-author-graphql-schema": "ONSdigital/eq-author-graphql-schema#ff87872",
+    "eq-author-graphql-schema": "ONSdigital/eq-author-graphql-schema#e5caa74",
     "eq-author-mock-api": "ONSdigital/eq-author-mock-api#4342f6a",
     "eslint-config-eq-author": "^1.0.2",
     "graphql-anywhere": "^3.1.0",

--- a/src/graphql/answerFragment.graphql
+++ b/src/graphql/answerFragment.graphql
@@ -1,7 +1,7 @@
 fragment MinimalAnswer on Answer {
   ... on MultipleChoiceAnswer {
     options {
-      id: newId
+      id
     }
   }
 }

--- a/src/graphql/createQuestionPage.graphql
+++ b/src/graphql/createQuestionPage.graphql
@@ -5,10 +5,10 @@ mutation createQuestionPage($input: CreateQuestionPageInput!) {
     ...Page
     pageType
     answers {
-      id: newId
+      id
     }
     section {
-      id: newId
+      id
     }
   }
 }

--- a/src/graphql/createQuestionnaire.graphql
+++ b/src/graphql/createQuestionnaire.graphql
@@ -1,10 +1,10 @@
 mutation createQuestionnaire($input: CreateQuestionnaireInput!) {
   createQuestionnaire(input: $input) {
-    id: newId
+    id
     sections {
-      id: newId
+      id
       pages {
-        id: newId
+        id
       }
     }
   }

--- a/src/graphql/createSection.graphql
+++ b/src/graphql/createSection.graphql
@@ -4,14 +4,14 @@ mutation CreateSection($input: CreateSectionInput!) {
   createSection(input: $input) {
     ...Section
     pages {
-      id: newId
+      id
       title
       description
       ... on QuestionPage {
         guidance
         pageType
         answers {
-          id: newId
+          id
         }
       }
     }

--- a/src/graphql/deleteAnswer.graphql
+++ b/src/graphql/deleteAnswer.graphql
@@ -1,5 +1,5 @@
 mutation DeleteAnswer($input: DeleteAnswerInput!) {
   deleteAnswer(input: $input) {
-    id: newId
+    id
   }
 }

--- a/src/graphql/deleteOption.graphql
+++ b/src/graphql/deleteOption.graphql
@@ -1,5 +1,5 @@
 mutation DeleteOption($input: DeleteOptionInput!) {
   deleteOption(input: $input) {
-    id: newId
+    id
   }
 }

--- a/src/graphql/deletePage.graphql
+++ b/src/graphql/deletePage.graphql
@@ -1,5 +1,5 @@
 mutation DeletePage($input: DeletePageInput!) {
   deletePage(input: $input) {
-    id: newId
+    id
   }
 }

--- a/src/graphql/deleteQuestionnaire.graphql
+++ b/src/graphql/deleteQuestionnaire.graphql
@@ -1,5 +1,5 @@
-mutation DeleteQuestionnaire($input: DeleteQuestionnaireInput) {
+mutation DeleteQuestionnaire($input: DeleteQuestionnaireInput!) {
   deleteQuestionnaire(input: $input) {
-    id: newId
+    id
   }
 }

--- a/src/graphql/fragments/answer.graphql
+++ b/src/graphql/fragments/answer.graphql
@@ -1,5 +1,5 @@
 fragment Answer on Answer {
-  id: newId
+  id
   description
   guidance
   label

--- a/src/graphql/fragments/option.graphql
+++ b/src/graphql/fragments/option.graphql
@@ -1,5 +1,5 @@
 fragment Option on Option {
-  id: newId
+  id
   description
   label
 }

--- a/src/graphql/fragments/page.graphql
+++ b/src/graphql/fragments/page.graphql
@@ -1,5 +1,5 @@
 fragment Page on QuestionPage {
-  id: newId
+  id
   title
   description
   guidance

--- a/src/graphql/fragments/questionnaire.graphql
+++ b/src/graphql/fragments/questionnaire.graphql
@@ -1,5 +1,5 @@
 fragment Questionnaire on Questionnaire {
-  id: newId
+  id
   title
   description
   surveyId

--- a/src/graphql/fragments/section.graphql
+++ b/src/graphql/fragments/section.graphql
@@ -1,5 +1,5 @@
 fragment Section on Section {
-  id: newId
+  id
   title
   description
 }

--- a/src/graphql/getQuestionnaire.graphql
+++ b/src/graphql/getQuestionnaire.graphql
@@ -3,13 +3,13 @@
 #import "./fragments/answer.graphql"
 #import "./fragments/option.graphql"
 
-query GetQuestionnaire($id: Int!) {
+query GetQuestionnaire($id: ID!) {
   questionnaire(id: $id) {
     ...Questionnaire
     sections {
       ...Section
       pages {
-        id: newId
+        id
         title
         description
         pageType

--- a/src/graphql/getQuestionnaireList.graphql
+++ b/src/graphql/getQuestionnaireList.graphql
@@ -1,13 +1,13 @@
 query GetQuestionnaireList {
   questionnaires {
-    id: newId
+    id
     title
     createdAt
     theme
     sections {
-      id: newId
+      id
       pages {
-        id: newId
+        id
       }
     }
   }

--- a/src/graphql/getSection.graphql
+++ b/src/graphql/getSection.graphql
@@ -1,10 +1,10 @@
 #import "./fragments/section.graphql"
 
-query getSection($id: Int!) {
+query getSection($id: ID!) {
   section(id: $id) {
     ...Section
     pages {
-      id: newId
+      id
     }
   }
 }

--- a/src/graphql/pageFragment.graphql
+++ b/src/graphql/pageFragment.graphql
@@ -1,6 +1,6 @@
 fragment MinimalPage on QuestionPage {
-  id: newId
+  id
   answers {
-    id: newId
+    id
   }
 }

--- a/src/graphql/questionnaireFragment.graphql
+++ b/src/graphql/questionnaireFragment.graphql
@@ -1,5 +1,5 @@
 fragment MinimalQuestionnaire on Questionnaire {
   sections {
-    id: newId
+    id
   }
 }

--- a/src/graphql/sectionFragment.graphql
+++ b/src/graphql/sectionFragment.graphql
@@ -1,6 +1,6 @@
 fragment MinimalSection on Section {
-  id: newId
+  id
   pages {
-    id: newId
+    id
   }
 }

--- a/src/tests/utils/MockResolvers.js
+++ b/src/tests/utils/MockResolvers.js
@@ -2,7 +2,6 @@ import { merge } from "lodash";
 import MockDataStore from "./MockDataStore";
 
 const localStorageKey = "mockDataStore";
-const getNewId = entity => entity.id.toString(10);
 
 const updateLocalStorage = dataStore => {
   if (typeof Storage !== "undefined") {
@@ -138,26 +137,22 @@ export default {
 
   Questionnaire: () => ({
     sections: (questionnaire, args, ctx) =>
-      DataStore.getSections(questionnaire.id),
-    newId: getNewId
+      DataStore.getSections(questionnaire.id)
   }),
 
   Section: () => ({
     pages: (section, args, ctx) => DataStore.getPages(section.id),
     questionnaire: (section, args, ctx) =>
-      DataStore.getQuestionnaire(section.questionnaireId),
-    newId: getNewId
+      DataStore.getQuestionnaire(section.questionnaireId)
   }),
 
   Page: () => ({
-    __resolveType: ({ pageType }) => pageType,
-    newId: getNewId
+    __resolveType: ({ pageType }) => pageType
   }),
 
   QuestionPage: () => ({
     answers: (page, args, ctx) => DataStore.getAnswers(page.id),
-    section: (page, args, ctx) => DataStore.getSection(page.sectionId),
-    newId: getNewId
+    section: (page, args, ctx) => DataStore.getSection(page.sectionId)
   }),
 
   Answer: () => ({
@@ -165,17 +160,11 @@ export default {
   }),
 
   BasicAnswer: () => ({
-    page: (answer, args, ctx) => DataStore.getPage(answer.questionPageId),
-    newId: getNewId
+    page: (answer, args, ctx) => DataStore.getPage(answer.questionPageId)
   }),
 
   MultipleChoiceAnswer: () => ({
     page: (answer, args, ctx) => DataStore.getPage(answer.questionPageId),
-    options: (answer, args, ctx) => DataStore.getOptions(answer.id),
-    newId: getNewId
-  }),
-
-  Option: () => ({
-    newId: getNewId
+    options: (answer, args, ctx) => DataStore.getOptions(answer.id)
   })
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3047,9 +3047,9 @@ enzyme@^2.8.2:
     prop-types "^15.5.10"
     uuid "^3.0.1"
 
-eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#ff87872:
+eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#e5caa74:
   version "1.0.0"
-  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/ff87872089cbfde430e3dbe9e90c1301fa01ae5d"
+  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/e5caa744b1fe0962c21b19448531e64a42174b01"
 
 eq-author-mock-api@ONSdigital/eq-author-mock-api#4342f6a:
   version "1.0.0"


### PR DESCRIPTION
**DEPENDENT ON https://github.com/ONSdigital/eq-author-api/pull/39 BEING MERGED FIRST**

---

### What is the context of this PR?
Drops usage of `newId` field throughout, now that `id` fields are of correct type

### How to review 
Run tests, check code