### PR TITLE
Move tabs into the main canvas and update snapshots.

### DIFF
--- a/src/components/BaseLayout/__snapshots__/BaseLayout.test.js.snap
+++ b/src/components/BaseLayout/__snapshots__/BaseLayout.test.js.snap
@@ -28,25 +28,6 @@ exports[`components/BaseLayout should render a Nav 1`] = `
           }
         }
       />
-      <BaseLayout__NavWrapper>
-        <Grid
-          align="top"
-          fillHeight={false}
-        >
-          <Column
-            cols={12}
-            offset={2}
-          >
-            <withRouter(NavWithoutRouter)
-              questionnaire={
-                Object {
-                  "title": "Questionnaire",
-                }
-              }
-            />
-          </Column>
-        </Grid>
-      </BaseLayout__NavWrapper>
       <BaseLayout__Main>
         Children
       </BaseLayout__Main>

--- a/src/components/BaseLayout/index.js
+++ b/src/components/BaseLayout/index.js
@@ -4,12 +4,10 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import App from "components/App";
 import Header from "components/Header";
-import Nav from "components/Nav";
 import ScrollPane from "components/ScrollPane";
 import DocumentTitle from "react-document-title";
 
 import CustomPropTypes from "custom-prop-types";
-import { Grid, Column } from "components/Grid";
 import { colors } from "constants/theme";
 
 import ToastContainer from "containers/ToastContainer";
@@ -28,11 +26,6 @@ const Main = styled.main`
   flex-direction: column;
 `;
 
-const NavWrapper = styled.div`
-  background: white;
-  border-bottom: 1px solid ${colors.borders};
-`;
-
 const Title = styled.h1`
   font-size: 1.4em;
   font-weight: 700;
@@ -45,15 +38,6 @@ const BaseLayout = ({ children, title, questionnaire, docTitle }) => (
     <App>
       <Wrapper>
         <Header questionnaire={questionnaire} />
-        {questionnaire && (
-          <NavWrapper>
-            <Grid fillHeight={false}>
-              <Column offset={2}>
-                <Nav questionnaire={questionnaire} />
-              </Column>
-            </Grid>
-          </NavWrapper>
-        )}
         <Main>
           {title ? (
             <ScrollPane>

--- a/src/components/MainCanvas/__snapshots__/index.test.js.snap
+++ b/src/components/MainCanvas/__snapshots__/index.test.js.snap
@@ -2,9 +2,10 @@
 
 exports[`MainCanvas should render 1`] = `
 .c0 {
-  width: 100%;
   max-width: 50em;
-  margin: 2em auto 1em;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 1em;
   position: relative;
 }
 

--- a/src/components/MainCanvas/index.js
+++ b/src/components/MainCanvas/index.js
@@ -1,9 +1,10 @@
 import styled from "styled-components";
 
 const MainCanvas = styled.div`
-  width: 100%;
   max-width: 50em;
-  margin: 2em auto 1em;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 1em;
   position: relative;
 `;
 

--- a/src/components/Nav/__snapshots__/nav.test.js.snap
+++ b/src/components/Nav/__snapshots__/nav.test.js.snap
@@ -2,12 +2,11 @@
 
 exports[`components/Nav should display active link when route matches 1`] = `
 .c0 {
-  margin: 0;
-  display: block;
+  margin: 1.25em 0;
 }
 
 .c1 {
-  padding: 1em 1.5em;
+  padding-bottom: 0.25em;
   display: inline-block;
   cursor: pointer;
   font-size: 0.875em;
@@ -23,6 +22,7 @@ exports[`components/Nav should display active link when route matches 1`] = `
   border-color: rgba(5,108,153,0);
   border-style: solid;
   border-width: 0 0 2px;
+  margin-right: 2em;
 }
 
 .c1:hover {
@@ -30,6 +30,38 @@ exports[`components/Nav should display active link when route matches 1`] = `
 }
 
 .c1.selected {
+  color: #056C99;
+  border-color: rgba(5,108,153,1);
+}
+
+.c2 {
+  padding-bottom: 0.25em;
+  display: inline-block;
+  cursor: pointer;
+  font-size: 0.875em;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  color: #4A4A4A;
+  -webkit-transition: color 200ms ease-in-out;
+  transition: color 200ms ease-in-out;
+  text-decoration: none;
+  border-color: rgba(5,108,153,0);
+  border-style: solid;
+  border-width: 0 0 2px;
+  margin-right: 2em;
+  color: #056C99;
+  cursor: default;
+  opacity: 0.5;
+}
+
+.c2:hover {
+  color: #056C99;
+}
+
+.c2.selected {
   color: #056C99;
   border-color: rgba(5,108,153,1);
 }
@@ -42,6 +74,11 @@ exports[`components/Nav should display active link when route matches 1`] = `
       },
       "path": "",
       "url": "",
+    }
+  }
+  page={
+    Object {
+      "id": "3",
     }
   }
   questionnaire={
@@ -59,6 +96,17 @@ exports[`components/Nav should display active link when route matches 1`] = `
         },
       ],
       "title": "Questionnaire",
+    }
+  }
+  section={
+    Object {
+      "id": "2",
+      "pages": Array [
+        Object {
+          "id": "3",
+        },
+      ],
+      "title": "Section 1",
     }
   }
 >
