### PR TITLE
Fix error observed on admin page when running with the mockAPI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "./",
   "scripts": {
     "start": "yarn && node scripts/start.js",
-    "start:mockAPI": "yarn && REACT_APP_USE_MOCK_API=true node scripts/start.js",
+    "start:mockAPI": "REACT_APP_USE_MOCK_API=true node scripts/start.js",
     "build": "node scripts/build.js",
     "build:mockAPI": "yarn && REACT_APP_USE_MOCK_API=true node scripts/build.js",
     "test": "node scripts/test.js",
@@ -99,7 +99,9 @@
     "eq-author-mock-api": "ONSdigital/eq-author-mock-api#4342f6a",
     "eslint-config-eq-author": "^1.0.2",
     "graphql-anywhere": "^3.1.0",
+    "graphql-iso-date": "^3.3.0",
     "graphql-tag": "^2.4.2",
+    "graphql-tools": "^1.2.3",
     "jest-transform-graphql": "^2.1.0",
     "lodash": "^4.17.4",
     "normalize.css": "^7.0.0",

--- a/src/apollo/createMockNetworkInterface.js
+++ b/src/apollo/createMockNetworkInterface.js
@@ -1,4 +1,15 @@
 import schema from "eq-author-graphql-schema";
+import { makeExecutableSchema } from "graphql-tools";
 const { MockNetworkInterface } = require("eq-author-mock-api");
+const { GraphQLDate } = require("graphql-iso-date");
 
-export default (mocks = {}) => new MockNetworkInterface(schema, mocks);
+export default (mocks = {}) => {
+  const executableSchema = makeExecutableSchema({
+    typeDefs: schema,
+    resolvers: {
+      Date: GraphQLDate
+    }
+  });
+
+  return new MockNetworkInterface(executableSchema, mocks);
+};

--- a/src/tests/utils/MockDataStore.js
+++ b/src/tests/utils/MockDataStore.js
@@ -45,10 +45,17 @@ class MockDataStore {
 
   createQuestionnaire(questionnaire) {
     const id = (++this.counter.questionnaire).toString();
+
+    const dateAsString = new Date().toISOString();
+    const dateWithoutTime = dateAsString.substring(
+      0,
+      dateAsString.indexOf("T")
+    );
+
     this.questionnaires[id] = merge(questionnaire, {
       id,
       sections: [],
-      createdAt: new Date().toISOString()
+      createdAt: dateWithoutTime
     });
 
     const defaultSection = this.createSection({

--- a/src/tests/utils/MockResolvers.js
+++ b/src/tests/utils/MockResolvers.js
@@ -1,6 +1,8 @@
 import { merge } from "lodash";
 import MockDataStore from "./MockDataStore";
 
+const { GraphQLDate } = require("graphql-iso-date");
+
 const localStorageKey = "mockDataStore";
 
 const updateLocalStorage = dataStore => {
@@ -137,7 +139,8 @@ export default {
 
   Questionnaire: () => ({
     sections: (questionnaire, args, ctx) =>
-      DataStore.getSections(questionnaire.id)
+      DataStore.getSections(questionnaire.id),
+    createdAt: () => GraphQLDate
   }),
 
   Section: () => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3047,10 +3047,6 @@ enzyme@^2.8.2:
     prop-types "^15.5.10"
     uuid "^3.0.1"
 
-eq-author-graphql-schema@ONSDigital/eq-author-graphql-schema#16132f5:
-  version "1.0.0"
-  resolved "https://codeload.github.com/ONSDigital/eq-author-graphql-schema/tar.gz/16132f5"
-
 eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#e5caa74:
   version "1.0.0"
   resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/e5caa74"
@@ -3059,7 +3055,6 @@ eq-author-mock-api@ONSdigital/eq-author-mock-api#4342f6a:
   version "1.0.0"
   resolved "https://codeload.github.com/ONSdigital/eq-author-mock-api/tar.gz/4342f6a13f02d804be4577a0304592786c3e43b7"
   dependencies:
-    eq-author-graphql-schema ONSDigital/eq-author-graphql-schema#16132f5
     graphql "^0.10.5"
     graphql-tag "^2.4.2"
     graphql-tools "^1.1.0"
@@ -3601,19 +3596,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.5, fbjs@^0.8.9:
-  version "0.8.14"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
-fbjs@^0.8.7:
+fbjs@^0.8.12, fbjs@^0.8.5, fbjs@^0.8.7, fbjs@^0.8.9:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.15.tgz#4f0695fdfcc16c37c0b07facec8cb4c4091685b9"
   dependencies:
@@ -4126,6 +4109,10 @@ graphql-config@^1.0.0:
     minimatch "^3.0.4"
     rimraf "^2.6.1"
 
+graphql-iso-date@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/graphql-iso-date/-/graphql-iso-date-3.3.0.tgz#cbe434b41e035e806338121b1b2b509a0f72bb80"
+
 graphql-request@^1.2.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.3.4.tgz#94d5f2e6644d9d9cbce0d06953e100c30e5cb633"
@@ -4136,7 +4123,7 @@ graphql-tag@^2.0.0, graphql-tag@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.4.2.tgz#6a63297d8522d03a2b72d26f1b239aab343840cd"
 
-graphql-tools@^1.1.0:
+graphql-tools@^1.1.0, graphql-tools@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-1.2.3.tgz#079bf4d157e46c0a0bae9fec117e0eea6e03ba2c"
   dependencies:


### PR DESCRIPTION
### What is the context of this PR?
Fixes an error when navigating to the admin page when running with the mockAPI.
The fix involved specifying a reducer for the scalar GraphQL Date type and ensuring that time values do not make it into the localStorage data store.

### How to review 
All tests and checks should pass.
Should no longer see the error on the admin page after creating a questionnaire when running with the mockAPI.
