### PR TITLE
Fixed the focus style issue on the add question button.

### DIFF
--- a/src/components/NavigationSidebar/SectionNavItem.js
+++ b/src/components/NavigationSidebar/SectionNavItem.js
@@ -22,6 +22,8 @@ export const AddPageBtn = styled.button`
   color: ${textInverted};
   font-weight: bold;
   font-size: 0.75em;
+  margin-bottom: 0.35em;
+  width: 100%;
 
   &::before {
     font-size: 1.25em;


### PR DESCRIPTION
### What is the context of this PR?
To change the style of the nav bar to bring the focus style of the add question button into line with the rest of the nav bar focus styles.

### How to review 
Should pass all tests and the focus style of the add question button should look the same as the page link focus styles. 
Also this blue line should no longer exist.
![image](https://user-images.githubusercontent.com/35268220/35806484-964f5b76-0a77-11e8-9027-077d84c12450.png)
