### PR TITLE
Remove the properties panel from questionnaire design page.

### DIFF
--- a/src/containers/QuestionnaireDesignPage/QuestionnaireDesignPage.js
+++ b/src/containers/QuestionnaireDesignPage/QuestionnaireDesignPage.js
@@ -9,7 +9,6 @@ import ScrollPane from "components/ScrollPane";
 import EditorSurface from "components/EditorSurface";
 import QuestionnaireNavContainer from "containers/QuestionnaireNavContainer";
 import getTextFromHTML from "utils/getTextFromHTML";
-import PropertiesPanel from "../../components/PropertiesPanel/index";
 
 export class QuestionnaireDesignPage extends Component {
   static propTypes = {
@@ -100,9 +99,7 @@ export class QuestionnaireDesignPage extends Component {
               </MainCanvas>
             </ScrollPane>
           </Column>
-          <Column cols={2} gutters={false}>
-            <PropertiesPanel page={page} orderMin={1} orderMax={10} />
-          </Column>
+          <Column cols={2} gutters={false} />
         </Grid>
       </BaseLayout>
     );

--- a/src/containers/QuestionnaireDesignPage/__snapshots__/QuestionnaireDesignPage.test.js.snap
+++ b/src/containers/QuestionnaireDesignPage/__snapshots__/QuestionnaireDesignPage.test.js.snap
@@ -148,32 +148,7 @@ exports[`QuestionnaireDesignPage should render form when loaded 1`] = `
     <Column
       cols={2}
       gutters={false}
-    >
-      <PropertiesPanel
-        orderMax={10}
-        orderMin={1}
-        page={
-          Object {
-            "answers": Array [
-              Object {
-                "id": "1",
-                "label": "",
-                "options": Array [
-                  Object {
-                    "id": "1",
-                  },
-                ],
-              },
-            ],
-            "description": "",
-            "guidance": "",
-            "id": "1",
-            "title": "",
-            "type": "General",
-          }
-        }
-      />
-    </Column>
+    />
   </Grid>
 </BaseLayout>
 `;


### PR DESCRIPTION
### What is the context of this PR?
This PR removes the properties panel from the right hand side of the Questionnaire Design page.
The panel will be added back once a decision has been made about which properties should be displayed.

### How to review 
Observe that the properties panel is no longer visible.
