### PR TITLE
Add properties header to right-hand side panel.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,16 @@
     "serve": "npm install -g serve && serve -p 3000 build/",
     "deploy": "npm run build && gh-pages -d build",
     "storybook": "export NODE_PATH=src/ && start-storybook -p 9001",
-    "storybook-build":
-      "export NODE_PATH=src/ && build-storybook -s public -o storybook-static",
+    "storybook-build": "export NODE_PATH=src/ && build-storybook -s public -o storybook-static",
     "storybook-deploy": "yarn storybook-build && gh-pages -d .out",
     "precommit": "lint-staged",
     "coverage": "yarn test -- --coverage"
   },
   "lint-staged": {
-    "*.js": ["prettier --write", "git add"]
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.12",
@@ -153,9 +155,10 @@
       "<rootDir>/config/polyfills.js",
       "<rootDir>/src/tests/setup/throwOnConsole.js"
     ],
-    "setupTestFrameworkScriptFile":
-      "<rootDir>/src/tests/setup/JestTestSetup.js",
-    "snapshotSerializers": ["<rootDir>/node_modules/enzyme-to-json/serializer"],
+    "setupTestFrameworkScriptFile": "<rootDir>/src/tests/setup/JestTestSetup.js",
+    "snapshotSerializers": [
+      "<rootDir>/node_modules/enzyme-to-json/serializer"
+    ],
     "testPathIgnorePatterns": [
       "<rootDir>[/\\\\](build|docs|node_modules|scripts)[/\\\\]"
     ],
@@ -166,14 +169,22 @@
       "\\.(gql|graphql)$": "jest-transform-graphql",
       "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
-    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
+    "transformIgnorePatterns": [
+      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
+    ],
     "moduleNameMapper": {
       "^react-native$": "react-native-web"
     },
-    "modulePaths": ["<rootDir>/src/"]
+    "modulePaths": [
+      "<rootDir>/src/"
+    ]
   },
   "babel": {
-    "presets": ["react-app"]
+    "presets": [
+      "react-app"
+    ]
   },
-  "moduleRoots": ["./src"]
+  "moduleRoots": [
+    "./src"
+  ]
 }

