### PR TITLE
Fixes section title not being truncated in navigation

### DIFF
--- a/src/components/NavigationSidebar/SectionTitle.js
+++ b/src/components/NavigationSidebar/SectionTitle.js
@@ -16,6 +16,8 @@ const textInverted = "#E1E1E1";
 const Link = styled(NavLink)`
   text-decoration: none;
   color: ${textInverted};
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   &:link,
   &:visited {
@@ -52,7 +54,9 @@ const SectionTitle = ({ questionnaire, section }) => {
   }
 
   const sectionTitle = (
-    <Title>{getTextFromHTML(section.title) || "Section Title"}</Title>
+    <Title title={getTextFromHTML(section.title)}>
+      {getTextFromHTML(section.title) || "Section Title"}
+    </Title>
   );
 
   if (section.pages.length === 0) {

--- a/src/components/NavigationSidebar/__snapshots__/SectionTitle.test.js.snap
+++ b/src/components/NavigationSidebar/__snapshots__/SectionTitle.test.js.snap
@@ -5,14 +5,18 @@ exports[`SectionNavItem SectionTitle should render link when section has pages 1
   activeClassName="selected"
   to="/questionnaire/1/design/3/2"
 >
-  <SectionTitle__Title>
+  <SectionTitle__Title
+    title="Section"
+  >
     Section
   </SectionTitle__Title>
 </SectionTitle__Link>
 `;
 
 exports[`SectionNavItem SectionTitle should render without link when section has no pages 1`] = `
-<SectionTitle__Title>
+<SectionTitle__Title
+  title="Section"
+>
   Section
 </SectionTitle__Title>
 `;


### PR DESCRIPTION
### What is the context of this PR?
This PR fixes #306 and where the section title wasn't being correctly truncated. As seen here:
<img width="286" alt="36733131-884915f6-1bc7-11e8-9af3-b00903da9f51" src="https://user-images.githubusercontent.com/35268220/37591805-97bd72a0-2b64-11e8-9ebf-a5e1c4556fa4.png">


### How to review 
The section title should now truncate correctly and tests should continue to pass.
![screen shot 2018-03-19 at 11 01 04](https://user-images.githubusercontent.com/35268220/37591873-d28d6566-2b64-11e8-983e-41cc363357f6.png)

