### PR TITLE
ensure coverage flag passed to jest correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "export NODE_PATH=src/ && build-storybook -s public -o storybook-static",
     "storybook-deploy": "yarn storybook-build && gh-pages -d .out",
     "precommit": "lint-staged",
-    "coverage": "yarn test --coverage"
+    "coverage": "yarn test -- --coverage"
   },
   "lint-staged": {
     "*.js": ["prettier --write", "git add"]


### PR DESCRIPTION
### What is the context of this PR?
Codecov hasn't been checking coverage because coverage reports weren't being generated. This is due to a version mismatch of `yarn` between our dev machines (`> v1`) and travis (`v0.27.3`). In yarn pre-v1, to pass args to package.json scripts you needed a double-dash separator:

```
yarn test -- --coverage
```

In yarn `> v1`, this separator has been retired:

```
yarn test --coverage
```

In v1 yarn the coverage flag will be forwarded correctly, but in yarn `pre-v1`, it will not. This meant that jest never got the coverage flag, lcov reports were not generated, and therefore codecov not correctly checking/enforcing coverage.

### How to review 
Check the Travis output of this PR. At the very end of the logs will be a call to codecov. If you expand this (using the arrow by line number), you should now see that codecov is finding the reports, where previously it was not.