--- a/src/components/Accordion/__snapshots__/index.test.js.snap
+++ b/src/components/Accordion/__snapshots__/index.test.js.snap
@@ -19,12 +19,11 @@ exports[`AccordionPanel Accordion panel behaviours should render title and body 
   user-select: none;
   position: relative;
   padding: 0.25em;
-  font-size: 1em;
 }
 
 .c1 button {
   color: #4A4A4A;
-  font-size: 0.75em;
+  font-size: 0.7em;
   font-weight: 900;
   background: none;
   border: none;
@@ -79,19 +78,6 @@ exports[`AccordionPanel Accordion panel behaviours should render title and body 
 .c2 {
   padding: 0.6em 1em;
   position: relative;
-  font-size: 1em;
-}
-
-.c2 label,
-.c2 input,
-.c2 select,
-.c2 textarea {
-  font-size: 0.75em;
-  font-weight: 500;
-}
-
-.c2 form {
-  margin-bottom: 0;
 }
 
 .c2[aria-hidden="true"] {
@@ -118,7 +104,7 @@ exports[`AccordionPanel Accordion panel behaviours should render title and body 
       className="c0"
       onKeyUp={[Function]}
     >
-      <Accordion__StyledPanelTitle
+      <Accordion__AccordionTitle
         controls="panel-body-accordion-panel-Answer-1"
         id="panel-title-accordion-panel-Answer-1"
         innerRef={[Function]}
@@ -147,8 +133,8 @@ exports[`AccordionPanel Accordion panel behaviours should render title and body 
             </button>
           </h3>
         </PanelTitle>
-      </Accordion__StyledPanelTitle>
-      <Accordion__StyledPanelBody
+      </Accordion__AccordionTitle>
+      <Accordion__AccordionBody
         id="panel-body-accordion-panel-Answer-1"
         labelledBy="panel-title-accordion-panel-Answer-1"
         open={false}
@@ -171,7 +157,7 @@ exports[`AccordionPanel Accordion panel behaviours should render title and body 
             </div>
           </div>
         </PanelBody>
-      </Accordion__StyledPanelBody>
+      </Accordion__AccordionBody>
     </div>
   </Accordion__AccordionInner>
 </AccordionPanel>
@@ -181,7 +167,7 @@ exports[`AccordionPanel should render 1`] = `
 <Accordion__AccordionInner
   onKeyUp={[Function]}
 >
-  <Accordion__StyledPanelTitle
+  <Accordion__AccordionTitle
     controls="panel-body-accordion-panel-Answer-1"
     id="panel-title-accordion-panel-Answer-1"
     innerRef={[Function]}
@@ -189,8 +175,8 @@ exports[`AccordionPanel should render 1`] = `
     open={false}
   >
     Answer properties
-  </Accordion__StyledPanelTitle>
-  <Accordion__StyledPanelBody
+  </Accordion__AccordionTitle>
+  <Accordion__AccordionBody
     id="panel-body-accordion-panel-Answer-1"
     labelledBy="panel-title-accordion-panel-Answer-1"
     open={false}
@@ -198,6 +184,6 @@ exports[`AccordionPanel should render 1`] = `
     <div>
       Content
     </div>
-  </Accordion__StyledPanelBody>
+  </Accordion__AccordionBody>
 </Accordion__AccordionInner>
 `;

--- a/src/components/Accordion/__snapshots__/index.test.js.snap
+++ b/src/components/Accordion/__snapshots__/index.test.js.snap
@@ -18,19 +18,19 @@ exports[`AccordionPanel Accordion panel behaviours should render title and body 
   -ms-user-select: none;
   user-select: none;
   position: relative;
-  padding: 0.65em 4px;
-  font-size: 0.7em;
+  padding: 0.25em;
+  font-size: 1em;
 }
 
 .c1 button {
   color: #4A4A4A;
-  font-size: 1em;
+  font-size: 0.75em;
   font-weight: 900;
   background: none;
   border: none;
   width: 100%;
   height: 100%;
-  padding: 1em;
+  padding: 0.6em 1em;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -77,8 +77,21 @@ exports[`AccordionPanel Accordion panel behaviours should render title and body 
 }
 
 .c2 {
-  padding: 1em;
+  padding: 0.6em 1em;
   position: relative;
+  font-size: 1em;
+}
+
+.c2 label,
+.c2 input,
+.c2 select,
+.c2 textarea {
+  font-size: 0.75em;
+  font-weight: 500;
+}
+
+.c2 form {
+  margin-bottom: 0;
 }
 
 .c2[aria-hidden="true"] {

--- a/src/components/Accordion/__snapshots__/index.test.js.snap
+++ b/src/components/Accordion/__snapshots__/index.test.js.snap
@@ -19,13 +19,12 @@ exports[`AccordionPanel Accordion panel behaviours should render title and body 
   user-select: none;
   position: relative;
   padding: 0.65em 4px;
-  font-size: 0.6em;
+  font-size: 0.7em;
 }
 
 .c1 button {
   color: #4A4A4A;
   font-size: 1em;
-  text-transform: uppercase;
   font-weight: 900;
   background: none;
   border: none;

--- a/src/components/Accordion/chevron.svg
+++ b/src/components/Accordion/chevron.svg
@@ -1,3 +1,8 @@
-<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-    <path d="M7.41 7.84L12 12.42l4.59-4.58L18 9.25l-6 6-6-6z" fill="#A6A6A6"/>
+<svg width="12px" height="9px" viewBox="0 0 12 9" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Artboard" fill-rule="nonzero" fill="#A6A6A6">
+            <polygon id="Shape" points="1.41 0.84 6 5.42 10.59 0.84 12 2.25 6 8.25 0 2.25"></polygon>
+        </g>
+    </g>
 </svg>

--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -13,12 +13,11 @@ const StyledPanelTitle = styled(PanelTitle)`
   user-select: none;
   position: relative;
   padding: 0.65em 4px;
-  font-size: 0.6em;
+  font-size: 0.7em;
 
   & button {
     color: ${colors.text};
     font-size: 1em;
-    text-transform: uppercase;
     font-weight: 900;
     background: none;
     border: none;

--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -12,18 +12,18 @@ const StyledPanelTitle = styled(PanelTitle)`
   margin: 0;
   user-select: none;
   position: relative;
-  padding: 0.65em 4px;
-  font-size: 0.7em;
+  padding: 0.25em;
+  font-size: 1em;
 
   & button {
     color: ${colors.text};
-    font-size: 1em;
+    font-size: 0.75em;
     font-weight: 900;
     background: none;
     border: none;
     width: 100%;
     height: 100%;
-    padding: 1em;
+    padding: 0.6em 1em;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -52,8 +52,21 @@ const StyledPanelTitle = styled(PanelTitle)`
 `;
 
 const StyledPanelBody = styled(PanelBody)`
-  padding: 1em;
+  padding: 0.6em 1em;
   position: relative;
+  font-size: 1em;
+
+  label,
+  input,
+  select,
+  textarea {
+    font-size: 0.75em;
+    font-weight: 500;
+  }
+
+  form {
+    margin-bottom: 0;
+  }
 
   &[aria-hidden="true"] {
     display: none;

--- a/src/components/Accordion/index.js
+++ b/src/components/Accordion/index.js
@@ -7,17 +7,16 @@ import chevronIcon from "components/Accordion/chevron.svg";
 import { colors } from "constants/theme";
 const KEY_CODE_ESCAPE = 27;
 
-const StyledPanelTitle = styled(PanelTitle)`
+const AccordionTitle = styled(PanelTitle)`
   cursor: pointer;
   margin: 0;
   user-select: none;
   position: relative;
   padding: 0.25em;
-  font-size: 1em;
 
   & button {
     color: ${colors.text};
-    font-size: 0.75em;
+    font-size: 0.7em;
     font-weight: 900;
     background: none;
     border: none;
@@ -51,22 +50,9 @@ const StyledPanelTitle = styled(PanelTitle)`
   }
 `;
 
-const StyledPanelBody = styled(PanelBody)`
+const AccordionBody = styled(PanelBody)`
   padding: 0.6em 1em;
   position: relative;
-  font-size: 1em;
-
-  label,
-  input,
-  select,
-  textarea {
-    font-size: 0.75em;
-    font-weight: 500;
-  }
-
-  form {
-    margin-bottom: 0;
-  }
 
   &[aria-hidden="true"] {
     display: none;
@@ -129,7 +115,7 @@ export class AccordionPanel extends React.Component {
 
     return (
       <AccordionInner onKeyUp={this.handleKeyUp}>
-        <StyledPanelTitle
+        <AccordionTitle
           id={"panel-title-" + id}
           controls={"panel-body-" + id}
           open={this.state.open}
@@ -137,14 +123,14 @@ export class AccordionPanel extends React.Component {
           innerRef={this.saveRef}
         >
           {title}
-        </StyledPanelTitle>
-        <StyledPanelBody
+        </AccordionTitle>
+        <AccordionBody
           id={"panel-body-" + id}
           labelledBy={"panel-title-" + id}
           open={open}
         >
           {children}
-        </StyledPanelBody>
+        </AccordionBody>
       </AccordionInner>
     );
   }

--- a/src/components/AnswerProperties/__snapshots__/AnswerProperties.test.js.snap
+++ b/src/components/AnswerProperties/__snapshots__/AnswerProperties.test.js.snap
@@ -7,7 +7,10 @@ exports[`Answer Properties should render 1`] = `
   <AnswerProperties__FlexField
     id="answer.required"
   >
-    <Label>
+    <Label
+      inline={true}
+      small={true}
+    >
       Required
     </Label>
     <AnswerProperties__StyledCheckboxInput
@@ -29,7 +32,9 @@ exports[`Answer Properties should render 1`] = `
   <Field
     id="answer.validation.message"
   >
-    <Label>
+    <Label
+      small={true}
+    >
       Custom validation message
     </Label>
     <withChangeHandler(TextArea)

--- a/src/components/AnswerProperties/index.js
+++ b/src/components/AnswerProperties/index.js
@@ -23,11 +23,13 @@ const AnswerProperties = props => {
   return (
     <Form onSubmit={props.onSubmit}>
       <FlexField id="answer.required">
-        <Label>Required</Label>
+        <Label small inline>
+          Required
+        </Label>
         <StyledCheckboxInput type="checkbox" {...props} />
       </FlexField>
       <Field id="answer.validation.message">
-        <Label>Custom validation message</Label>
+        <Label small>Custom validation message</Label>
         <TextArea placeholder="Optional" {...props} />
       </Field>
     </Form>

--- a/src/components/Forms/Field/__snapshots__/Field.test.js.snap
+++ b/src/components/Forms/Field/__snapshots__/Field.test.js.snap
@@ -43,9 +43,11 @@ exports[`components/Forms/Field should render correctly 1`] = `
       <Label
         id="name"
         key=".0"
+        small={false}
       >
         <Label__StyledLabel
           htmlFor="name"
+          small={false}
         >
           <label
             className="c1"

--- a/src/components/Forms/Form/index.js
+++ b/src/components/Forms/Form/index.js
@@ -4,10 +4,10 @@ import styled from "styled-components";
 
 const StyledForm = styled.form`
   width: 100%;
-  margin-bottom: 2em;
+  margin-bottom: 0;
 `;
 
-const Form = ({ action, children, onSubmit, ...otherProps }) =>
+const Form = ({ action, children, onSubmit, ...otherProps }) => (
   <StyledForm
     action={action}
     method="POST"
@@ -16,7 +16,8 @@ const Form = ({ action, children, onSubmit, ...otherProps }) =>
     {...otherProps}
   >
     {children}
-  </StyledForm>;
+  </StyledForm>
+);
 
 Form.propTypes = {
   action: PropTypes.string,

--- a/src/components/Forms/Label/__snapshots__/Label.test.js.snap
+++ b/src/components/Forms/Label/__snapshots__/Label.test.js.snap
@@ -3,6 +3,7 @@
 exports[`components/Forms/Label should render correctly 1`] = `
 <Label__StyledLabel
   htmlFor="name"
+  small={false}
 >
   Name
 </Label__StyledLabel>

--- a/src/components/Forms/Label/index.js
+++ b/src/components/Forms/Label/index.js
@@ -4,20 +4,26 @@ import styled from "styled-components";
 
 const StyledLabel = styled.label`
   display: ${props => (props.inline ? "inline-block" : "block")};
-  font-size: 0.9em;
+  font-size: ${props => (props.small ? "0.75" : "0.9")}em;
   margin-bottom: ${props => (props.inline ? "0" : "0.4em")};
   font-weight: 700;
   vertical-align: middle;
 `;
 
-const Label = ({ id, children, ...otherProps }) =>
+const Label = ({ id, children, ...otherProps }) => (
   <StyledLabel htmlFor={id} {...otherProps}>
     {children}
-  </StyledLabel>;
+  </StyledLabel>
+);
 
 Label.propTypes = {
   id: PropTypes.string,
-  children: PropTypes.string.isRequired
+  children: PropTypes.string.isRequired,
+  small: PropTypes.bool
+};
+
+Label.defaultProps = {
+  small: false
 };
 
 export default Label;

--- a/src/components/PageProperties/__snapshots__/PageProperties.test.js.snap
+++ b/src/components/PageProperties/__snapshots__/PageProperties.test.js.snap
@@ -7,7 +7,9 @@ exports[`Page Properties should render 1`] = `
   <Field
     id="page.type"
   >
-    <Label>
+    <Label
+      small={true}
+    >
       Page type
     </Label>
     <withChangeHandler(Select)
@@ -25,7 +27,9 @@ exports[`Page Properties should render 1`] = `
   <Field
     id="page.order"
   >
-    <Label>
+    <Label
+      small={true}
+    >
       Order
     </Label>
     <Number

--- a/src/components/PageProperties/index.js
+++ b/src/components/PageProperties/index.js
@@ -11,10 +11,10 @@ const PageProperties = ({
   onChange,
   onSubmit,
   onBlur
-}) =>
+}) => (
   <Form onSubmit={onSubmit}>
     <Field id="page.type">
-      <Label>Page type</Label>
+      <Label small>Page type</Label>
       <Select
         options={["Question", "Interstitial"]}
         defaultValue={page.type}
@@ -23,7 +23,7 @@ const PageProperties = ({
       />
     </Field>
     <Field id="page.order">
-      <Label>Order</Label>
+      <Label small>Order</Label>
       <Number
         value={page.order || "0"}
         onChange={onChange}
@@ -32,7 +32,8 @@ const PageProperties = ({
         max={orderMax}
       />
     </Field>
-  </Form>;
+  </Form>
+);
 
 PageProperties.propTypes = {
   page: CustomPropTypes.page.isRequired,

--- a/src/components/PropertiesPanel/__snapshots__/PropertiesPanel.test.js.snap
+++ b/src/components/PropertiesPanel/__snapshots__/PropertiesPanel.test.js.snap
@@ -1,104 +1,114 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PropertiesPanel should render when there are answers 1`] = `
-<PropertiesPanel__StyledDiv>
-  <ScrollPane>
-    <StatelessAccordion>
-      <AccordionPanel
-        id="Page1"
-        open={false}
-        title="Page properties"
-      >
-        <PageProperties
-          onBlur={[Function]}
-          onChange={[Function]}
-          onSubmit={[Function]}
-          orderMax={10}
-          orderMin={1}
-          page={
-            Object {
-              "__typename": "Page",
-              "answers": Array [
-                Object {
-                  "__typename": "Answer",
-                  "id": "1",
-                },
-                Object {
-                  "__typename": "Answer",
-                  "id": "2",
-                },
-              ],
-              "id": "1",
-              "type": "Questionnaire",
+<PropertiesPanel__OuterDiv>
+  <h2>
+    Properties
+  </h2>
+  <PropertiesPanel__InnerDiv>
+    <ScrollPane>
+      <StatelessAccordion>
+        <AccordionPanel
+          id="Page1"
+          open={false}
+          title="Page"
+        >
+          <PageProperties
+            onBlur={[Function]}
+            onChange={[Function]}
+            onSubmit={[Function]}
+            orderMax={10}
+            orderMin={1}
+            page={
+              Object {
+                "__typename": "Page",
+                "answers": Array [
+                  Object {
+                    "__typename": "Answer",
+                    "id": "1",
+                  },
+                  Object {
+                    "__typename": "Answer",
+                    "id": "2",
+                  },
+                ],
+                "id": "1",
+                "type": "Questionnaire",
+              }
             }
-          }
-        />
-      </AccordionPanel>
-      <AccordionPanel
-        id="Answer1"
-        key="1"
-        open={false}
-        title="Answer 1 properties"
-      >
-        <AnswerProperties
-          answer={
-            Object {
-              "__typename": "Answer",
-              "id": "1",
+          />
+        </AccordionPanel>
+        <AccordionPanel
+          id="Answer1"
+          key="1"
+          open={false}
+          title="Answer 1"
+        >
+          <AnswerProperties
+            answer={
+              Object {
+                "__typename": "Answer",
+                "id": "1",
+              }
             }
-          }
-          onChange={[Function]}
-          onSubmit={[Function]}
-        />
-      </AccordionPanel>
-      <AccordionPanel
-        id="Answer2"
-        key="2"
-        open={false}
-        title="Answer 2 properties"
-      >
-        <AnswerProperties
-          answer={
-            Object {
-              "__typename": "Answer",
-              "id": "2",
+            onChange={[Function]}
+            onSubmit={[Function]}
+          />
+        </AccordionPanel>
+        <AccordionPanel
+          id="Answer2"
+          key="2"
+          open={false}
+          title="Answer 2"
+        >
+          <AnswerProperties
+            answer={
+              Object {
+                "__typename": "Answer",
+                "id": "2",
+              }
             }
-          }
-          onChange={[Function]}
-          onSubmit={[Function]}
-        />
-      </AccordionPanel>
-    </StatelessAccordion>
-  </ScrollPane>
-</PropertiesPanel__StyledDiv>
+            onChange={[Function]}
+            onSubmit={[Function]}
+          />
+        </AccordionPanel>
+      </StatelessAccordion>
+    </ScrollPane>
+  </PropertiesPanel__InnerDiv>
+</PropertiesPanel__OuterDiv>
 `;
 
 exports[`PropertiesPanel should render when there are no answers 1`] = `
-<PropertiesPanel__StyledDiv>
-  <ScrollPane>
-    <StatelessAccordion>
-      <AccordionPanel
-        id="Page1"
-        open={false}
-        title="Page properties"
-      >
-        <PageProperties
-          onBlur={[Function]}
-          onChange={[Function]}
-          onSubmit={[Function]}
-          orderMax={10}
-          orderMin={1}
-          page={
-            Object {
-              "__typename": "Page",
-              "answers": Array [],
-              "id": "1",
-              "type": "Questionnaire",
+<PropertiesPanel__OuterDiv>
+  <h2>
+    Properties
+  </h2>
+  <PropertiesPanel__InnerDiv>
+    <ScrollPane>
+      <StatelessAccordion>
+        <AccordionPanel
+          id="Page1"
+          open={false}
+          title="Page"
+        >
+          <PageProperties
+            onBlur={[Function]}
+            onChange={[Function]}
+            onSubmit={[Function]}
+            orderMax={10}
+            orderMin={1}
+            page={
+              Object {
+                "__typename": "Page",
+                "answers": Array [],
+                "id": "1",
+                "type": "Questionnaire",
+              }
             }
-          }
-        />
-      </AccordionPanel>
-    </StatelessAccordion>
-  </ScrollPane>
-</PropertiesPanel__StyledDiv>
+          />
+        </AccordionPanel>
+      </StatelessAccordion>
+    </ScrollPane>
+  </PropertiesPanel__InnerDiv>
+</PropertiesPanel__OuterDiv>
 `;

--- a/src/components/PropertiesPanel/index.js
+++ b/src/components/PropertiesPanel/index.js
@@ -19,16 +19,16 @@ const OuterDiv = styled.div`
   padding: 0;
   margin: 0;
   border-left: 2px solid #eee;
-  font-size: 1em;
 
   h2 {
     font-size: 0.6em;
     text-transform: uppercase;
     font-weight: 900;
     margin: 0;
-    line-height: 1.5em;
+    line-height: 1;
     position: relative;
-    padding: 1.7em 1.4em 1.2em;
+    padding: 1.2em 1.5em;
+    border-bottom: 1px solid ${colors.borders};
   }
 `;
 

--- a/src/components/PropertiesPanel/index.js
+++ b/src/components/PropertiesPanel/index.js
@@ -10,14 +10,35 @@ import ScrollPane from "components/ScrollPane";
 import { noop } from "lodash";
 import getIdForObject from "utils/getIdForObject";
 
-const StyledDiv = styled.div`
+const OuterDiv = styled.div`
+  background: ${colors.white};
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  border-left: 2px solid #eee;
+  font-size: 1em;
+
+  h2 {
+    font-size: 0.6em;
+    text-transform: uppercase;
+    font-weight: 900;
+    margin: 0;
+    line-height: 1.5em;
+    position: relative;
+    padding: 1.7em 1.4em 1.2em;
+  }
+`;
+
+const InnerDiv = styled.div`
   background: ${colors.white};
   display: flex;
   width: 100%;
   height: 100%;
   padding: 0;
   margin: 0;
-  border-left: 2px solid #eee;
 `;
 
 class PropertiesPanel extends React.Component {
@@ -35,38 +56,38 @@ class PropertiesPanel extends React.Component {
 
   render() {
     return (
-      <StyledDiv>
-        <ScrollPane>
-          <Accordion>
-            <AccordionPanel
-              id={getIdForObject(this.props.page)}
-              title="Page properties"
-            >
-              <PageProperties
-                page={this.props.page}
-                onChange={this.handleChange}
-                onBlur={this.handleBlur}
-                onSubmit={this.handleSubmit}
-                orderMin={this.props.orderMin}
-                orderMax={this.props.orderMax}
-              />
-            </AccordionPanel>
-            {this.props.page.answers.map((answer, index) => (
-              <AccordionPanel
-                key={answer.id}
-                id={getIdForObject(answer)}
-                title={`Answer ${index + 1} properties`}
-              >
-                <AnswerProperties
-                  answer={answer}
+      <OuterDiv>
+        <h2>Properties</h2>
+        <InnerDiv>
+          <ScrollPane>
+            <Accordion>
+              <AccordionPanel id={getIdForObject(this.props.page)} title="Page">
+                <PageProperties
+                  page={this.props.page}
                   onChange={this.handleChange}
+                  onBlur={this.handleBlur}
                   onSubmit={this.handleSubmit}
+                  orderMin={this.props.orderMin}
+                  orderMax={this.props.orderMax}
                 />
               </AccordionPanel>
-            ))}
-          </Accordion>
-        </ScrollPane>
-      </StyledDiv>
+              {this.props.page.answers.map((answer, index) => (
+                <AccordionPanel
+                  key={answer.id}
+                  id={getIdForObject(answer)}
+                  title={`Answer ${index + 1}`}
+                >
+                  <AnswerProperties
+                    answer={answer}
+                    onChange={this.handleChange}
+                    onSubmit={this.handleSubmit}
+                  />
+                </AccordionPanel>
+              ))}
+            </Accordion>
+          </ScrollPane>
+        </InnerDiv>
+      </OuterDiv>
     );
   }
 }

--- a/src/components/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
+++ b/src/components/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
@@ -8,7 +8,9 @@ exports[`QuestionnaireMeta should render 1`] = `
     <Field
       id="title"
     >
-      <Label>
+      <Label
+        small={false}
+      >
         Questionnaire Title
       </Label>
       <withChangeHandler(Input)
@@ -22,7 +24,9 @@ exports[`QuestionnaireMeta should render 1`] = `
     <Field
       id="description"
     >
-      <Label>
+      <Label
+        small={false}
+      >
         Description
       </Label>
       <withChangeHandler(TextArea)
@@ -43,7 +47,9 @@ exports[`QuestionnaireMeta should render 1`] = `
         <Field
           id="surveyId"
         >
-          <Label>
+          <Label
+            small={false}
+          >
             Survey ID
           </Label>
           <withChangeHandler(Input)
@@ -64,7 +70,9 @@ exports[`QuestionnaireMeta should render 1`] = `
         <Field
           id="theme"
         >
-          <Label>
+          <Label
+            small={false}
+          >
             Theme
           </Label>
           <withChangeHandler(Select)
@@ -86,7 +94,9 @@ exports[`QuestionnaireMeta should render 1`] = `
         <Field
           id="legalBasis"
         >
-          <Label>
+          <Label
+            small={false}
+          >
             Legal Basis
           </Label>
           <withChangeHandler(Select)
@@ -113,6 +123,7 @@ exports[`QuestionnaireMeta should render 1`] = `
       />
       <Label
         inline={true}
+        small={false}
       >
         Navigation
       </Label>

--- a/src/containers/QuestionnaireDesignPage/QuestionnaireDesignPage.js
+++ b/src/containers/QuestionnaireDesignPage/QuestionnaireDesignPage.js
@@ -9,6 +9,7 @@ import ScrollPane from "components/ScrollPane";
 import EditorSurface from "components/EditorSurface";
 import QuestionnaireNavContainer from "containers/QuestionnaireNavContainer";
 import getTextFromHTML from "utils/getTextFromHTML";
+import PropertiesPanel from "components/PropertiesPanel";
 
 export class QuestionnaireDesignPage extends Component {
   static propTypes = {
@@ -99,7 +100,9 @@ export class QuestionnaireDesignPage extends Component {
               </MainCanvas>
             </ScrollPane>
           </Column>
-          <Column cols={2} gutters={false} />
+          <Column cols={2} gutters={false}>
+            <PropertiesPanel page={page} orderMin={1} orderMax={10} />
+          </Column>
         </Grid>
       </BaseLayout>
     );

--- a/src/containers/QuestionnaireDesignPage/__snapshots__/QuestionnaireDesignPage.test.js.snap
+++ b/src/containers/QuestionnaireDesignPage/__snapshots__/QuestionnaireDesignPage.test.js.snap
@@ -148,7 +148,32 @@ exports[`QuestionnaireDesignPage should render form when loaded 1`] = `
     <Column
       cols={2}
       gutters={false}
-    />
+    >
+      <PropertiesPanel
+        orderMax={10}
+        orderMin={1}
+        page={
+          Object {
+            "answers": Array [
+              Object {
+                "id": "1",
+                "label": "",
+                "options": Array [
+                  Object {
+                    "id": "1",
+                  },
+                ],
+              },
+            ],
+            "description": "",
+            "guidance": "",
+            "id": "1",
+            "title": "",
+            "type": "General",
+          }
+        }
+      />
+    </Column>
   </Grid>
 </BaseLayout>
 `;


### PR DESCRIPTION
### What is the context of this PR?
This PR adds a "Properties" header to the right hand side panel.
The word "properties" has been dropped from subsequent sections.
The side panel has been re-introduced into the application in preparation for some of the upcoming stories.
Snapshots have been updated.

### How to review 
A visual inspection of the app to see that the properties heading is displayed above all accordion sections.
