### PR TITLE
242 Visually Differentiate Input Types

### DIFF
--- a/src/components/Answers/CurrencyAnswer/__snapshots__/CurrencyAnswer.test.js.snap
+++ b/src/components/Answers/CurrencyAnswer/__snapshots__/CurrencyAnswer.test.js.snap
@@ -15,7 +15,7 @@ exports[`CurrencyAnswer should render 1`] = `
     <CurrencyComponent
       currencyUnit="£"
     />
-    <TextInput__DummyTextInput />
+    <DummyTextInput />
   </CurrencyAnswer__FieldWrapper>
 </withEntityEditor(StatelessBasicAnswer)>
 `;

--- a/src/components/Answers/CurrencyAnswer/index.js
+++ b/src/components/Answers/CurrencyAnswer/index.js
@@ -14,15 +14,17 @@ const StyledSpan = styled.span`
   width: 2.5em;
   font-weight: 700;
   font-size: 1em;
+  line-height: 1.1;
   text-align: center;
   position: absolute;
   left: 0;
   top: 0;
+  color: ${colors.lightGrey};
 `;
 
 const FieldWrapper = styled.div`
   display: block;
-  width: 100%;
+  width: 50%;
   margin-bottom: 1em;
   position: relative;
   overflow: hidden;

--- a/src/components/Answers/Dummy/DateRange/__snapshots__/index.test.js.snap
+++ b/src/components/Answers/Dummy/DateRange/__snapshots__/index.test.js.snap
@@ -18,36 +18,30 @@ exports[`Dummy/DateRange should render 1`] = `
 `;
 
 exports[`Dummy/DateRange should render dummy DatePicker 1`] = `
-<div>
-  <DateRange__Field
-    colWidth="25%"
-  >
+<DateRange__Flex>
+  <DateRange__Field>
     <DateRange__Label>
       Day
     </DateRange__Label>
-    <DateRange__Input>
-      DD
-    </DateRange__Input>
+    <DateRange__Input
+      placeholder="DD"
+    />
   </DateRange__Field>
-  <DateRange__Field
-    colWidth="50%"
-  >
+  <DateRange__SelectField>
     <DateRange__Label>
       Month
     </DateRange__Label>
-    <DateRange__Select>
-      Select month
-    </DateRange__Select>
-  </DateRange__Field>
-  <DateRange__Field
-    colWidth="25%"
-  >
+    <DateRange__Select
+      placeholder="Select month"
+    />
+  </DateRange__SelectField>
+  <DateRange__Field>
     <DateRange__Label>
       Year
     </DateRange__Label>
-    <DateRange__Input>
-      YYYY
-    </DateRange__Input>
+    <DateRange__Input
+      placeholder="YYYY"
+    />
   </DateRange__Field>
-</div>
+</DateRange__Flex>
 `;

--- a/src/components/Answers/Dummy/DateRange/index.js
+++ b/src/components/Answers/Dummy/DateRange/index.js
@@ -1,32 +1,29 @@
 import React from "react";
 import styled from "styled-components";
-import PropTypes from "prop-types";
 import DummyTextInput from "../TextInput";
 import { colors } from "constants/theme";
 import chevronIcon from "components/Accordion/chevron.svg";
 
-const GUTTER = "0.625em";
-
 const Field = styled.div`
   display: inline-block;
-  width: calc(${props => props.colWidth} - ${GUTTER});
-  margin-left: ${GUTTER};
+  margin-left: 1em;
+  flex: 1 1 auto;
 
   &:first-of-type {
     margin-left: 0;
   }
 `;
 
-Field.propTypes = {
-  colWidth: PropTypes.string.isRequired
-};
+const SelectField = styled(Field)`
+  flex: 3 3 auto;
+`;
 
 const Input = styled(DummyTextInput)`
-  width: auto;
-  border-radius: 3px;
-  padding: 0.875em 1em;
-  border-color: #bfbfbf;
-  color: #bfbfbf;
+  width: 100%;
+`;
+
+const Flex = styled.div`
+  display: flex;
 `;
 
 const Select = styled(Input)`
@@ -34,7 +31,10 @@ const Select = styled(Input)`
     content: url(${chevronIcon});
     position: absolute;
     right: 0.75em;
-    top: 0.75em;
+    top: 0;
+    bottom: 0;
+    margin: auto;
+    height: 1em;
   }
 `;
 
@@ -43,7 +43,7 @@ const Label = styled.p`
   font-size: 0.875em;
   font-weight: bold;
   margin-top: 0;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
 `;
 
 const Fieldset = styled.div`
@@ -63,20 +63,20 @@ const Legend = styled.p`
 `;
 
 export const DatePicker = () => (
-  <div>
-    <Field colWidth="25%">
+  <Flex>
+    <Field>
       <Label>Day</Label>
-      <Input>DD</Input>
+      <Input placeholder="DD" />
     </Field>
-    <Field colWidth="50%">
+    <SelectField>
       <Label>Month</Label>
-      <Select>Select month</Select>
-    </Field>
-    <Field colWidth="25%">
+      <Select placeholder="Select month" />
+    </SelectField>
+    <Field>
       <Label>Year</Label>
-      <Input>YYYY</Input>
+      <Input placeholder="YYYY" />
     </Field>
-  </div>
+  </Flex>
 );
 
 const StyledDateRange = styled.div.attrs({

--- a/src/components/Answers/Dummy/TextArea/__snapshots__/index.test.js.snap
+++ b/src/components/Answers/Dummy/TextArea/__snapshots__/index.test.js.snap
@@ -11,6 +11,7 @@ exports[`components/Answers/Dummy/TextArea shoulder render 1`] = `
   padding: 1.2em 1.2em 1.2em 2em;
   position: relative;
   background-color: transparent;
