### PR TITLE
Fix guidance not being persisted to API

### DIFF
--- a/cypress/integration/author_spec.js
+++ b/cypress/integration/author_spec.js
@@ -66,6 +66,23 @@ describe("eq-author", () => {
     cy.get("[data-test='page-item']").should("have.length", 2);
   });
 
+  it("can edit question guidance", () => {
+    const guidance = "this is some guidance";
+    typeIntoDraftEditor("[data-testid='txt-question-guidance']", guidance);
+
+    cy
+      .get(`[data-test="page-item"]`)
+      .first()
+      .click();
+
+    cy
+      .get(`[data-test="page-item"]`)
+      .last()
+      .click();
+
+    cy.get("[data-testid='txt-question-guidance']").should("contain", guidance);
+  });
+
   it("can delete a page", () => {
     cy.get("[data-test='btn-delete']").click();
     cy.get("[data-test='btn-delete-modal']").click();

--- a/src/components/QuestionPageEditor/MetaEditor.js
+++ b/src/components/QuestionPageEditor/MetaEditor.js
@@ -73,7 +73,7 @@ export class StatelessMetaEditor extends React.Component {
             testSelector="txt-question-description"
           />
         </Field>
-        <Field>
+        <Field id="guidance">
           <GuidanceRichTextEditor
             placeholder="Include / exclude guidance (optional)…"
             value={page.guidance}

--- a/src/components/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
+++ b/src/components/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
@@ -42,7 +42,9 @@ exports[`MetaEditor should render 1`] = `
       value="Page description"
     />
   </Field>
-  <Field>
+  <Field
+    id="guidance"
+  >
     <MetaEditor__GuidanceRichTextEditor
       controls={
         Object {


### PR DESCRIPTION
### What is the context of this PR?
Fixes bug where question guidance would not be persisted to API. Adds test to prevent regression.

### How to review 
Change looks good, tests pass