@@ -104,6 +152,13 @@ exports[`components/Nav should display active link when route matches 1`] = `
           </Route>
         </NavLink>
       </Nav__StyledNavLink>
+      <Nav__StyledNavLink>
+        <span
+          className="c2"
+        >
+          Routing
+        </span>
+      </Nav__StyledNavLink>
     </nav>
   </Nav__StyledNav>
 </NavWithoutRouter>
@@ -111,12 +166,11 @@ exports[`components/Nav should display active link when route matches 1`] = `
 
 exports[`components/Nav should render Nav 1`] = `
 .c0 {
-  margin: 0;
-  display: block;
+  margin: 1.25em 0;
 }
 
 .c1 {
-  padding: 1em 1.5em;
+  padding-bottom: 0.25em;
   display: inline-block;
   cursor: pointer;
   font-size: 0.875em;
@@ -132,6 +186,7 @@ exports[`components/Nav should render Nav 1`] = `
   border-color: rgba(5,108,153,0);
   border-style: solid;
   border-width: 0 0 2px;
+  margin-right: 2em;
 }
 
 .c1:hover {
@@ -143,12 +198,49 @@ exports[`components/Nav should render Nav 1`] = `
   border-color: rgba(5,108,153,1);
 }
 
+.c2 {
+  padding-bottom: 0.25em;
+  display: inline-block;
+  cursor: pointer;
+  font-size: 0.875em;
+  font-weight: 400;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  color: #4A4A4A;
+  -webkit-transition: color 200ms ease-in-out;
+  transition: color 200ms ease-in-out;
+  text-decoration: none;
+  border-color: rgba(5,108,153,0);
+  border-style: solid;
+  border-width: 0 0 2px;
+  margin-right: 2em;
+  color: #056C99;
+  cursor: default;
+  opacity: 0.5;
+}
+
+.c2:hover {
+  color: #056C99;
+}
+
+.c2.selected {
+  color: #056C99;
+  border-color: rgba(5,108,153,1);
+}
+
 <NavWithoutRouter
   match={
     Object {
       "params": Object {},
       "path": "",
       "url": "",
+    }
+  }
+  page={
+    Object {
+      "id": "3",
     }
   }
   questionnaire={
@@ -166,6 +258,17 @@ exports[`components/Nav should render Nav 1`] = `
         },
       ],
       "title": "Questionnaire",
+    }
+  }
+  section={
+    Object {
+      "id": "2",
+      "pages": Array [
+        Object {
+          "id": "3",
+        },
+      ],
+      "title": "Section 1",
     }
   }
 >
@@ -210,6 +313,13 @@ exports[`components/Nav should render Nav 1`] = `
             </Link>
           </Route>
         </NavLink>
+      </Nav__StyledNavLink>
+      <Nav__StyledNavLink>
+        <span
+          className="c2"
+        >
+          Routing
+        </span>
       </Nav__StyledNavLink>
     </nav>
   </Nav__StyledNav>

--- a/src/components/Nav/index.js
+++ b/src/components/Nav/index.js
@@ -3,18 +3,16 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 import { NavLink, withRouter } from "react-router-dom";
 import { colors } from "constants/theme";
-import { get } from "lodash";
 import { getLink } from "utils/UrlUtils";
 
 import CustomPropsTypes from "custom-prop-types";
 
 export const StyledNav = styled.nav`
-  margin: 0;
-  display: block;
+  margin: 1.25em 0;
 `;
 
 const StyledNavLink = styled(NavLink)`
-  padding: 1em 1.5em;
+  padding-bottom: 0.25em;
   display: inline-block;
   cursor: pointer;
   font-size: 0.875em;
