### PR TITLE
Fix missing "created by" on Questionnaires list page

### DIFF
--- a/cypress/integration/author_spec.js
+++ b/cypress/integration/author_spec.js
@@ -18,8 +18,21 @@ describe("eq-author", () => {
 
   it("can create a questionnaire", () => {
     cy.get("[data-test='create-questionnaire']").click();
-    setQuestionnaireSettings("Title");
+    setQuestionnaireSettings("My Questionnaire Title");
     cy.hash().should("match", /questionnaire\/(\d+)\/design\//);
+  });
+
+  it("should show questionnaire on listing page", () => {
+    cy.get(`[data-test="logo"]`).click();
+
+    cy.get(`[data-test="username"]`).then($name => {
+      cy
+        .get("tbody tr")
+        .should("contain", "My Questionnaire Title")
+        .and("contain", $name.text())
+        .find("a")
+        .click();
+    });
   });
 
   it("can edit section title", () => {

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ Object {
       "createdAt": "2018-01-01",
       "createdBy": Object {
         "__typename": "User",
-        "name": "",
+        "name": "Integration test",
         Symbol(id): "$Questionnaire1.createdBy",
       },
       "id": "1",

--- a/src/components/Header/__snapshots__/Header.test.js.snap
+++ b/src/components/Header/__snapshots__/Header.test.js.snap
@@ -10,6 +10,7 @@ exports[`components/Header renders correctly  1`] = `
       cols={2}
     >
       <Header__Logo
+        data-test="logo"
         to="/"
       >
         <img

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -70,7 +70,7 @@ export class UnconnectedHeader extends React.Component {
       <StyledHeader>
         <Grid align="center">
           <Column cols={2}>
-            <Logo to="/">
+            <Logo to="/" data-test="logo">
               <img src={logo} alt="Author" />
             </Logo>
           </Column>

--- a/src/components/UserProfile/__snapshots__/index.test.js.snap
+++ b/src/components/UserProfile/__snapshots__/index.test.js.snap
@@ -13,7 +13,9 @@ exports[`UserProfile should render 1`] = `
       role="presentation"
       src="http://foo.b.ar/photo.jpg"
     />
-    <UserProfile__UserName>
+    <UserProfile__UserName
+      data-test="username"
+    >
       Foo Bar
     </UserProfile__UserName>
   </UserProfile__LogoutButton>

--- a/src/components/UserProfile/index.js
+++ b/src/components/UserProfile/index.js
@@ -31,7 +31,7 @@ const UserProfile = ({ user, onSignOut }) => (
         alt=""
         role="presentation"
       />
-      <UserName>{user.displayName}</UserName>
+      <UserName data-test="username">{user.displayName}</UserName>
     </LogoutButton>
   </Tooltip>
 );

--- a/src/containers/QuestionnairesPage/index.js
+++ b/src/containers/QuestionnairesPage/index.js
@@ -5,9 +5,14 @@ import withDeleteQuestionnaire from "../enhancers/withDeleteQuestionnaire";
 import withCreateQuestionnaire from "../enhancers/withCreateQuestionnaire";
 import { raiseToast } from "redux/toast/actions";
 import { connect } from "react-redux";
+import { getUser } from "redux/auth/reducer";
+
+const mapStateToProps = state => ({
+  user: getUser(state)
+});
 
 export default flowRight(
-  connect(null, { raiseToast }),
+  connect(mapStateToProps, { raiseToast }),
   withQuestionnaireList,
   withCreateQuestionnaire,
   withDeleteQuestionnaire // relies on raiseToast to display undo

--- a/src/tests/utils/MockDataStore.js
+++ b/src/tests/utils/MockDataStore.js
@@ -55,7 +55,10 @@ class MockDataStore {
     this.questionnaires[id] = merge(questionnaire, {
       id,
       sections: [],
-      createdAt: dateWithoutTime
+      createdAt: dateWithoutTime,
+      createdBy: {
+        name: questionnaire.createdBy
+      }
     });
 
     const defaultSection = this.createSection({


### PR DESCRIPTION
### What is the context of this PR?
The user's display name wasn't being supplied when creating a questionnaire, so it would be displayed as "Unknown" when listing questionnaires.

Unfortunately it's difficult/impossible to write a unit test for this. I added a test to our cypress suite to cover this instead.

The basic fix was to pull the user from the store in the `QuestionnairesPage` container. To get the test passing with mock API I needed to also modify the `MockDataStore` as it didn't support createdBy. This test passes with both mock and real API.

### How to review 
Tests pass, code looks good
