### PR TITLE
Focus on new section when created

### DIFF
--- a/src/components/QuestionnaireNav/SectionNav.js
+++ b/src/components/QuestionnaireNav/SectionNav.js
@@ -1,11 +1,10 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
 import styled from "styled-components";
+
 import { TransitionGroup, CSSTransition } from "react-transition-group";
 import SectionNavItem from "./SectionNavItem";
-
-const duration = 200;
 
 const NavList = styled.ol`
   margin: 0;
@@ -13,38 +12,63 @@ const NavList = styled.ol`
   list-style: none;
 `;
 
-const SectionNav = ({
-  questionnaire,
-  onAddPage,
-  onDeleteSection,
-  onDeletePage
-}) => (
-  <TransitionGroup component={NavList}>
-    {questionnaire.sections
-      .map((section, i) => ({
-        ...section,
-        number: i + 1
-      }))
-      .map((section, sectionNum) => (
-        <CSSTransition key={section.id} timeout={duration} classNames="section">
-          <SectionNavItem
-            questionnaire={questionnaire}
-            section={section}
-            duration={duration}
-            onDeletePage={onDeletePage}
-            onDeleteSection={onDeleteSection}
-            onAddPage={onAddPage}
-          />
-        </CSSTransition>
-      ))}
-  </TransitionGroup>
-);
+const duration = 200;
 
-SectionNav.propTypes = {
-  questionnaire: CustomPropTypes.questionnaire,
-  onAddPage: PropTypes.func.isRequired,
-  onDeleteSection: PropTypes.func.isRequired,
-  onDeletePage: PropTypes.func.isRequired
-};
+class SectionNav extends Component {
+  sectionItems = [];
+
+  static propTypes = {
+    questionnaire: CustomPropTypes.questionnaire,
+    onAddPage: PropTypes.func.isRequired,
+    onDeleteSection: PropTypes.func.isRequired,
+    onDeletePage: PropTypes.func.isRequired
+  };
+
+  scrollSectionIntoView = id =>
+    this.sectionItems[id].scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+      inline: "start"
+    });
+
+  saveSectionItemRef = (id, node) => {
+    this.sectionItems[id] = node;
+  };
+
+  render() {
+    const {
+      questionnaire,
+      onAddPage,
+      onDeletePage,
+      onDeleteSection
+    } = this.props;
+    return (
+      <TransitionGroup component={NavList}>
+        {questionnaire.sections
+          .map((section, i) => ({
+            ...section,
+            number: i + 1
+          }))
+          .map((section, sectionNum) => (
+            <CSSTransition
+              key={section.id}
+              timeout={duration}
+              classNames="section"
+            >
+              <SectionNavItem
+                questionnaire={questionnaire}
+                section={section}
+                duration={duration}
+                onDeletePage={onDeletePage}
+                onDeleteSection={onDeleteSection}
+                onAddPage={onAddPage}
+                saveSectionItemRef={this.saveSectionItemRef}
+              />
+            </CSSTransition>
+          ))}
+      </TransitionGroup>
+    );
+  }
+}
 
 export default SectionNav;

--- a/src/components/QuestionnaireNav/SectionNav.test.js
+++ b/src/components/QuestionnaireNav/SectionNav.test.js
@@ -31,4 +31,16 @@ describe("SectionNav", () => {
   it("should render", () => {
     expect(wrapper).toMatchSnapshot();
   });
+
+  it("should call after a delay scrollSectionIntoView", () => {
+    const scrollIntoView = jest.fn();
+
+    wrapper.instance().saveSectionItemRef(section.id, { scrollIntoView });
+    wrapper.instance().scrollSectionIntoView(section.id);
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+      inline: "start"
+    });
+  });
 });

--- a/src/components/QuestionnaireNav/SectionNavItem.js
+++ b/src/components/QuestionnaireNav/SectionNavItem.js
@@ -1,43 +1,13 @@
 import React from "react";
 import styled from "styled-components";
-import { first } from "lodash";
-import { getLink } from "utils/UrlUtils";
-import { NavLink } from "react-router-dom";
+
 import { colors } from "constants/theme";
-import sectionIcon from "./icon-section.svg";
-import HoverDeleteButton from "./HoverDeleteButton";
+import HoverDeleteButton from "components/QuestionnaireNav/HoverDeleteButton";
 import PageNav from "components/QuestionnaireNav/PageNav";
+import SectionTitle from "components/QuestionnaireNav/SectionTitle";
 import Tooltip from "components/Tooltip";
 import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
-import getTextFromHTML from "utils/getTextFromHTML";
-
-const Link = styled(NavLink)`
-  text-decoration: none;
-  &:link,
-  &:visited {
-    color: ${colors.text};
-  }
-`;
-
-const SectionTitle = styled.h3`
-  padding: 0.5em 2.5em 0.5em 0;
-  font-size: 0.75em;
-  margin: 0;
-  font-weight: 900;
-  display: flex;
-  position: relative;
-  width: 100%;
-  display: inline-block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-
-  &:before {
-    content: url(${sectionIcon});
-    margin-right: 0.5em;
-  }
-`;
 
 export const AddPageBtn = styled.button`
   appearance: none;
@@ -62,37 +32,6 @@ export const SectionDeleteButton = styled(HoverDeleteButton)`
   }
 `;
 
-export const LinkedSectionTitle = ({ questionnaire, section }) => {
-  if (!section) {
-    return null;
-  }
-
-  const sectionTitle = (
-    <SectionTitle>
-      {getTextFromHTML(section.title) || "Section Title"}
-    </SectionTitle>
-  );
-  if (section.pages.length > 0) {
-    const firstPage = first(section.pages);
-    return (
-      <Link
-        to={getLink(questionnaire.id, section.id, firstPage.id)}
-        aria-disabled={parseInt(firstPage.id, 10) < 0}
-        activeClassName="selected"
-      >
-        {sectionTitle}
-      </Link>
-    );
-  } else {
-    return sectionTitle;
-  }
-};
-
-LinkedSectionTitle.propTypes = {
-  questionnaire: CustomPropTypes.questionnaire.isRequired,
-  section: CustomPropTypes.section.isRequired
-};
-
 const halfDuration = props => props.duration / 2;
 const duration = props => props.duration;
 
