### PR TITLE
Various visual tweaks/fixes

### DIFF
--- a/src/components/Accordion/__snapshots__/index.test.js.snap
+++ b/src/components/Accordion/__snapshots__/index.test.js.snap
@@ -18,12 +18,13 @@ exports[`AccordionPanel Accordion panel behaviours should render title and body 
   -ms-user-select: none;
   user-select: none;
   position: relative;
-  padding: 3px;
-  height: 3em;
+  padding: 0.65em 4px;
+  font-size: 0.6em;
 }
 
 .c1 button {
-  font-size: 0.6em;
+  color: #4A4A4A;
+  font-size: 1em;
   text-transform: uppercase;
   font-weight: 900;
   background: none;

--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -12,11 +12,12 @@ const StyledPanelTitle = styled(PanelTitle)`
   margin: 0;
   user-select: none;
   position: relative;
-  padding: 3px;
-  height: 3em;
+  padding: 0.65em 4px;
+  font-size: 0.6em;
 
   & button {
-    font-size: 0.6em;
+    color: ${colors.text};
+    font-size: 1em;
     text-transform: uppercase;
     font-weight: 900;
     background: none;

--- a/src/components/QuestionnaireNav/PageNav.js
+++ b/src/components/QuestionnaireNav/PageNav.js
@@ -98,6 +98,7 @@ const Link = styled(NavLink)`
 
 export const LinkText = styled.span`
   display: inline-block;
+  vertical-align: middle;
   width: 100%;
   position: relative;
   z-index: 2;

--- a/src/components/QuestionnaireNav/SectionTitle.js
+++ b/src/components/QuestionnaireNav/SectionTitle.js
@@ -27,11 +27,15 @@ const Title = styled.h3`
   position: relative;
   width: 100%;
   display: inline-block;
+  vertical-align: middle;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 
   &::before {
+    height: 1rem;
+    vertical-align: sub;
+    display: inline-block;
     content: url(${sectionIcon});
     margin-right: 0.5em;
   }

--- a/src/components/QuestionnaireNav/__snapshots__/index.test.js.snap
+++ b/src/components/QuestionnaireNav/__snapshots__/index.test.js.snap
@@ -129,6 +129,7 @@ exports[`QuestionnaireNav should render 1`] = `
 
 .c14 {
   display: inline-block;
+  vertical-align: middle;
   width: 100%;
   position: relative;
   z-index: 2;
@@ -174,12 +175,16 @@ exports[`QuestionnaireNav should render 1`] = `
   position: relative;
   width: 100%;
   display: inline-block;
+  vertical-align: middle;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .c5::before {
+  height: 1rem;
+  vertical-align: sub;
+  display: inline-block;
   content: url(icon-section.svg);
   margin-right: 0.5em;
 }

--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -18,6 +18,7 @@ const styleMap = {
 
 const heading = css`
   font-size: 1.3em;
+  line-height: 1.4;
   font-weight: bold;
 `;
 
@@ -29,6 +30,7 @@ const sizes = {
   large: css`
     font-size: 1.75em;
     font-weight: 700;
+    line-height: 1.3;
   `,
 
   medium: css`
@@ -43,11 +45,11 @@ const sizes = {
 
 const Wrapper = styled.div`
   position: relative;
+  line-height: 1.5;
 
   .header-two,
   .unstyled,
   .unordered-list-item {
-    line-height: 1.5;
     margin: 0;
   }
 


### PR DESCRIPTION

<img width="1321" alt="screenshot 2017-10-19 13 40 09" src="https://user-images.githubusercontent.com/930398/31771197-15c286c6-b4d3-11e7-8238-f84162f7e457.png">

### What is the context of this PR?

Tidied up some visual snags:

- Change colour of properties accordion titles to main text colour (from pure black).
- Change font-size of accordion title to match elsewhere.
- Fixed some alignment issues in the navigation between labels, icons and their surrounding boxes 
- Fixed some line-height issues in the RTE

### How to review 

- check each change is satisfactory
