### PR TITLE
Fix broken storybook deployment step on travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
   - yarn lint
   - yarn coverage
   - ./scripts/run_smoketests_author.sh
+  - yarn storybook-build
 
 after_success:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD


### PR DESCRIPTION
### What is the context of this PR?
I noticed that the master branch was failing to build successfully on Travis.
Recent changes introduced removed the building of the storybook. The deployment was failing because the storybook static directory was not found.
This PR adds a step to the travis build so that the storybook site is at least being built.

### How to review 
Ensure that travis builds storybook. Deployment should succeed when merged into master.
