### PR TITLE
Separate panels on main editing canvas.

### DIFF
--- a/src/components/AnswerTypeSelector/AnswerTypeGrid.js
+++ b/src/components/AnswerTypeSelector/AnswerTypeGrid.js
@@ -21,6 +21,7 @@ const Menu = styled.div`
   background-color: white;
   box-shadow: rgba(0, 0, 0, 0.16) 0 5px 20px 0;
   width: 340px;
+  text-align: initial;
 `;
 
 const Header = styled.div`

--- a/src/components/AnswerTypeSelector/AnswerTypeSelector.test.js
+++ b/src/components/AnswerTypeSelector/AnswerTypeSelector.test.js
@@ -9,10 +9,17 @@ let component, handleSelect;
 describe("components/AnswerTypeSelector", () => {
   beforeEach(() => {
     handleSelect = jest.fn();
-    component = shallow(<AnswerTypeSelector onSelect={handleSelect} />);
+    component = shallow(
+      <AnswerTypeSelector onSelect={handleSelect} answers={[]} />
+    );
   });
 
   it("shouldn't render content when closed", () => {
+    expect(component).toMatchSnapshot();
+  });
+
+  it("should say to add 'another' answer if > 0 answers currently", () => {
+    component.setProps({ answers: [{}] });
     expect(component).toMatchSnapshot();
   });
 

--- a/src/components/AnswerTypeSelector/__snapshots__/AnswerTypeSelector.test.js.snap
+++ b/src/components/AnswerTypeSelector/__snapshots__/AnswerTypeSelector.test.js.snap
@@ -11,7 +11,32 @@ exports[`components/AnswerTypeSelector should render content when open 1`] = `
       id="add-answer-btn"
       type="button"
     >
-      Add an answer
+      Add 
+      an
+       answer
+    </AnswerTypeSelector__AddAnswerBtn>
+  }
+>
+  <AnswerTypeGrid
+    onSelect={[Function]}
+  />
+</Popout>
+`;
+
+exports[`components/AnswerTypeSelector should say to add 'another' answer if > 0 answers currently 1`] = `
+<Popout
+  onEntered={[Function]}
+  onToggleOpen={[Function]}
+  open={false}
+  transition={[Function]}
+  trigger={
+    <AnswerTypeSelector__AddAnswerBtn
+      id="add-answer-btn"
+      type="button"
+    >
+      Add 
+      another
+       answer
     </AnswerTypeSelector__AddAnswerBtn>
   }
 >
@@ -32,7 +57,9 @@ exports[`components/AnswerTypeSelector shouldn't render content when closed 1`] 
       id="add-answer-btn"
       type="button"
     >
-      Add an answer
+      Add 
+      an
+       answer
     </AnswerTypeSelector__AddAnswerBtn>
   }
 >

--- a/src/components/AnswerTypeSelector/index.js
+++ b/src/components/AnswerTypeSelector/index.js
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import { colors } from "constants/theme";
 import AnswerTypeGrid from "./AnswerTypeGrid";
 import addIcon from "./icon-add.svg";
+import CustomPropTypes from "../../custom-prop-types";
 
 export const AddAnswerBtn = styled.button`
   appearance: none;
@@ -30,7 +31,8 @@ export const AddAnswerBtn = styled.button`
 
 export default class AnswerTypeSelector extends React.Component {
   static propTypes = {
-    onSelect: PropTypes.func.isRequired
+    onSelect: PropTypes.func.isRequired,
+    answers: PropTypes.arrayOf(CustomPropTypes.answer).isRequired
   };
 
   state = {
@@ -56,7 +58,7 @@ export default class AnswerTypeSelector extends React.Component {
   render() {
     const trigger = (
       <AddAnswerBtn type="button" id="add-answer-btn">
-        Add an answer
+        Add {this.props.answers.length === 0 ? "an" : "another"} answer
       </AddAnswerBtn>
     );
 

--- a/src/components/EditorSurface/CanvasSection.js
+++ b/src/components/EditorSurface/CanvasSection.js
@@ -17,6 +17,7 @@ export const BasicSection = styled.div`
   background-color: white;
   position: relative;
   box-shadow: ${shadow};
+  margin-bottom: 1em !important;
 `;
 
 const FocusableSection = styled(BasicSection)`

--- a/src/components/Popout/Popout.test.js
+++ b/src/components/Popout/Popout.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow, mount } from "enzyme";
-import Popout from "./";
+import Popout from "components/Popout";
 
 let component, handleToggleOpen, trigger;
 

--- a/src/components/QuestionPageEditor/__snapshots__/QuestionPageEditor.test.js.snap
+++ b/src/components/QuestionPageEditor/__snapshots__/QuestionPageEditor.test.js.snap
@@ -95,6 +95,24 @@ exports[`Question Page Editor should render 1`] = `
   </TransitionGroup>
   <CanvasSection__BasicSection>
     <AnswerTypeSelector
+      answers={
+        Array [
+          Object {
+            "__typename": "BasicAnswer",
+            "description": "",
+            "id": "1",
+            "title": "First name",
+            "type": "TextField",
+          },
+          Object {
+            "__typename": "BasicAnswer",
+            "description": "",
+            "id": "2",
+            "title": "Last name",
+            "type": "TextField",
+          },
+        ]
+      }
       onSelect={[Function]}
     />
   </CanvasSection__BasicSection>

--- a/src/components/QuestionPageEditor/index.js
+++ b/src/components/QuestionPageEditor/index.js
@@ -23,6 +23,11 @@ import withDeleteOption from "containers/enhancers/withDeleteOption";
 import * as ToastActionCreators from "redux/toast/actions";
 import { connect } from "react-redux";
 
+const AddAnswerSection = BasicSection.extend`
+  text-align: center;
+  padding: 1em;
+`;
+
 export class QPE extends React.Component {
   static propTypes = {
     onUpdateAnswer: PropTypes.func.isRequired,
@@ -82,9 +87,12 @@ export class QPE extends React.Component {
             </SlideTransition>
           ))}
         </TransitionGroup>
-        <BasicSection>
-          <AnswerTypeSelector onSelect={this.handleAddAnswer} />
-        </BasicSection>
+        <AddAnswerSection>
+          <AnswerTypeSelector
+            onSelect={this.handleAddAnswer}
+            answers={page.answers}
+          />
+        </AddAnswerSection>
       </div>
     );
   }


### PR DESCRIPTION
### What is the context of this PR?
Visual change to separate the panels on the main editing canvas.
Also the add answer button has been re-named to "Add another answer", centered and now spans the entire width of the section as per the new design.

### How to review 
Ensure that the visual changes match the design attached to the trello card.
All existing checks and tests should continue to pass.
