### PR TITLE
Tweak codecov config - 90% target, 0.25% threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,8 +2,8 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: null
+        target: 90%
+        threshold: 0.25%
         base: auto
 
 comment: off


### PR DESCRIPTION
### What is the context of this PR?
We have a high level code coverage, and codecov is currently configured to expect a constant upwards trend. It is more reasonable and practical to have a lower bound, combined with a threshold, so small dips are permissible but we keep coverage high.

### How to review 
Ensure configuration is reasonable and codecov passes