@@ -26,6 +24,7 @@ const StyledNavLink = styled(NavLink)`
   border-color: rgba(5, 108, 153, 0);
   border-style: solid;
   border-width: 0 0 2px;
+  margin-right: 2em;
 
   &:hover {
     color: ${colors.blue};
@@ -37,15 +36,17 @@ const StyledNavLink = styled(NavLink)`
   }
 `;
 
+const DisabledNavLink = StyledNavLink.withComponent("span").extend`
+  color: ${colors.blue};
+  cursor: default;
+  opacity: 0.5;
+`;
+
 // TODO: find out why route matching doesn't work automatically
 // Given a route /foo/:bar/blah
 // I would expect that /foo, /foo/1/blah, /foo/2/blah etc would all "match"
 // But this is not the case. Unsure if bug or implementation issue
-export const NavWithoutRouter = ({ questionnaire, match }) => {
-  const { id } = questionnaire;
-  const section = get(questionnaire, "sections[0]", {});
-  const page = get(section, "pages[0]", {});
-
+export const NavWithoutRouter = ({ questionnaire, section, page, match }) => {
   const navIsActive = () => {
     return match.params.sectionId;
   };
@@ -53,18 +54,21 @@ export const NavWithoutRouter = ({ questionnaire, match }) => {
   return (
     <StyledNav>
       <StyledNavLink
-        to={getLink(id, section.id, page.id)}
+        to={getLink(questionnaire.id, section.id, page.id)}
         activeClassName="selected"
         isActive={navIsActive}
       >
         Builder
       </StyledNavLink>
+      <DisabledNavLink>Routing</DisabledNavLink>
     </StyledNav>
   );
 };
 
 NavWithoutRouter.propTypes = {
   questionnaire: CustomPropsTypes.questionnaire,
+  section: CustomPropsTypes.section,
+  page: CustomPropsTypes.page,
   match: PropTypes.shape({
     params: PropTypes.object.isRequired
   })

--- a/src/components/Nav/nav.test.js
+++ b/src/components/Nav/nav.test.js
@@ -11,7 +11,11 @@ const questionnaire = {
     {
       id: "2",
       title: "Section 1",
-      pages: [{ id: "3" }]
+      pages: [
+        {
+          id: "3"
+        }
+      ]
     }
   ]
 };
@@ -21,7 +25,12 @@ const match = { params: {}, path: "", url: "" };
 describe("components/Nav", () => {
   beforeEach(() => {
     wrapper = mountWithRouter(
-      <NavWithoutRouter questionnaire={questionnaire} match={match} />
+      <NavWithoutRouter
+        questionnaire={questionnaire}
+        section={questionnaire.sections[0]}
+        page={questionnaire.sections[0].pages[0]}
+        match={match}
+      />
     );
   });
 

--- a/src/containers/QuestionnaireDesignPage/QuestionnaireDesignPage.js
+++ b/src/containers/QuestionnaireDesignPage/QuestionnaireDesignPage.js
@@ -10,6 +10,7 @@ import EditorSurface from "components/EditorSurface";
 import QuestionnaireNavContainer from "containers/QuestionnaireNavContainer";
 import getTextFromHTML from "utils/getTextFromHTML";
 import ConnectedPropertiesPanel from "components/PropertiesPanel";
+import Nav from "components/Nav";
 
 export class QuestionnaireDesignPage extends Component {
   static propTypes = {
@@ -76,6 +77,11 @@ export class QuestionnaireDesignPage extends Component {
           <Column gutters={false}>
             <ScrollPane>
               <MainCanvas>
+                <Nav
+                  questionnaire={questionnaire}
+                  section={section}
+                  page={page}
+                />
                 <EditorSurface
                   section={section}
                   page={page}

--- a/src/containers/QuestionnaireDesignPage/__snapshots__/QuestionnaireDesignPage.test.js.snap
+++ b/src/containers/QuestionnaireDesignPage/__snapshots__/QuestionnaireDesignPage.test.js.snap
@@ -90,6 +90,86 @@ exports[`QuestionnaireDesignPage should render form when loaded 1`] = `
     >
       <ScrollPane>
         <MainCanvas>
+          <withRouter(NavWithoutRouter)
+            page={
+              Object {
+                "answers": Array [
+                  Object {
+                    "id": "1",
+                    "label": "",
+                    "options": Array [
+                      Object {
+                        "id": "1",
+                      },
+                    ],
+                  },
+                ],
+                "description": "",
+                "guidance": "",
+                "id": "1",
+                "title": "",
+                "type": "General",
+              }
+            }
+            questionnaire={
+              Object {
+                "id": "3",
+                "sections": Array [
+                  Object {
+                    "id": "2",
+                    "pages": Array [
+                      Object {
+                        "answers": Array [
+                          Object {
+                            "id": "1",
+                            "label": "",
+                            "options": Array [
+                              Object {
+                                "id": "1",
+                              },
+                            ],
+                          },
+                        ],
+                        "description": "",
+                        "guidance": "",
+                        "id": "1",
+                        "title": "",
+                        "type": "General",
+                      },
+                    ],
+                    "title": "",
+                  },
+                ],
+                "title": "hello world",
+              }
+            }
+            section={
+              Object {
+                "id": "2",
+                "pages": Array [
+                  Object {
+                    "answers": Array [
+                      Object {
+                        "id": "1",
+                        "label": "",
+                        "options": Array [
+                          Object {
+                            "id": "1",
+                          },
+                        ],
+                      },
+                    ],
+                    "description": "",
+                    "guidance": "",
+                    "id": "1",
+                    "title": "",
+                    "type": "General",
+                  },
+                ],
+                "title": "",
+              }
+            }
+          />
           <EditorSurface
             onUpdatePage={[Function]}
             onUpdateSection={[Function]}


### PR DESCRIPTION
### What is the context of this PR?
Move the tabs into the main editing canvas. Previously the tabs occupied their own toolbar which was taking up precious screen real-estate.
This PR moves the tabs down into the main editing canvas. Routing tab does not exist at the moment.
Updated the relevant snapshots.

### How to review 
All checks and tests should pass.
Visually inspect that tabs are now appearing in the main editing canvas and matches the design on the Trello card.