+  width: 50%;
   height: NaNem;
 }
 

--- a/src/components/Answers/Dummy/TextArea/index.js
+++ b/src/components/Answers/Dummy/TextArea/index.js
@@ -7,6 +7,7 @@ const DummyTextArea = styled.div`
   padding: 1.2em 1.2em 1.2em 2em;
   position: relative;
   background-color: transparent;
+  width: 50%;
   height: ${props => props.rows + 2}em;
 `;
 

--- a/src/components/Answers/Dummy/TextInput/__snapshots__/index.test.js.snap
+++ b/src/components/Answers/Dummy/TextInput/__snapshots__/index.test.js.snap
@@ -1,26 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components/Answers/Dummy/TextInput shoulder render 1`] = `
-.c0 {
-  padding: 0.7em;
-  width: 100%;
-  display: block;
-  border-radius: 2px;
-  border: 1px solid #EAEAEA;
-  font-size: 0.9em;
-  padding: 1.2em 1.2em 1.2em 2em;
-  position: relative;
-  background-color: transparent;
-  z-index: 0;
-  width: 50%;
-}
-
-.c0:focus {
-  outline: none;
-  border: 1px solid #61BDE0;
-}
-
-<div
-  className="c0"
-/>
-`;
+exports[`components/Answers/Dummy/TextInput shoulder render 1`] = `<TextInput />`;

--- a/src/components/Answers/Dummy/TextInput/index.js
+++ b/src/components/Answers/Dummy/TextInput/index.js
@@ -1,7 +1,9 @@
+import React from "react";
+import PropTypes from "prop-types";
 import styled from "styled-components";
 import { sharedStyles } from "components/Forms/css";
 
-const DummyTextInput = styled.div`
+const TextInput = styled.div`
   ${sharedStyles};
   padding: 1.2em 1.2em 1.2em 2em;
   position: relative;
@@ -9,5 +11,27 @@ const DummyTextInput = styled.div`
   z-index: 0;
   width: 50%;
 `;
+
+const Placeholder = styled.div`
+  position: absolute;
+  left: 1em;
+  top: 0;
+  bottom: 0;
+  height: 1em;
+  line-height: 1;
+  margin: auto;
+  color: #c5c5c5;
+`;
+
+const DummyTextInput = ({ placeholder, ...props }) => (
+  <TextInput {...props}>
+    {placeholder && <Placeholder>{placeholder}</Placeholder>}
+  </TextInput>
+);
+
+DummyTextInput.propTypes = {
+  placeholder: PropTypes.string,
+  children: PropTypes.node
+};
 
 export default DummyTextInput;

--- a/src/components/Answers/MultipleChoiceAnswer/index.js
+++ b/src/components/Answers/MultipleChoiceAnswer/index.js
@@ -11,7 +11,7 @@ import Button from "components/Button";
 import Option from "./Option";
 
 const AnswerWrapper = styled.div`
-  width: 25em;
+  width: 50%;
   margin: 0;
 `;
 

--- a/src/components/Answers/NumberAnswer/__snapshots__/NumberAnswer.test.js.snap
+++ b/src/components/Answers/NumberAnswer/__snapshots__/NumberAnswer.test.js.snap
@@ -11,8 +11,10 @@ exports[`NumberAnswer should render 1`] = `
   onChange={[Function]}
   onUpdate={[Function]}
 >
-  <div>
-    <TextInput__DummyTextInput />
-  </div>
+  <NumberAnswer__Width>
+    <DummyTextInput
+      placeholder="eg. 123"
+    />
+  </NumberAnswer__Width>
 </withEntityEditor(StatelessBasicAnswer)>
 `;

--- a/src/components/Answers/NumberAnswer/index.js
+++ b/src/components/Answers/NumberAnswer/index.js
@@ -1,12 +1,19 @@
 import React from "react";
+import styled from "styled-components";
 import BasicAnswer from "components/Answers/BasicAnswer";
 import DummyTextInput from "components/Answers/Dummy/TextInput";
 
-const NumberAnswer = props =>
+const Width = styled.div`
+  position: relative;
+  width: 50%;
+`;
+
+const NumberAnswer = props => (
   <BasicAnswer {...props}>
-    <div>
-      <DummyTextInput />
-    </div>
-  </BasicAnswer>;
+    <Width>
+      <DummyTextInput placeholder="eg. 123" />
+    </Width>
+  </BasicAnswer>
+);
 
 export default NumberAnswer;

--- a/src/components/Answers/TextAnswer/__snapshots__/TextAnswer.test.js.snap
+++ b/src/components/Answers/TextAnswer/__snapshots__/TextAnswer.test.js.snap
@@ -11,6 +11,6 @@ exports[`TextAnswer should render 1`] = `
   onChange={[Function]}
   onUpdate={[Function]}
 >
-  <TextInput__DummyTextInput />
+  <DummyTextInput />
 </withEntityEditor(StatelessBasicAnswer)>
 `;


### PR DESCRIPTION
### What is the context of this PR?

[Trello card](https://trello.com/c/NPM3FK6y/242-visually-differentiate-input-types)

Added styling to visually differentiate text and number dummy inputs. And make all inputs consistent sizes, colours etc

![screenshot 2017-11-29 16 24 02](https://user-images.githubusercontent.com/930398/33386091-1b745314-d522-11e7-98a4-2fac12a9d42f.png)


### How to review 

- Check styling aligns with that on the task


