### PR TITLE
inject git rev into container before generating status page inside

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
 after_success:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - export TAG=`if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "" ]; then echo "latest"; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi`
-  - docker build -t onsdigital/eq-author:$TAG -f Dockerfile .
+  - docker build -t onsdigital/eq-author:$TAG --build-arg APPLICATION_VERSION=$(git rev-parse HEAD) -f Dockerfile .
   - echo "Pushing with tag [$TAG]"
   - docker push onsdigital/eq-author:$TAG
   - bash <(curl -s https://codecov.io/bash) -e TRAVIS_NODE_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ WORKDIR /app
 
 RUN npm install -g serve
 
+ARG APPLICATION_VERSION
+ENV EQ_AUTHOR_VERSION $APPLICATION_VERSION
+
 ENTRYPOINT ["sh", "docker-entrypoint.sh"]
 
 # Install

--- a/scripts/build-status-page.js
+++ b/scripts/build-status-page.js
@@ -1,17 +1,12 @@
 /* eslint-disable import/unambiguous, no-console */
-const process = require("child_process");
 const fs = require("fs");
 const chalk = require("chalk");
 
 const OUTPUT_PATH = "public/status.json";
-const rev = process
-  .execSync("git rev-parse HEAD")
-  .toString()
-  .trim();
 
 const status = {
   status: "OK",
-  version: rev
+  version: process.env.EQ_AUTHOR_VERSION
 };
 
 fs.writeFileSync(OUTPUT_PATH, JSON.stringify(status, null, "  "));


### PR DESCRIPTION
### What is the context of this PR?
fixes issue with previous attempt.

git revision needs to be grabbed _outside_ of docker container, then injected _into_ container, as an env var, before the status page is generated inside

### How to review 
/shrug

```sh
docker build -t onsdigital/eq-author --build-arg APPLICATION_VERSION=$(git rev-parse HEAD) -f Dockerfile .

docker run -p 3000:3000 onsdigital/eq-author

curl http://localhost:3000/status.json
```
