### PR TITLE
Enable pressing ENTER to add additional options.

### DIFF
--- a/src/components/Answers/MultipleChoiceAnswer/MultipleChoiceAnswer.story.js
+++ b/src/components/Answers/MultipleChoiceAnswer/MultipleChoiceAnswer.story.js
@@ -5,19 +5,27 @@ import { action } from "@storybook/addon-actions";
 import { reject } from "lodash";
 import MultipleChoiceAnswer from "./index";
 import { CHECKBOX, RADIO } from "constants/answer-types";
+import styled from "styled-components";
+
+const Wrapper = styled.div`
+  padding: 1em;
+  width: 80%;
+`;
 
 const options = [
   {
     id: "0",
     label: "",
     value: "",
-    description: ""
+    description: "",
+    __typename: "Option"
   },
   {
     id: "1",
     label: "",
     value: "",
-    description: ""
+    description: "",
+    __typename: "Option"
   }
 ];
 
@@ -41,7 +49,8 @@ class MultipleChoiceAnswerWrapper extends React.Component {
     const { answer } = this.state;
     const newOption = {
       ...options[0],
-      id: (++this.nextId).toString()
+      id: (++this.nextId).toString(),
+      __typename: "Option"
     };
 
     const newState = {
@@ -52,6 +61,8 @@ class MultipleChoiceAnswerWrapper extends React.Component {
     };
 
     this.setState(newState);
+
+    return Promise.resolve(newOption);
   };
 
   handleDeleteOption = id => {
@@ -69,15 +80,17 @@ class MultipleChoiceAnswerWrapper extends React.Component {
 
   render() {
     return (
-      <MultipleChoiceAnswer
-        type={this.props.type}
-        answer={this.state.answer}
-        onUpdateOption={action("update option")}
-        onUpdate={action("update")}
-        onChange={action("change")}
-        onAddOption={this.handleAddOption}
-        onDeleteOption={this.handleDeleteOption}
-      />
+      <Wrapper>
+        <MultipleChoiceAnswer
+          type={this.props.type}
+          answer={this.state.answer}
+          onUpdateOption={action("update option")}
+          onUpdate={action("update")}
+          onChange={action("change")}
+          onAddOption={this.handleAddOption}
+          onDeleteOption={this.handleDeleteOption}
+        />
+      </Wrapper>
     );
   }
 }

--- a/src/components/Answers/MultipleChoiceAnswer/MultipleChoiceAnswer.test.js
+++ b/src/components/Answers/MultipleChoiceAnswer/MultipleChoiceAnswer.test.js
@@ -16,7 +16,8 @@ describe("MultipleChoiceAnswer", () => {
       {
         id: "1",
         label: "",
-        description: ""
+        description: "",
+        __typename: "Option"
       }
     ]
   };
@@ -26,18 +27,20 @@ describe("MultipleChoiceAnswer", () => {
     __typename: "Option"
   };
 
-  let mockHandlers = {
-    onAddOption: jest.fn(() => Promise.resolve(option)),
-    onUpdate: jest.fn(),
-    onUpdateOption: jest.fn(),
-    onDeleteOption: jest.fn(),
-    onChange: jest.fn()
-  };
+  let mockHandlers;
 
   const createWrapper = ({ answer }, render = shallow) =>
     render(<MultipleChoiceAnswer {...mockHandlers} answer={answer} />);
 
   beforeEach(() => {
+    mockHandlers = {
+      onAddOption: jest.fn(() => Promise.resolve(option)),
+      onUpdate: jest.fn(),
+      onUpdateOption: jest.fn(),
+      onDeleteOption: jest.fn(),
+      onChange: jest.fn()
+    };
+
     wrapper = createWrapper({ answer });
   });
 
@@ -104,6 +107,15 @@ describe("MultipleChoiceAnswer", () => {
         optionId,
         answer.id
       );
+    });
+
+    it("should add a new option onEnterKey", () => {
+      wrapper
+        .find(Option)
+        .first()
+        .simulate("enterKey", { preventDefault: jest.fn() });
+
+      expect(mockHandlers.onAddOption).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Answers/MultipleChoiceAnswer/Option.js
+++ b/src/components/Answers/MultipleChoiceAnswer/Option.js
@@ -11,6 +11,9 @@ import Tooltip from "components/Tooltip";
 import { CHECKBOX, RADIO } from "constants/answer-types";
 import { get } from "lodash";
 import optionFragment from "graphql/fragments/option.graphql";
+import getIdForObject from "utils/getIdForObject";
+
+const ENTER_KEY = 13;
 
 export const DeleteContainer = styled.div`
   padding: 0.2em;
@@ -104,12 +107,19 @@ export class StatelessOption extends Component {
     onChange: PropTypes.func.isRequired,
     onUpdate: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
+    onEnterKey: PropTypes.func,
     hasDeleteButton: PropTypes.bool.isRequired,
     type: PropTypes.oneOf([RADIO, CHECKBOX]).isRequired
   };
 
   handleDeleteClick = e => {
     this.props.onDelete(this.props.option.id);
+  };
+
+  handleKeyDown = e => {
+    if (e.keyCode === ENTER_KEY) {
+      this.props.onEnterKey(e);
+    }
   };
 
   renderDeleteButton() {
@@ -131,7 +141,7 @@ export class StatelessOption extends Component {
     const { hasDeleteButton, option, onChange, onUpdate, type } = this.props;
 
     return (
-      <StyledOption key={option.id}>
+      <StyledOption id={getIdForObject(option)} key={option.id}>
         <LabelField>
           <DummyInput type={type} />
           <SeamlessLabel
@@ -141,6 +151,7 @@ export class StatelessOption extends Component {
             value={option.label}
             onChange={onChange}
             onBlur={onUpdate}
+            onKeyDown={this.handleKeyDown}
             data-test="option-label"
             data-autofocus
           />
@@ -152,6 +163,7 @@ export class StatelessOption extends Component {
             onChange={onChange}
             value={option.description}
             onBlur={onUpdate}
+            onKeyDown={this.handleKeyDown}
             data-test="option-description"
           />
         </Field>

--- a/src/components/Answers/MultipleChoiceAnswer/Option.test.js
+++ b/src/components/Answers/MultipleChoiceAnswer/Option.test.js
@@ -6,6 +6,7 @@ import DeleteButton from "components/DeleteButton";
 import { CHECKBOX, RADIO } from "constants/answer-types";
 
 import { shallow, mount } from "enzyme";
+import { merge } from "lodash";
 
 describe("Option", () => {
   let mockMutations;
@@ -15,7 +16,8 @@ describe("Option", () => {
   const option = {
     id: "1",
     label: "",
-    description: ""
+    description: "",
+    __typename: "Option"
   };
 
   const render = (method = shallow, otherProps) => {
@@ -42,7 +44,8 @@ describe("Option", () => {
       onChange: jest.fn(),
       onUpdate: jest.fn(),
       onFocus: jest.fn(),
-      onDelete: jest.fn()
+      onDelete: jest.fn(),
+      onEnterKey: jest.fn()
     };
 
     render();
@@ -97,5 +100,23 @@ describe("Option", () => {
     wrapper.find(DeleteButton).simulate("click", mockEvent);
 
     expect(mockMutations.onDelete).toHaveBeenCalledWith(option.id);
+  });
+
+  it("should call onEnterKey when Enter key pressed", () => {
+    wrapper
+      .find(WrappingInput)
+      .first()
+      .simulate("keyDown", merge(mockEvent, { keyCode: 13 }));
+
+    expect(mockMutations.onEnterKey).toHaveBeenCalledWith(mockEvent);
+  });
+
+  it("should not call onEnterKey when other keys are pressed", () => {
+    wrapper
+      .find(WrappingInput)
+      .first()
+      .simulate("keyDown", merge(mockEvent, { keyCode: 27 }));
+
+    expect(mockMutations.onEnterKey).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Answers/MultipleChoiceAnswer/__snapshots__/MultipleChoiceAnswer.test.js.snap
+++ b/src/components/Answers/MultipleChoiceAnswer/__snapshots__/MultipleChoiceAnswer.test.js.snap
@@ -7,6 +7,7 @@ exports[`MultipleChoiceAnswer should match snapshot 1`] = `
       "id": "0",
       "options": Array [
         Object {
+          "__typename": "Option",
           "description": "",
           "id": "1",
           "label": "",
@@ -33,9 +34,11 @@ exports[`MultipleChoiceAnswer should match snapshot 1`] = `
           onAddOption={[Function]}
           onDelete={[Function]}
           onDeleteOption={[Function]}
+          onEnterKey={[Function]}
           onUpdate={[Function]}
           option={
             Object {
+              "__typename": "Option",
               "description": "",
               "id": "1",
               "label": "",

--- a/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Option should match snapshot 1`] = `
 <Option__StyledOption
   duration={200}
+  id="Option1"
   key="1"
 >
   <Option__LabelField>
@@ -15,6 +16,7 @@ exports[`Option should match snapshot 1`] = `
       name="label"
       onBlur={[Function]}
       onChange={[Function]}
+      onKeyDown={[Function]}
       placeholder="Label"
       size="medium"
       value=""
@@ -26,6 +28,7 @@ exports[`Option should match snapshot 1`] = `
       name="description"
       onBlur={[Function]}
       onChange={[Function]}
+      onKeyDown={[Function]}
       placeholder="Optional description"
       value=""
     />
@@ -250,10 +253,12 @@ exports[`Option should render a checkbox 1`] = `
   hasDeleteButton={true}
   onChange={[Function]}
   onDelete={[Function]}
+  onEnterKey={[Function]}
   onFocus={[Function]}
   onUpdate={[Function]}
   option={
     Object {
+      "__typename": "Option",
       "description": "",
       "id": "1",
       "label": "",
@@ -263,10 +268,12 @@ exports[`Option should render a checkbox 1`] = `
 >
   <Option__StyledOption
     duration={200}
+    id="Option1"
     key="1"
   >
     <div
       className="c0"
+      id="Option1"
     >
       <Option__LabelField>
         <Field
@@ -294,6 +301,7 @@ exports[`Option should render a checkbox 1`] = `
                 name="label"
                 onBlur={[Function]}
                 onChange={[Function]}
+                onKeyDown={[Function]}
                 placeholder="Label"
                 size="medium"
                 value=""
@@ -305,6 +313,7 @@ exports[`Option should render a checkbox 1`] = `
                   name="label"
                   onBlur={[Function]}
                   onChange={[Function]}
+                  onKeyDown={[Function]}
                   placeholder="Label"
                   size="medium"
                   value=""
@@ -316,6 +325,7 @@ exports[`Option should render a checkbox 1`] = `
                     name="label"
                     onBlur={[Function]}
                     onChange={[Function]}
+                    onKeyDown={[Function]}
                     placeholder="Label"
                     size="medium"
                     value=""
@@ -383,6 +393,7 @@ exports[`Option should render a checkbox 1`] = `
               name="description"
               onBlur={[Function]}
               onChange={[Function]}
+              onKeyDown={[Function]}
               placeholder="Optional description"
               value=""
             >
@@ -391,6 +402,7 @@ exports[`Option should render a checkbox 1`] = `
                 name="description"
                 onBlur={[Function]}
                 onChange={[Function]}
+                onKeyDown={[Function]}
                 placeholder="Optional description"
                 size="small"
                 value=""
@@ -515,6 +527,7 @@ exports[`Option should render a checkbox 1`] = `
 exports[`Option shouldn't render delete button if not applicable 1`] = `
 <Option__StyledOption
   duration={200}
+  id="Option1"
   key="1"
 >
   <Option__LabelField>
@@ -527,6 +540,7 @@ exports[`Option shouldn't render delete button if not applicable 1`] = `
       name="label"
       onBlur={[Function]}
       onChange={[Function]}
+      onKeyDown={[Function]}
       placeholder="Label"
       size="medium"
       value=""
@@ -538,6 +552,7 @@ exports[`Option shouldn't render delete button if not applicable 1`] = `
       name="description"
       onBlur={[Function]}
       onChange={[Function]}
+      onKeyDown={[Function]}
       placeholder="Optional description"
       value=""
     />

--- a/src/components/Answers/MultipleChoiceAnswer/index.js
+++ b/src/components/Answers/MultipleChoiceAnswer/index.js
@@ -75,9 +75,8 @@ class MultipleChoiceAnswer extends Component {
     this.props.onDeleteOption(optionId, this.props.answer.id);
   };
 
-  handleAddOptionClick = e => {
+  handleAddOption = e => {
     e.preventDefault();
-
     return this.props.onAddOption(this.props.answer.id).then(focusOnEntity);
   };
 
@@ -111,6 +110,7 @@ class MultipleChoiceAnswer extends Component {
                   option={option}
                   onDelete={this.handleOptionDelete}
                   onUpdate={onUpdateOption}
+                  onEnterKey={this.handleAddOption}
                   hasDeleteButton={options.length > minOptions}
                 />
               </CSSTransition>
@@ -120,7 +120,7 @@ class MultipleChoiceAnswer extends Component {
             <Button
               type="button"
               secondary
-              onClick={this.handleAddOptionClick}
+              onClick={this.handleAddOption}
               data-test="btn-add-option"
             >
               Add another option

--- a/src/components/WrappingInput/index.js
+++ b/src/components/WrappingInput/index.js
@@ -5,6 +5,7 @@ import AutoResizeTextArea from "react-textarea-autosize";
 import withChangeHandler from "components/Forms/withChangeHandler";
 import { colors } from "constants/theme";
 import { transparentize } from "polished";
+import { invoke } from "lodash";
 
 const ENTER_KEY = 13;
 
@@ -58,6 +59,7 @@ class WrappingTextArea extends React.Component {
   static propTypes = {
     value: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
+    onKeyDown: PropTypes.func,
     size: PropTypes.oneOf(Object.keys(sizes))
   };
 
@@ -74,6 +76,8 @@ class WrappingTextArea extends React.Component {
     if (e.keyCode === ENTER_KEY) {
       e.preventDefault();
     }
+
+    invoke(this.props, "onKeyDown", e);
   };
 
   render() {


### PR DESCRIPTION
### What is the context of this PR?
![enter-adds-options](https://user-images.githubusercontent.com/4097796/37156943-58952b46-22df-11e8-8b12-725f91c7563d.gif)

It was identified that being able to press the ENTER key when adding Checkbox/Radio options would help to improve the user experience.

This PR enables changes Checkbox and Radio answers so that pressing the ENTER key adds a new Option and brings the new option into focus.

### How to review 
All existing tests and checks should pass.
Have a play around to make sure it behaves as expected.
Pressing the ENTER key in other fields should not add new answers.