### PR TITLE
Added frozen-lockfile flag to travis install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
   chrome: stable
 
 install:
- - yarn install
+ - yarn install --frozen-lockfile
  - yarn upgrade eq-author-graphql-schema
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ addons:
 
 install:
  - yarn install --frozen-lockfile
- - yarn upgrade eq-author-graphql-schema
 
 before_script:
  - set -e


### PR DESCRIPTION
What is the context of this PR?
Travis seems to generate its own lockfile instead of using the one in the github repo. Which means tests can pass on travis but not be up to date when run locally.

How to review
Travis should fail if the lock-file is out of date with the package.json file and should pass if the inverse is true.