@@ -113,7 +52,6 @@ const StyledSectionNavItem = styled.li`
   &.section-enter-active {
     opacity: 1;
     transform: translateX(0);
-
     transition: opacity ${duration}ms ease-out, transform ${duration}ms ease-out;
   }
 
@@ -126,7 +64,6 @@ const StyledSectionNavItem = styled.li`
     opacity: 0;
     transform: translateX(-20px);
     height: 0 !important;
-
     transition: opacity ${halfDuration}ms ease-out,
       transform ${halfDuration}ms ease-out,
       height ${halfDuration}ms ease-in ${halfDuration}ms;
@@ -144,7 +81,8 @@ class SectionNavItem extends React.Component {
     onDeleteSection: PropTypes.func.isRequired,
     onDeletePage: PropTypes.func.isRequired,
     section: CustomPropTypes.section.isRequired,
-    duration: PropTypes.number.isRequired
+    duration: PropTypes.number.isRequired,
+    saveSectionItemRef: PropTypes.func.isRequired
   };
 
   state = {
@@ -165,7 +103,9 @@ class SectionNavItem extends React.Component {
   };
 
   saveRef = elem => {
+    const { section, saveSectionItemRef } = this.props;
     this.elem = elem;
+    saveSectionItemRef(section.id, elem);
   };
 
   render() {
@@ -178,7 +118,7 @@ class SectionNavItem extends React.Component {
         duration={duration}
       >
         <div className="section-title-wrapper">
-          <LinkedSectionTitle questionnaire={questionnaire} section={section} />
+          <SectionTitle questionnaire={questionnaire} section={section} />
           <Tooltip content="Delete section" offset={{ right: -5 }}>
             <SectionDeleteButton
               type="button"

--- a/src/components/QuestionnaireNav/SectionNavItem.test.js
+++ b/src/components/QuestionnaireNav/SectionNavItem.test.js
@@ -2,14 +2,16 @@ import { shallow } from "enzyme";
 import PageNav from "./PageNav";
 import SectionNavItem, {
   AddPageBtn,
-  SectionDeleteButton,
-  LinkedSectionTitle
+  SectionDeleteButton
 } from "./SectionNavItem";
 import React from "react";
 
 describe("SectionNavItem", () => {
-  let wrapper;
-  let handleAddPage, handleDeleteSection, handleDeletePage;
+  let wrapper,
+    handleAddPage,
+    handleDeleteSection,
+    handleDeletePage,
+    saveSectionItemRef;
 
   const page = { id: "2", title: "Page" };
   const section = { id: "3", title: "Section", pages: [page] };
@@ -20,9 +22,10 @@ describe("SectionNavItem", () => {
   };
 
   beforeEach(() => {
-    handleAddPage = jest.fn();
+    handleAddPage = jest.fn(() => Promise.resolve);
     handleDeleteSection = jest.fn();
     handleDeletePage = jest.fn();
+    saveSectionItemRef = jest.fn();
 
     wrapper = shallow(
       <SectionNavItem
@@ -31,6 +34,7 @@ describe("SectionNavItem", () => {
         onAddPage={handleAddPage}
         onDeleteSection={handleDeleteSection}
         onDeletePage={handleDeletePage}
+        saveSectionItemRef={saveSectionItemRef}
         duration={123}
       />
     );
@@ -62,22 +66,9 @@ describe("SectionNavItem", () => {
     expect(handleDeletePage).toHaveBeenCalled();
   });
 
-  describe("LinkedSectionTitle", () => {
-    it("should render link when section has pages", () => {
-      const result = shallow(
-        <LinkedSectionTitle questionnaire={questionnaire} section={section} />
-      );
-
-      expect(result).toMatchSnapshot();
-    });
-
-    it("should render without link when section has no pages", () => {
-      section.pages = [];
-      const result = shallow(
-        <LinkedSectionTitle questionnaire={questionnaire} section={section} />
-      );
-
-      expect(result).toMatchSnapshot();
-    });
+  it("saveSectionItemRef", () => {
+    const elem = shallow(<div />);
+    wrapper.instance().saveRef(elem);
+    expect(saveSectionItemRef).toHaveBeenCalledWith(section.id, elem);
   });
 });

--- a/src/components/QuestionnaireNav/SectionTitle.js
+++ b/src/components/QuestionnaireNav/SectionTitle.js
@@ -1,0 +1,69 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { first } from "lodash";
+import styled from "styled-components";
+
+import { getLink } from "utils/UrlUtils";
+import { colors } from "constants/theme";
+
+import sectionIcon from "./icon-section.svg";
+import getTextFromHTML from "utils/getTextFromHTML";
+
+import CustomPropTypes from "custom-prop-types";
+const Link = styled(NavLink)`
+  text-decoration: none;
+  &:link,
+  &:visited {
+    color: ${colors.text};
+  }
+`;
+
+const Title = styled.h3`
+  padding: 0.5em 2.5em 0.5em 0;
+  font-size: 0.75em;
+  margin: 0;
+  font-weight: 900;
+  display: flex;
+  position: relative;
+  width: 100%;
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:before {
+    content: url(${sectionIcon});
+    margin-right: 0.5em;
+  }
+`;
+
+const SectionTitle = ({ questionnaire, section }) => {
+  if (!section) {
+    return null;
+  }
+
+  const sectionTitle = (
+    <Title>{getTextFromHTML(section.title) || "Section Title"}</Title>
+  );
+
+  if (section.pages.length === 0) {
+    return sectionTitle;
+  }
+
+  const firstPage = first(section.pages);
+  return (
+    <Link
+      to={getLink(questionnaire.id, section.id, firstPage.id)}
+      activeClassName="selected"
+    >
+      {sectionTitle}
+    </Link>
+  );
+};
+
+SectionTitle.propTypes = {
+  questionnaire: CustomPropTypes.questionnaire.isRequired,
+  section: CustomPropTypes.section.isRequired
+};
+
+export default SectionTitle;

--- a/src/components/QuestionnaireNav/SectionTitle.test.js
+++ b/src/components/QuestionnaireNav/SectionTitle.test.js
@@ -1,0 +1,39 @@
+import { shallow } from "enzyme";
+
+import SectionTitle from "./SectionTitle";
+import React from "react";
+
+describe("SectionNavItem", () => {
+  let wrapper;
+
+  const page = { id: "2", title: "Page" };
+  const section = { id: "3", title: "Section", pages: [page] };
+  const questionnaire = {
+    id: "1",
+    title: "Questionnaire",
+    sections: [section]
+  };
+
+  it("should render", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe("SectionTitle", () => {
+    it("should render link when section has pages", () => {
+      const result = shallow(
+        <SectionTitle questionnaire={questionnaire} section={section} />
+      );
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it("should render without link when section has no pages", () => {
+      section.pages = [];
+      const result = shallow(
+        <SectionTitle questionnaire={questionnaire} section={section} />
+      );
+
+      expect(result).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/QuestionnaireNav/__snapshots__/SectionNav.test.js.snap
+++ b/src/components/QuestionnaireNav/__snapshots__/SectionNav.test.js.snap
@@ -32,6 +32,7 @@ exports[`SectionNav should render 1`] = `
           "title": "Questionnaire",
         }
       }
+      saveSectionItemRef={[Function]}
       section={
         Object {
           "id": "3",

--- a/src/components/QuestionnaireNav/__snapshots__/SectionNavItem.test.js.snap
+++ b/src/components/QuestionnaireNav/__snapshots__/SectionNavItem.test.js.snap
@@ -1,23 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SectionNavItem LinkedSectionTitle should render link when section has pages 1`] = `
-<SectionNavItem__Link
-  activeClassName="selected"
-  aria-disabled={false}
-  to="/questionnaire/1/design/3/2"
->
-  <SectionNavItem__SectionTitle>
-    Section
-  </SectionNavItem__SectionTitle>
-</SectionNavItem__Link>
-`;
-
-exports[`SectionNavItem LinkedSectionTitle should render without link when section has no pages 1`] = `
-<SectionNavItem__SectionTitle>
-  Section
-</SectionNavItem__SectionTitle>
-`;
-
 exports[`SectionNavItem should render 1`] = `
 <SectionNavItem__StyledSectionNavItem
   duration={123}
@@ -27,7 +9,7 @@ exports[`SectionNavItem should render 1`] = `
   <div
     className="section-title-wrapper"
   >
-    <LinkedSectionTitle
+    <SectionTitle
       questionnaire={
         Object {
           "id": "1",

--- a/src/components/QuestionnaireNav/__snapshots__/SectionTitle.test.js.snap
+++ b/src/components/QuestionnaireNav/__snapshots__/SectionTitle.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SectionNavItem SectionTitle should render link when section has pages 1`] = `
+<SectionTitle__Link
+  activeClassName="selected"
+  to="/questionnaire/1/design/3/2"
+>
+  <SectionTitle__Title>
+    Section
+  </SectionTitle__Title>
+</SectionTitle__Link>
+`;
+
+exports[`SectionNavItem SectionTitle should render without link when section has no pages 1`] = `
+<SectionTitle__Title>
+  Section
+</SectionTitle__Title>
+`;
+
+exports[`SectionNavItem should render 1`] = `undefined`;

--- a/src/components/QuestionnaireNav/__snapshots__/index.test.js.snap
+++ b/src/components/QuestionnaireNav/__snapshots__/index.test.js.snap
@@ -1,30 +1,823 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`QuestionnaireNav should render 1`] = `
-<QuestionnaireNav__Container
-  id="questionnaire-nav"
->
-  <QuestionnaireNav__Title>
-    Questionnaire structure
-  </QuestionnaireNav__Title>
-  <SectionNav
-    onAddPage={[Function]}
-    onDeletePage={[Function]}
-    onDeleteSection={[Function]}
-    questionnaire={
-      Object {
-        "id": "1",
-      }
+.c8 {
+  color: #4A4A4A;
+  border: none;
+  background: transparent;
+  font-size: 1.25em;
+  padding: 0.125em 0.625em 0.125em 0.375em;
+  position: absolute;
+  right: 0;
+  z-index: 3;
+  cursor: pointer;
+  -webkit-transform: translateX(50%);
+  -ms-transform: translateX(50%);
+  transform: translateX(50%);
+  opacity: 0;
+  -webkit-transition: -webkit-transform 0.1s ease-in,opacity 0.1s ease-in;
+  -webkit-transition: transform 0.1s ease-in,opacity 0.1s ease-in;
+  transition: transform 0.1s ease-in,opacity 0.1s ease-in;
+}
+
+.c9 {
+  background-color: rgba(97,97,97,0.9) !important;
+  font-size: 0.625rem !important;
+  line-height: 2.2em !important;
+  padding: 0 0.6em !important;
+  border-radius: 2px !important;
+  white-space: pre;
+}
+
+.c9::before,
+.c9::after {
+  border-bottom: none !important;
+  border-top: none !important;
+}
+
+.c12 {
+  padding: 0;
+  margin: 0;
+  font-weight: 500;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  z-index: 1;
+  position: relative;
+}
+
+.c12.page-enter,
+.c12.page-exit.page-exit-active {
+  opacity: 0;
+  height: 0;
+  -webkit-transform: translateX(-20px);
+  -ms-transform: translateX(-20px);
+  transform: translateX(-20px);
+}
+
+.c12.page-exit,
+.c12.page-enter.page-enter-active {
+  opacity: 1;
+  height: 2em;
+  -webkit-transform: translateX(0);
+  -ms-transform: translateX(0);
+  transform: translateX(0);
+}
+
+.c12.page-enter-active {
+  -webkit-transition: height 150ms ease-out,opacity 150ms ease-out 150ms,-webkit-transform 150ms ease-out 150ms;
+  -webkit-transition: height 150ms ease-out,opacity 150ms ease-out 150ms,transform 150ms ease-out 150ms;
+  transition: height 150ms ease-out,opacity 150ms ease-out 150ms,transform 150ms ease-out 150ms;
+}
+
+.c12.page-exit-active {
+  -webkit-transition: opacity 150ms ease-out,-webkit-transform 150ms ease-out,height 150ms ease-out 150ms;
+  -webkit-transition: opacity 150ms ease-out,transform 150ms ease-out,height 150ms ease-out 150ms;
+  transition: opacity 150ms ease-out,transform 150ms ease-out,height 150ms ease-out 150ms;
+}
+
+.c14 {
+  text-decoration: none;
+  color: #4A4A4A;
+  font-size: 0.75em;
+  padding: 0.7em 2.5em 0.7em 0.9em;
+  display: block;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+  -webkit-transition: opacity 100ms ease-out;
+  transition: opacity 100ms ease-out;
+}
+
+.c14::before {
+  opacity: 0;
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  -webkit-transition: all 200ms ease-out;
+  transition: all 200ms ease-out;
+  background: #EAEAEA;
+  z-index: 1;
+}
+
+.c11:hover .c14::before {
+  opacity: 0.5;
+  width: 100%;
+}
+
+.c14.selected::before {
+  opacity: 1 !important;
+  width: 100%;
+}
+
+.c14[aria-disabled="true"] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.c15 {
+  display: inline-block;
+  width: 100%;
+  position: relative;
+  z-index: 2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 1;
+}
+
+.c10 {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.c16 {
+  top: 0.1em;
+}
+
+.c11:hover .c16,
+.c13:focus + .c16,
+.c16:focus {
+  opacity: 1;
+  -webkit-transform: translateX(0);
+  -ms-transform: translateX(0);
+  transform: translateX(0);
+}
+
+.c5 {
+  text-decoration: none;
+}
+
+.c5:link,
+.c5:visited {
+  color: #4A4A4A;
+}
+
+.c6 {
+  padding: 0.5em 2.5em 0.5em 0;
+  font-size: 0.75em;
+  margin: 0;
+  font-weight: 900;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  width: 100%;
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.c6:before {
+  content: url(icon-section.svg);
+  margin-right: 0.5em;
+}
+
+.c17 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 1em;
+  color: #4A4A4A;
+}
+
+.c17:hover {
+  color: black;
+}
+
+.c7 {
+  top: 0.5em;
+}
+
+.c4:hover .c7,
+.c4:focus + .c7,
+.c7:focus {
+  opacity: 1;
+  -webkit-transform: translateX(0);
+  -ms-transform: translateX(0);
+  transform: translateX(0);
+}
+
+.c3 {
+  margin: 0;
+  padding: 0.5em 0;
+  position: relative;
+}
+
+.c3:not(:last-child) {
+  border-bottom: 1px solid #c3c3c3;
+}
+
+.c3.section-enter {
+  opacity: 0;
+  -webkit-transform: translateX(-20px);
+  -ms-transform: translateX(-20px);
+  transform: translateX(-20px);
+}
+
+.c3.section-enter-active {
+  opacity: 1;
+  -webkit-transform: translateX(0);
+  -ms-transform: translateX(0);
+  transform: translateX(0);
+  -webkit-transition: opacity 200ms ease-out,-webkit-transform 200ms ease-out;
+  -webkit-transition: opacity 200ms ease-out,transform 200ms ease-out;
+  transition: opacity 200ms ease-out,transform 200ms ease-out;
+}
+
+.c3.section-exit {
+  opacity: 1;
+  -webkit-transform: translateX(0);
+  -ms-transform: translateX(0);
+  transform: translateX(0);
+}
+
+.c3.section-exit-active {
+  opacity: 0;
+  -webkit-transform: translateX(-20px);
+  -ms-transform: translateX(-20px);
+  transform: translateX(-20px);
+  height: 0 !important;
+  -webkit-transition: opacity 100ms ease-out,-webkit-transform 100ms ease-out,height 100ms ease-in 100ms;
+  -webkit-transition: opacity 100ms ease-out,transform 100ms ease-out,height 100ms ease-in 100ms;
+  transition: opacity 100ms ease-out,transform 100ms ease-out,height 100ms ease-in 100ms;
+}
+
+.c2 {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.c0 {
+  padding: 1em;
+  margin: 0;
+}
+
+.c1 {
+  font-size: 0.6em;
+  text-transform: uppercase;
+  font-weight: 900;
+  margin: 0;
+  line-height: 1.5;
+  position: relative;
+}
+
+.c18 {
+  border-top: 1px solid #c3c3c3;
+  padding: 1em 0;
+  position: sticky;
+  z-index: 99999;
+  bottom: 0;
+  left: 0;
+  background: #f5f5f5;
+}
+
+.c19 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  color: #4A4A4A;
+  font-weight: 600;
+  font-size: 0.75em;
+}
+
+.c19::before {
+  vertical-align: middle;
+  display: inline-block;
+  content: url(icon-plus.svg);
+  margin-right: 0.6em;
+}
+
+.c19:hover {
+  color: black;
+}
+
+<QuestionnaireNav
+  onAddPage={[Function]}
+  onAddSection={[Function]}
+  onDeletePage={[Function]}
+  onDeleteSection={[Function]}
+  questionnaire={
+    Object {
+      "id": "1",
+      "sections": Array [
+        Object {
+          "id": "3",
+          "pages": Array [
+            Object {
+              "id": "2",
+              "title": "Page",
+            },
+          ],
+          "title": "Section",
+        },
+      ],
+      "title": "Questionnaire",
     }
-    transitionDuration={200}
-  />
-  <QuestionnaireNav__AddSection>
-    <QuestionnaireNav__AddSectionBtn
-      onClick={[Function]}
-      primary={true}
+  }
+>
+  <QuestionnaireNav__Container
+    id="questionnaire-nav"
+  >
+    <div
+      className="c0"
+      id="questionnaire-nav"
     >
-      Create new section
-    </QuestionnaireNav__AddSectionBtn>
-  </QuestionnaireNav__AddSection>
-</QuestionnaireNav__Container>
+      <QuestionnaireNav__Title>
+        <h2
+          className="c1"
+        >
+          Questionnaire structure
+        </h2>
+      </QuestionnaireNav__Title>
+      <SectionNav
+        onAddPage={[Function]}
+        onDeletePage={[Function]}
+        onDeleteSection={[Function]}
+        questionnaire={
+          Object {
+            "id": "1",
+            "sections": Array [
+              Object {
+                "id": "3",
+                "pages": Array [
+                  Object {
+                    "id": "2",
+                    "title": "Page",
+                  },
+                ],
+                "title": "Section",
+              },
+            ],
+            "title": "Questionnaire",
+          }
+        }
+        transitionDuration={200}
+      >
+        <TransitionGroup
+          childFactory={[Function]}
+          component={[Function]}
+        >
+          <SectionNav__NavList>
+            <ol
+              className="c2"
+            >
+              <CSSTransition
+                classNames="section"
+                in={true}
+                onExited={[Function]}
+                timeout={200}
+              >
+                <Transition
+                  appear={false}
+                  enter={true}
+                  exit={true}
+                  in={true}
+                  mountOnEnter={false}
+                  onEnter={[Function]}
+                  onEntered={[Function]}
+                  onEntering={[Function]}
+                  onExit={[Function]}
+                  onExited={[Function]}
+                  onExiting={[Function]}
+                  timeout={200}
+                  unmountOnExit={false}
+                >
+                  <SectionNavItem
+                    duration={200}
+                    onAddPage={[Function]}
+                    onDeletePage={[Function]}
+                    onDeleteSection={[Function]}
+                    questionnaire={
+                      Object {
+                        "id": "1",
+                        "sections": Array [
+                          Object {
+                            "id": "3",
+                            "pages": Array [
+                              Object {
+                                "id": "2",
+                                "title": "Page",
+                              },
+                            ],
+                            "title": "Section",
+                          },
+                        ],
+                        "title": "Questionnaire",
+                      }
+                    }
+                    saveSectionItemRef={[Function]}
+                    section={
+                      Object {
+                        "id": "3",
+                        "number": 1,
+                        "pages": Array [
+                          Object {
+                            "id": "2",
+                            "title": "Page",
+                          },
+                        ],
+                        "title": "Section",
+                      }
+                    }
+                  >
+                    <SectionNavItem__StyledSectionNavItem
+                      duration={200}
+                      innerRef={[Function]}
+                      style={Object {}}
+                    >
+                      <li
+                        className="c3"
+                        style={Object {}}
+                      >
+                        <div
+                          className="c4"
+                        >
+                          <SectionTitle
+                            questionnaire={
+                              Object {
+                                "id": "1",
+                                "sections": Array [
+                                  Object {
+                                    "id": "3",
+                                    "pages": Array [
+                                      Object {
+                                        "id": "2",
+                                        "title": "Page",
+                                      },
+                                    ],
+                                    "title": "Section",
+                                  },
+                                ],
+                                "title": "Questionnaire",
+                              }
+                            }
+                            section={
+                              Object {
+                                "id": "3",
+                                "number": 1,
+                                "pages": Array [
+                                  Object {
+                                    "id": "2",
+                                    "title": "Page",
+                                  },
+                                ],
+                                "title": "Section",
+                              }
+                            }
+                          >
+                            <SectionTitle__Link
+                              activeClassName="selected"
+                              to="/questionnaire/1/design/3/2"
+                            >
+                              <NavLink
+                                activeClassName="selected"
+                                className="c5"
+                                to="/questionnaire/1/design/3/2"
+                              >
+                                <Route
+                                  path="/questionnaire/1/design/3/2"
+                                >
+                                  <Link
+                                    className="c5"
+                                    replace={false}
+                                    to="/questionnaire/1/design/3/2"
+                                  >
+                                    <a
+                                      className="c5"
+                                      href="/questionnaire/1/design/3/2"
+                                      onClick={[Function]}
+                                    >
+                                      <SectionTitle__Title>
+                                        <h3
+                                          className="c6"
+                                        >
+                                          Section
+                                        </h3>
+                                      </SectionTitle__Title>
+                                    </a>
+                                  </Link>
+                                </Route>
+                              </NavLink>
+                            </SectionTitle__Link>
+                          </SectionTitle>
+                          <Tooltip
+                            content="Delete section"
+                            offset={
+                              Object {
+                                "right": -5,
+                              }
+                            }
+                          >
+                            <div>
+                              <SectionNavItem__SectionDeleteButton
+                                aria-label="Delete section"
+                                data-for="tooltip-1"
+                                data-tip={true}
+                                onClick={[Function]}
+                                type="button"
+                              >
+                                <HoverDeleteButton__HoverDeleteButton
+                                  aria-label="Delete section"
+                                  className="c7"
+                                  data-for="tooltip-1"
+                                  data-tip={true}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <button
+                                    aria-label="Delete section"
+                                    className="c7 c8"
+                                    data-for="tooltip-1"
+                                    data-tip={true}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    ×
+                                  </button>
+                                </HoverDeleteButton__HoverDeleteButton>
+                              </SectionNavItem__SectionDeleteButton>
+                              <Tooltip__StyledTooltip
+                                delayShow={200}
+                                effect="solid"
+                                id="tooltip-1"
+                                offset={
+                                  Object {
+                                    "right": -5,
+                                  }
+                                }
+                                place="bottom"
+                              >
+                                <ReactTooltip
+                                  className="c9"
+                                  delayShow={200}
+                                  effect="solid"
+                                  id="tooltip-1"
+                                  insecure={true}
+                                  offset={
+                                    Object {
+                                      "right": -5,
+                                    }
+                                  }
+                                  place="bottom"
+                                  resizeHide={true}
+                                  wrapper="div"
+                                >
+                                  <div
+                                    className="__react_component_tooltip place-top type-dark "
+                                    data-id="tooltip"
+                                  />
+                                </ReactTooltip>
+                              </Tooltip__StyledTooltip>
+                            </div>
+                          </Tooltip>
+                        </div>
+                        <PageNav
+                          onDelete={[Function]}
+                          questionnaire={
+                            Object {
+                              "id": "1",
+                              "sections": Array [
+                                Object {
+                                  "id": "3",
+                                  "pages": Array [
+                                    Object {
+                                      "id": "2",
+                                      "title": "Page",
+                                    },
+                                  ],
+                                  "title": "Section",
+                                },
+                              ],
+                              "title": "Questionnaire",
+                            }
+                          }
+                          section={
+                            Object {
+                              "id": "3",
+                              "number": 1,
+                              "pages": Array [
+                                Object {
+                                  "id": "2",
+                                  "title": "Page",
+                                },
+                              ],
+                              "title": "Section",
+                            }
+                          }
+                        >
+                          <TransitionGroup
+                            childFactory={[Function]}
+                            component={[Function]}
+                          >
+                            <PageNav__NavList>
+                              <ol
+                                className="c10"
+                              >
+                                <CSSTransition
+                                  classNames="page"
+                                  in={true}
+                                  onExited={[Function]}
+                                  timeout={300}
+                                >
+                                  <Transition
+                                    appear={false}
+                                    enter={true}
+                                    exit={true}
+                                    in={true}
+                                    mountOnEnter={false}
+                                    onEnter={[Function]}
+                                    onEntered={[Function]}
+                                    onEntering={[Function]}
+                                    onExit={[Function]}
+                                    onExited={[Function]}
+                                    onExiting={[Function]}
+                                    timeout={300}
+                                    unmountOnExit={false}
+                                  >
+                                    <PageNavItem
+                                      index={1}
+                                      onDelete={[Function]}
+                                      pageId="2"
+                                      pageNumber="1.1"
+                                      questionnaireId="1"
+                                      sectionId="3"
+                                      title="Page"
+                                    >
+                                      <PageNav__StyledPageItem
+                                        index={1}
+                                      >
+                                        <li
+                                          className="c11 c12"
+                                        >
+                                          <PageNav__Link
+                                            activeClassName="selected"
+                                            aria-disabled={false}
+                                            to="/questionnaire/1/design/3/2"
+                                          >
+                                            <NavLink
+                                              activeClassName="selected"
+                                              aria-disabled={false}
+                                              className="c13 c14"
+                                              to="/questionnaire/1/design/3/2"
+                                            >
+                                              <Route
+                                                path="/questionnaire/1/design/3/2"
+                                              >
+                                                <Link
+                                                  aria-disabled={false}
+                                                  className="c13 c14"
+                                                  replace={false}
+                                                  to="/questionnaire/1/design/3/2"
+                                                >
+                                                  <a
+                                                    aria-disabled={false}
+                                                    className="c13 c14"
+                                                    href="/questionnaire/1/design/3/2"
+                                                    onClick={[Function]}
+                                                  >
+                                                    <PageNav__LinkText
+                                                      fade={false}
+                                                    >
+                                                      <span
+                                                        className="c15"
+                                                      >
+                                                        1.1
+                                                         
+                                                        Page
+                                                      </span>
+                                                    </PageNav__LinkText>
+                                                  </a>
+                                                </Link>
+                                              </Route>
+                                            </NavLink>
+                                          </PageNav__Link>
+                                          <Tooltip
+                                            content="Delete page"
+                                          >
+                                            <div>
+                                              <PageNav__DeleteButton
+                                                aria-label="Delete page"
+                                                data-for="tooltip-2"
+                                                data-tip={true}
+                                                onClick={[Function]}
+                                                type="button"
+                                              >
+                                                <HoverDeleteButton__HoverDeleteButton
+                                                  aria-label="Delete page"
+                                                  className="c16"
+                                                  data-for="tooltip-2"
+                                                  data-tip={true}
+                                                  onClick={[Function]}
+                                                  type="button"
+                                                >
+                                                  <button
+                                                    aria-label="Delete page"
+                                                    className="c16 c8"
+                                                    data-for="tooltip-2"
+                                                    data-tip={true}
+                                                    onClick={[Function]}
+                                                    type="button"
+                                                  >
+                                                    ×
+                                                  </button>
+                                                </HoverDeleteButton__HoverDeleteButton>
+                                              </PageNav__DeleteButton>
+                                              <Tooltip__StyledTooltip
+                                                delayShow={200}
+                                                effect="solid"
+                                                id="tooltip-2"
+                                                place="bottom"
+                                              >
+                                                <ReactTooltip
+                                                  className="c9"
+                                                  delayShow={200}
+                                                  effect="solid"
+                                                  id="tooltip-2"
+                                                  insecure={true}
+                                                  place="bottom"
+                                                  resizeHide={true}
+                                                  wrapper="div"
+                                                >
+                                                  <div
+                                                    className="__react_component_tooltip place-top type-dark "
+                                                    data-id="tooltip"
+                                                  />
+                                                </ReactTooltip>
+                                              </Tooltip__StyledTooltip>
+                                            </div>
+                                          </Tooltip>
+                                        </li>
+                                      </PageNav__StyledPageItem>
+                                    </PageNavItem>
+                                  </Transition>
+                                </CSSTransition>
+                              </ol>
+                            </PageNav__NavList>
+                          </TransitionGroup>
+                        </PageNav>
+                        <SectionNavItem__AddPageBtn
+                          id="btn-add-page"
+                          onClick={[Function]}
+                        >
+                          <button
+                            className="c17"
+                            id="btn-add-page"
+                            onClick={[Function]}
+                          >
+                            + Add page
+                          </button>
+                        </SectionNavItem__AddPageBtn>
+                      </li>
+                    </SectionNavItem__StyledSectionNavItem>
+                  </SectionNavItem>
+                </Transition>
+              </CSSTransition>
+            </ol>
+          </SectionNav__NavList>
+        </TransitionGroup>
+      </SectionNav>
+      <QuestionnaireNav__AddSection>
+        <div
+          className="c18"
+        >
+          <QuestionnaireNav__AddSectionBtn
+            onClick={[Function]}
+            primary={true}
+          >
+            <button
+              className="c19"
+              onClick={[Function]}
+            >
+              Create new section
+            </button>
+          </QuestionnaireNav__AddSectionBtn>
+        </div>
+      </QuestionnaireNav__AddSection>
+    </div>
+  </QuestionnaireNav__Container>
+</QuestionnaireNav>
 `;

--- a/src/components/QuestionnaireNav/index.js
+++ b/src/components/QuestionnaireNav/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 
 import styled from "styled-components";
 
@@ -29,6 +29,7 @@ const AddSection = styled.div`
   border-top: 1px solid #c3c3c3;
   padding: 1em 0;
   position: sticky;
+  z-index: 99999;
   bottom: 0;
   left: 0;
   background: ${colors.lighterGrey};
@@ -55,40 +56,55 @@ export const AddSectionBtn = styled.button`
   }
 `;
 
-const QuestionnaireNav = ({
-  questionnaire,
-  onAddPage,
-  onAddSection,
-  onDeleteSection,
-  onDeletePage
-}) => (
-  <Container id="questionnaire-nav">
-    <Title>Questionnaire structure</Title>
-    <SectionNav
-      transitionDuration={200}
-      questionnaire={questionnaire}
-      onAddPage={onAddPage}
-      onDeleteSection={onDeleteSection}
-      onDeletePage={onDeletePage}
-    />
-    <AddSection>
-      <AddSectionBtn
-        primary
-        onClick={function() {
-          onAddSection(questionnaire.id);
-        }}
-      >
-        Create new section
-      </AddSectionBtn>
-    </AddSection>
-  </Container>
-);
+class QuestionnaireNav extends Component {
+  static propTypes = {
+    questionnaire: CustomPropTypes.questionnaire.isRequired,
+    onAddPage: PropTypes.func.isRequired,
+    onDeletePage: PropTypes.func.isRequired,
+    onAddSection: PropTypes.func.isRequired,
+    onDeleteSection: PropTypes.func.isRequired
+  };
 
-QuestionnaireNav.propTypes = {
-  questionnaire: CustomPropTypes.questionnaire.isRequired,
-  onAddPage: PropTypes.func.isRequired,
-  onDeleteSection: PropTypes.func.isRequired,
-  onDeletePage: PropTypes.func.isRequired,
-  onAddSection: PropTypes.func.isRequired
-};
+  saveSectionNavRef = sectionNav => {
+    this.sectionNav = sectionNav;
+  };
+
+  handleAddSectionClick = () => {
+    const { questionnaire, onAddSection } = this.props;
+    onAddSection(questionnaire.id).then(({ id }) =>
+      this.sectionNav.scrollSectionIntoView(id)
+    );
+  };
+
+  handleAddPage = sectionId => {
+    const { onAddPage } = this.props;
+    onAddPage(sectionId).then(({ section }) =>
+      this.sectionNav.scrollSectionIntoView(section.id)
+    );
+  };
+
+  render() {
+    const { questionnaire, onDeletePage, onDeleteSection } = this.props;
+
+    return (
+      <Container id="questionnaire-nav">
+        <Title>Questionnaire structure</Title>
+        <SectionNav
+          transitionDuration={200}
+          questionnaire={questionnaire}
+          onAddPage={this.handleAddPage}
+          onDeletePage={onDeletePage}
+          onDeleteSection={onDeleteSection}
+          ref={this.saveSectionNavRef}
+        />
+        <AddSection>
+          <AddSectionBtn primary onClick={this.handleAddSectionClick}>
+            Create new section
+          </AddSectionBtn>
+        </AddSection>
+      </Container>
+    );
+  }
+}
+
 export default QuestionnaireNav;

--- a/src/components/QuestionnaireNav/index.test.js
+++ b/src/components/QuestionnaireNav/index.test.js
@@ -1,17 +1,42 @@
 import React from "react";
-import { shallow } from "enzyme";
+import mountWithRouter from "tests/utils/mountWithRouter";
 import QuestionnaireNav, { AddSectionBtn } from "components/QuestionnaireNav";
 
 describe("QuestionnaireNav", () => {
-  let wrapper;
-  const questionnaire = { id: "1" };
-  const handleAddSection = jest.fn();
-  const handleAddPage = jest.fn();
-  const handleDeleteSection = jest.fn();
-  const handleDeletePage = jest.fn();
+  let wrapper,
+    handleAddSection,
+    handleAddPage,
+    handleDeleteSection,
+    handleDeletePage,
+    sectionNav;
+
+  const page = { id: "2", title: "Page" };
+  const section = { id: "3", title: "Section", pages: [page] };
+  const questionnaire = {
+    id: "1",
+    title: "Questionnaire",
+    sections: [section]
+  };
 
   beforeEach(() => {
-    wrapper = shallow(
+    const fakeResolvedPromise = args => {
+      return {
+        then(fn) {
+          fn(args);
+          return fakeResolvedPromise();
+        },
+        catch() {
+          return fakeResolvedPromise();
+        }
+      };
+    };
+    handleAddSection = jest.fn(() => fakeResolvedPromise(questionnaire));
+    handleAddPage = jest.fn(() => fakeResolvedPromise({ section }));
+    handleDeleteSection = jest.fn();
+    handleDeletePage = jest.fn();
+    sectionNav = { scrollSectionIntoView: jest.fn() };
+
+    wrapper = mountWithRouter(
       <QuestionnaireNav
         questionnaire={questionnaire}
         onAddPage={handleAddPage}
@@ -20,14 +45,29 @@ describe("QuestionnaireNav", () => {
         onDeletePage={handleDeletePage}
       />
     );
+
+    wrapper.instance().saveSectionNavRef(sectionNav);
   });
 
   it("should render", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it("should store a reference to the SectionNav instance", () => {
+    expect(wrapper.instance().sectionNav).toEqual(sectionNav);
+  });
+
   it("should handle clicks on `create a new section`", () => {
     wrapper.find(AddSectionBtn).simulate("click");
     expect(handleAddSection).toHaveBeenCalledWith(questionnaire.id);
+    expect(sectionNav.scrollSectionIntoView).toHaveBeenCalledWith(
+      questionnaire.id
+    );
+  });
+
+  it("should ", () => {
+    wrapper.instance().handleAddPage(section.id);
+    expect(handleAddPage).toHaveBeenCalledWith(section.id);
+    expect(sectionNav.scrollSectionIntoView).toHaveBeenCalledWith(section.id);
   });
 });

--- a/src/containers/enhancers/withCreatePage.js
+++ b/src/containers/enhancers/withCreatePage.js
@@ -35,7 +35,10 @@ export const mapMutateToProps = ({ ownProps, mutate }) => ({
     return mutate({
       variables: { input: page },
       update
-    }).then(redirectToNewPage(ownProps));
+    }).then(result => {
+      redirectToNewPage(ownProps)(result);
+      return result.data.createQuestionPage;
+    });
   }
 });
 

--- a/src/containers/enhancers/withCreatePage.test.js
+++ b/src/containers/enhancers/withCreatePage.test.js
@@ -90,8 +90,9 @@ describe("containers/QuestionnaireDesignPage/withCreatePage", () => {
       expect(props.onAddPage).toBeInstanceOf(Function);
     });
 
-    it("should redirect", () => {
-      return props.onAddPage(section.id).then(() => {
+    it("should redirect and return the new page", () => {
+      return props.onAddPage(section.id).then(result => {
+        expect(result).toEqual(newPage);
         expect(history.push).toHaveBeenCalled();
       });
     });

--- a/src/containers/enhancers/withCreateSection.js
+++ b/src/containers/enhancers/withCreateSection.js
@@ -37,7 +37,10 @@ export const mapMutateToProps = ({ mutate, ownProps }) => ({
     return mutate({
       variables: { input: section },
       update
-    }).then(redirectToNewPage(ownProps));
+    }).then(res => {
+      redirectToNewPage(ownProps)(res);
+      return res.data.createSection;
+    });
   }
 });
 

--- a/src/containers/enhancers/withCreateSection.test.js
+++ b/src/containers/enhancers/withCreateSection.test.js
@@ -85,7 +85,8 @@ describe("containers/QuestionnaireDesignPage/withCreateSection", () => {
     });
 
     it("should redirect", () => {
-      return props.onAddSection().then(() => {
+      return props.onAddSection().then(result => {
+        expect(result).toEqual(newSection);
         expect(history.push).toHaveBeenCalled();
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3051,14 +3051,19 @@ enzyme@^2.8.2:
     prop-types "^15.5.10"
     uuid "^3.0.1"
 
+eq-author-graphql-schema@ONSDigital/eq-author-graphql-schema#16132f5:
+  version "1.0.0"
+  resolved "https://codeload.github.com/ONSDigital/eq-author-graphql-schema/tar.gz/16132f502fbe84737554b456ae944af4f3cb523c"
+
 eq-author-graphql-schema@ONSdigital/eq-author-graphql-schema#e5caa74:
   version "1.0.0"
-  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/e5caa74"
+  resolved "https://codeload.github.com/ONSdigital/eq-author-graphql-schema/tar.gz/e5caa744b1fe0962c21b19448531e64a42174b01"
 
 eq-author-mock-api@ONSdigital/eq-author-mock-api#4342f6a:
   version "1.0.0"
   resolved "https://codeload.github.com/ONSdigital/eq-author-mock-api/tar.gz/4342f6a13f02d804be4577a0304592786c3e43b7"
   dependencies:
+    eq-author-graphql-schema ONSDigital/eq-author-graphql-schema#16132f5
     graphql "^0.10.5"
     graphql-tag "^2.4.2"
     graphql-tools "^1.1.0"


### PR DESCRIPTION
### What is the context of this PR?

[Trello](https://trello.com/c/FkGCN5EE/254-focus-on-new-section-when-created-2)

Uses [`scrollIntoView`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) to ensure any new items (section or pages) are scrolled into view of the questionnaire nav when added.

### How to review 

Add a variety of sections and pages from different starting scroll positions.
