### PR TITLE
Fixed the broken Cypress test

### DIFF
--- a/cypress/integration/author_spec.js
+++ b/cypress/integration/author_spec.js
@@ -28,6 +28,7 @@ describe("eq-author", () => {
     cy.get(`[data-test="username"]`).then($name => {
       cy
         .get("tbody tr")
+        .last()
         .should("contain", "My Questionnaire Title")
         .and("contain", $name.text())
         .find("a")


### PR DESCRIPTION
### What is the context of this PR?
Cypress tests were broken: "should show questionnaire on listing page" was selecting all questionnaire elements on the page so broke when run on a application with more than one questionnaire saved.

### How to review 
Cypress tests should pass both locally and on Travis
