### PR TITLE
Fixing visual glitches with new delete/undo toast messages.

### DIFF
--- a/src/components/Menu/__snapshots__/Menu.test.js.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.js.snap
@@ -116,6 +116,11 @@ exports[`components/Menu should render a Menu 1`] = `
   width: 10px;
 }
 
+.c2 >:first-child {
+  -webkit-backface-visibility: hidden !important;
+  backface-visibility: hidden !important;
+}
+
 .c1 {
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/components/ScrollPane/__snapshots__/index.test.js.snap
+++ b/src/components/ScrollPane/__snapshots__/index.test.js.snap
@@ -37,6 +37,11 @@ exports[`ScrollPane should render 1`] = `
   width: 10px;
 }
 
+.c0 >:first-child {
+  -webkit-backface-visibility: hidden !important;
+  backface-visibility: hidden !important;
+}
+
 <div
   className="c0"
 >

--- a/src/components/ScrollPane/index.js
+++ b/src/components/ScrollPane/index.js
@@ -33,6 +33,10 @@ const ScrollPane = styled.div`
   ::-webkit-scrollbar {
     width: 10px;
   }
+
+  > :first-child {
+    backface-visibility: hidden !important;
+  }
 `;
 
 export default ScrollPane;

--- a/src/containers/ToastContainer/index.js
+++ b/src/containers/ToastContainer/index.js
@@ -36,8 +36,9 @@ const ToastOuterContainer = styled.div`
   position: absolute;
   bottom: 0;
   text-align: center;
-  width: 100%;
+  min-width: 10em;
   margin-bottom: ${props => (props.hasMargin ? "0.5em" : "0")};
+  z-index: 999;
 `;
 
 const ToastInnerContainer = styled.div`
@@ -45,28 +46,41 @@ const ToastInnerContainer = styled.div`
   text-align: initial;
 `;
 
+const ToastWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+`;
+
 const ToastArea = ({ toasts, dismissToast, undoToast, ...otherProps }) => {
   return (
-    <ToastOuterContainer>
-      <ToastInnerContainer>
-        <ToastList>
-          {map(toasts, (toast, id) => (
-            <Toast key={id} id={id} timeout={5000} onClose={dismissToast}>
-              <StyledDiv>
-                {toast.message}
-                <UndoButton
-                  onClick={function() {
-                    undoToast(id, otherProps[toast.undoAction], toast.context);
-                  }}
-                >
-                  Undo
-                </UndoButton>
-              </StyledDiv>
-            </Toast>
-          ))}
-        </ToastList>
-      </ToastInnerContainer>
-    </ToastOuterContainer>
+    <ToastWrapper>
+      <ToastOuterContainer>
+        <ToastInnerContainer>
+          <ToastList>
+            {map(toasts, (toast, id) => (
+              <Toast key={id} id={id} timeout={5000} onClose={dismissToast}>
+                <StyledDiv>
+                  {toast.message}
+                  <UndoButton
+                    onClick={function() {
+                      undoToast(
+                        id,
+                        otherProps[toast.undoAction],
+                        toast.context
+                      );
+                    }}
+                  >
+                    Undo
+                  </UndoButton>
+                </StyledDiv>
+              </Toast>
+            ))}
+          </ToastList>
+        </ToastInnerContainer>
+      </ToastOuterContainer>
+    </ToastWrapper>
   );
 };
 


### PR DESCRIPTION
### What is the context of this PR?
This PR fixes a few visual glitches with the toast.
- Fixes #259 
- Fixes #260
- Fixes #261  - In addition to z-index had to remove the transparent background on toast messages to prevent text from bleeding through.

### How to review 
Re-test the above defects to confirm they are fixed.