### PR TITLE
Add status page to the Author application.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-error.log*
 jsconfig.json
 
 graphql.config.json
+public/status.json

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "start": "yarn && node scripts/start.js",
     "start:mockAPI": "REACT_APP_USE_MOCK_API=true node scripts/start.js",
-    "build": "node scripts/build.js",
-    "build:mockAPI": "REACT_APP_USE_MOCK_API=true node scripts/build.js",
+    "build": "yarn build:status && node scripts/build.js",
+    "build:mockAPI":
+      "yarn build:status && REACT_APP_USE_MOCK_API=true node scripts/build.js",
+    "build:status": "node scripts/build-status-page.js",
     "test": "node scripts/test.js",
     "smoketest:author": "chimp config/chimp.author.js",
     "smoketest:storybook": "chimp config/chimp.storybook.js",
@@ -17,16 +19,14 @@
     "serve": "npm install -g serve && serve -p 3000 build/",
     "deploy": "npm run build && gh-pages -d build",
     "storybook": "export NODE_PATH=src/ && start-storybook -p 9001",
-    "storybook-build": "export NODE_PATH=src/ && build-storybook -s public -o storybook-static",
+    "storybook-build":
+      "export NODE_PATH=src/ && build-storybook -s public -o storybook-static",
     "storybook-deploy": "yarn storybook-build && gh-pages -d .out",
     "precommit": "lint-staged",
     "coverage": "yarn test -- --coverage"
   },
   "lint-staged": {
-    "*.js": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.js": ["prettier --write", "git add"]
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.12",
@@ -159,10 +159,9 @@
       "<rootDir>/config/polyfills.js",
       "<rootDir>/src/tests/setup/throwOnConsole.js"
     ],
-    "setupTestFrameworkScriptFile": "<rootDir>/src/tests/setup/JestTestSetup.js",
-    "snapshotSerializers": [
-      "<rootDir>/node_modules/enzyme-to-json/serializer"
-    ],
+    "setupTestFrameworkScriptFile":
+      "<rootDir>/src/tests/setup/JestTestSetup.js",
+    "snapshotSerializers": ["<rootDir>/node_modules/enzyme-to-json/serializer"],
     "testPathIgnorePatterns": [
       "<rootDir>[/\\\\](build|docs|node_modules|scripts)[/\\\\]"
     ],
@@ -173,22 +172,14 @@
       "\\.(gql|graphql)$": "jest-transform-graphql",
       "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
+    "transformIgnorePatterns": ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
     "moduleNameMapper": {
       "^react-native$": "react-native-web"
     },
-    "modulePaths": [
-      "<rootDir>/src/"
-    ]
+    "modulePaths": ["<rootDir>/src/"]
   },
   "babel": {
-    "presets": [
-      "react-app"
-    ]
+    "presets": ["react-app"]
   },
-  "moduleRoots": [
-    "./src"
-  ]
+  "moduleRoots": ["./src"]
 }

--- a/scripts/build-status-page.js
+++ b/scripts/build-status-page.js
@@ -1,0 +1,21 @@
+/* eslint-disable import/unambiguous, no-console */
+const process = require("child_process");
+const fs = require("fs");
+const chalk = require("chalk");
+
+const OUTPUT_PATH = "public/status.json";
+const rev = process
+  .execSync("git rev-parse HEAD")
+  .toString()
+  .trim();
+
+const status = {
+  status: "OK",
+  version: rev
+};
+
+fs.writeFileSync(OUTPUT_PATH, JSON.stringify(status, null, "  "));
+
+console.log(`
+Status file written to: ${chalk.green(OUTPUT_PATH)}
+`);


### PR DESCRIPTION
### What is the context of this PR?
This PR introduces a new `/#/status` route for the author application.
A `Status` component has been introduced which outputs simple text with a status of "OK" and the Git SHA-1 has if supplied.

### How to review 
Build a docker container on this branch using the following command:
```docker build -t onsdigital/eq-author:latest --build-arg APPLICATION_VERSION=$(git rev-parse HEAD) .```
Run the newly built author image pointing at a valid API url e.g.
```docker run -ti -e REACT_APP_API_URL=http://docker.for.mac.localhost:4000/graphql 127328c9b756``` (Replace *127328c9b756* with the image Id for onsdigital/eq-author:latest, which can be found by running `docker images`.
Navigate to the application running on port 3000. Browse to the `/#/status` endpoint.
You should see status OK and the Git SHA-1 hash for version.
