### PR TITLE
issue-313 Fix prop warning in MultipleChoiceAnswer

### DIFF
--- a/src/components/Answers/MultipleChoiceAnswer/__snapshots__/MultipleChoiceAnswer.test.js.snap
+++ b/src/components/Answers/MultipleChoiceAnswer/__snapshots__/MultipleChoiceAnswer.test.js.snap
@@ -16,7 +16,6 @@ exports[`MultipleChoiceAnswer should match snapshot 1`] = `
     }
   }
   labelPlaceholder="Label (optional)"
-  onChange={[Function]}
   onUpdate={[Function]}
 >
   <MultipleChoiceAnswer__AnswerWrapper>
@@ -32,6 +31,7 @@ exports[`MultipleChoiceAnswer should match snapshot 1`] = `
         <withEntityEditor(StatelessOption)
           hasDeleteButton={false}
           onAddOption={[Function]}
+          onChange={[Function]}
           onDelete={[Function]}
           onDeleteOption={[Function]}
           onEnterKey={[Function]}

--- a/src/components/Answers/MultipleChoiceAnswer/index.js
+++ b/src/components/Answers/MultipleChoiceAnswer/index.js
@@ -59,7 +59,6 @@ class MultipleChoiceAnswer extends Component {
   static propTypes = {
     answer: CustomPropTypes.answer.isRequired,
     onUpdate: PropTypes.func.isRequired,
-    onChange: PropTypes.func.isRequired,
     onAddOption: PropTypes.func.isRequired,
     onUpdateOption: PropTypes.func.isRequired,
     onDeleteOption: PropTypes.func.isRequired,
@@ -85,7 +84,6 @@ class MultipleChoiceAnswer extends Component {
       answer,
       onUpdateOption,
       onUpdate,
-      onChange,
       minOptions,
       id,
       ...otherProps
@@ -95,7 +93,6 @@ class MultipleChoiceAnswer extends Component {
       <BasicAnswer
         answer={answer}
         onUpdate={onUpdate}
-        onChange={onChange}
         labelPlaceholder="Label (optional)"
       >
         <AnswerWrapper>


### PR DESCRIPTION
### What is the context of this PR?
Fixes #313 

`MultipleChoiceAnswer` was requiring `onUpdate` prop and passing to `BasicAnswer`. This prop isn't needed as it's provided by `withEntityEditor`.


### How to review 

- test pass
- check the label/description fields of Radio/Checkbox answers work as expected
