### PR TITLE
Upgrade react-tooltip to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^4.0.8",
     "react-textarea-autosize": "^5.1.0",
-    "react-tooltip": "^3.3.1",
+    "react-tooltip": "^3.4.0",
     "react-transition-group": "^2.2.1",
     "redux": "^3.7.2",
     "redux-devtools-extension": "^2.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2364,7 +2364,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@^2.2.0, classnames@^2.2.5:
+classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -8208,12 +8208,12 @@ react-textarea-autosize@^5.1.0:
   dependencies:
     prop-types "^15.5.10"
 
-react-tooltip@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.3.1.tgz#c8eb0f64c3852e5aadb10b1569bcd469562b326d"
+react-tooltip@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.4.0.tgz#037f38f797c3e6b1b58d2534ccc8c2c76af4f52d"
   dependencies:
-    classnames "^2.2.0"
-    prop-types "^15.5.8"
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
 
 react-transition-group@^1.1.2:
   version "1.2.1"


### PR DESCRIPTION
### What is the context of this PR?

The current version of `react-tooltip` is causing errors in production, this upgrades the version to one compatible with React 16.

### How to review 

App should no longer throw errors in prod (check Netifly build)
