### PR TITLE
Add split button component.

### DIFF
--- a/src/components/Popout/index.js
+++ b/src/components/Popout/index.js
@@ -15,10 +15,24 @@ const Container = styled.div`
 
 const Layer = styled.div`
   position: absolute;
-  bottom: 0;
-  left: 0;
+  ${props => `${props.horizontalAlignment}: ${props.offsetX}`};
+  ${props => `${props.verticalAlignment}: ${props.offsetY}`};
   z-index: 10;
 `;
+
+Layer.defaultProps = {
+  horizontalAlignment: "left",
+  verticalAlignment: "bottom",
+  offsetX: "0",
+  offsetY: "0"
+};
+
+Layer.propTypes = {
+  horizontalAlignment: PropTypes.oneOf(["left", "right"]),
+  verticalAlignment: PropTypes.oneOf(["top", "bottom"]),
+  offsetX: PropTypes.string,
+  offsetY: PropTypes.string
+};
 
 const DefaultTransition = props => (
   <CSSTransition {...props} timeout={0} classNames="" />
@@ -32,7 +46,11 @@ class Popout extends React.Component {
     onToggleOpen: PropTypes.func.isRequired,
     onEntered: PropTypes.func,
     onExited: PropTypes.func,
-    transition: PropTypes.any // eslint-disable-line react/forbid-prop-types
+    transition: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+    horizontalAlignment: Layer.propTypes.horizontalAlignment,
+    verticalAlignment: Layer.propTypes.verticalAlignment,
+    offsetX: Layer.propTypes.offsetX,
+    offsetY: Layer.propTypes.offsetY
   };
 
   static defaultProps = {
@@ -121,7 +139,13 @@ class Popout extends React.Component {
           ref: trigger => (this.trigger = trigger)
         })}
 
-        <TransitionGroup component={Layer}>
+        <TransitionGroup
+          component={Layer}
+          horizontalAlignment={this.props.horizontalAlignment}
+          verticalAlignment={this.props.verticalAlignment}
+          offsetX={this.props.offsetX}
+          offsetY={this.props.offsetY}
+        >
           {this.props.open ? this.renderContent() : null}
         </TransitionGroup>
       </Container>

--- a/src/components/SplitButton/Dropdown.js
+++ b/src/components/SplitButton/Dropdown.js
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+
+const Dropdown = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 23em;
+  padding: 0.25em;
+  margin-top: 0.25em;
+  box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.3);
+`;
+
+export default Dropdown;

--- a/src/components/SplitButton/MenuButton.js
+++ b/src/components/SplitButton/MenuButton.js
@@ -1,0 +1,49 @@
+import React from "react";
+import styled from "styled-components";
+import Chevron from "./chevron.svg?inline";
+import { colors } from "constants/theme";
+import IconButton from "components/IconButton";
+
+const StyledChevron = styled(Chevron)`
+  height: 1em;
+  path {
+    stroke: ${colors.blue};
+  }
+`;
+
+const StyledIconButton = styled(IconButton)`
+  background: ${colors.white};
+  border: 1px solid ${colors.blue};
+  color: ${colors.blue};
+  border-radius: 0 4px 4px 0;
+  flex: 0;
+  padding: 0.7em 1em;
+
+  &:focus {
+    color: ${colors.white};
+    background-color: ${colors.blue};
+    outline: 0;
+  }
+
+  &:focus ${StyledChevron} path {
+    stroke: ${colors.white};
+  }
+
+  &:hover ${StyledChevron} path {
+    fill: none;
+  }
+`;
+
+// Trigger needs to be a class component since the Popout manages
+// a Ref and this cannot be achieved with a stateless Trigger component.
+class MenuButton extends React.Component {
+  render() {
+    return (
+      <StyledIconButton icon={StyledChevron} iconOnly {...this.props}>
+        Show additional options
+      </StyledIconButton>
+    );
+  }
+}
+
+export default MenuButton;

--- a/src/components/SplitButton/MenuItem.js
+++ b/src/components/SplitButton/MenuItem.js
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+import { colors } from "constants/theme";
+
+const MenuItem = styled.button`
+  border: none;
+  text-align: left;
+  border-radius: 0.5em;
+  padding: 0.75em 1.5em;
+  margin-bottom: 0.25em;
+  outline: none;
+  &:last-of-type {
+    margin: 0;
+  }
+
+  &:focus,
+  &:hover {
+    background: ${colors.blue};
+    color: ${colors.white};
+  }
+`;
+
+export default MenuItem;

--- a/src/components/SplitButton/PrimaryButton.js
+++ b/src/components/SplitButton/PrimaryButton.js
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+import { colors } from "constants/theme";
+
+const PrimaryButton = styled.button`
+  padding: 0.7em;
+  background: ${colors.white};
+  border: 1px solid ${colors.blue};
+  color: ${colors.blue};
+  font-weight: bold;
+  border-radius: 4px 0 0 4px;
+  border-right: 0;
+  flex: 1;
+  cursor: pointer;
+
+  &:focus {
+    color: ${colors.white};
+    background-color: ${colors.blue};
+    outline: 0;
+  }
+`;
+
+export default PrimaryButton;

--- a/src/components/SplitButton/SplitButton.story.js
+++ b/src/components/SplitButton/SplitButton.story.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import styled from "styled-components";
+import SplitButton from "components/SplitButton";
+import Dropdown from "components/SplitButton/Dropdown";
+import MenuItem from "components/SplitButton/MenuItem";
+import uncontrollable from "uncontrollable";
+import { action } from "@storybook/addon-actions";
+
+const Wrapper = styled.div`
+  padding: 1em;
+  width: 25em;
+`;
+
+const UncontrolledSplitButton = uncontrollable(SplitButton, {
+  open: "onToggleOpen"
+});
+
+storiesOf("SplitButton", module).add("Default", () => (
+  <Wrapper>
+    <UncontrolledSplitButton
+      primaryAction={action("Primary action")}
+      primaryText="Add checkbox"
+    >
+      <Dropdown>
+        <MenuItem onClick={action("Secondary action")}>
+          Checkbox (other option)
+        </MenuItem>
+        <MenuItem onClick={action("Tertiary action")}>
+          Checkbox (mutually exclusive)
+        </MenuItem>
+      </Dropdown>
+    </UncontrolledSplitButton>
+  </Wrapper>
+));

--- a/src/components/SplitButton/SplitButton.test.js
+++ b/src/components/SplitButton/SplitButton.test.js
@@ -1,0 +1,64 @@
+import React from "react";
+import { shallow } from "enzyme";
+import SplitButton from "components/SplitButton";
+import MenuButton from "components/SplitButton/MenuButton";
+import Popout from "components/Popout";
+import Button from "components/Button";
+import ButtonGroup from "components/ButtonGroup";
+
+const createWrapper = (
+  { primaryAction, primaryText, onToggleOpen, open, children },
+  render = shallow
+) =>
+  render(
+    <SplitButton
+      primaryAction={primaryAction}
+      primaryText={primaryText}
+      onToggleOpen={onToggleOpen}
+      open={open}
+    >
+      {children}
+    </SplitButton>
+  );
+
+describe("SplitButton", () => {
+  let wrapper;
+  let props;
+
+  beforeEach(() => {
+    const children = (
+      <ButtonGroup>
+        <Button onClick={jest.fn()} secondary>
+          Add other answer
+        </Button>
+      </ButtonGroup>
+    );
+
+    props = {
+      primaryAction: jest.fn(),
+      primaryText: "Add checkbox",
+      onToggleOpen: jest.fn(),
+      open: false,
+      children
+    };
+    wrapper = createWrapper(props);
+  });
+
+  it("should render when closed", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should render when open", () => {
+    wrapper = createWrapper(Object.assign({}, props, { open: true }));
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should call onToggleOpen when menu button clicked", () => {
+    wrapper
+      .find(Popout)
+      .dive()
+      .find(MenuButton)
+      .simulate("click");
+    expect(props.onToggleOpen).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/SplitButton/__snapshots__/SplitButton.test.js.snap
+++ b/src/components/SplitButton/__snapshots__/SplitButton.test.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SplitButton should render when closed 1`] = `
+<SplitButton__FlexContainer>
+  <PrimaryButton
+    onClick={[Function]}
+  >
+    Add checkbox
+  </PrimaryButton>
+  <Popout
+    horizontalAlignment="right"
+    offsetY="100%"
+    onToggleOpen={[Function]}
+    open={false}
+    transition={[Function]}
+    trigger={<MenuButton />}
+    verticalAlignment="top"
+  >
+    <ButtonGroup>
+      <Button
+        onClick={[Function]}
+        secondary={true}
+      >
+        Add other answer
+      </Button>
+    </ButtonGroup>
+  </Popout>
+</SplitButton__FlexContainer>
+`;
+
+exports[`SplitButton should render when open 1`] = `
+<SplitButton__FlexContainer>
+  <PrimaryButton
+    onClick={[Function]}
+  >
+    Add checkbox
+  </PrimaryButton>
+  <Popout
+    horizontalAlignment="right"
+    offsetY="100%"
+    onToggleOpen={[Function]}
+    open={true}
+    transition={[Function]}
+    trigger={<MenuButton />}
+    verticalAlignment="top"
+  >
+    <ButtonGroup>
+      <Button
+        onClick={[Function]}
+        secondary={true}
+      >
+        Add other answer
+      </Button>
+    </ButtonGroup>
+  </Popout>
+</SplitButton__FlexContainer>
+`;

--- a/src/components/SplitButton/chevron.svg
+++ b/src/components/SplitButton/chevron.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="10px" height="6px" viewBox="0 0 10 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-opacity="0.6">
+        <g id="chevron" transform="translate(5.000000, 3.000000) rotate(90.000000) translate(-5.000000, -3.000000) translate(3.000000, -1.000000)" stroke="#000000">
+            <polyline id="Shape" points="0 0 4 4 0 8"></polyline>
+        </g>
+    </g>
+</svg>

--- a/src/components/SplitButton/index.js
+++ b/src/components/SplitButton/index.js
@@ -1,0 +1,51 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import PrimaryButton from "components/SplitButton/PrimaryButton";
+import MenuButton from "components/SplitButton/MenuButton";
+import Popout from "components/Popout";
+
+const FlexContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+class SplitButton extends React.Component {
+  static propTypes = {
+    primaryAction: PropTypes.func.isRequired,
+    primaryText: PropTypes.string.isRequired,
+    onToggleOpen: PropTypes.func.isRequired,
+    open: PropTypes.bool,
+    children: PropTypes.node
+  };
+
+  static defaultProps = {
+    open: false
+  };
+
+  handleToggleOpen = open => {
+    this.props.onToggleOpen(open);
+  };
+
+  render() {
+    const { primaryAction, primaryText, open, children } = this.props;
+    const trigger = <MenuButton />;
+    return (
+      <FlexContainer>
+        <PrimaryButton onClick={primaryAction}>{primaryText}</PrimaryButton>
+        <Popout
+          trigger={trigger}
+          horizontalAlignment="right"
+          verticalAlignment="top"
+          offsetY="100%"
+          onToggleOpen={this.handleToggleOpen}
+          open={open}
+        >
+          {children}
+        </Popout>
+      </FlexContainer>
+    );
+  }
+}
+
+export default SplitButton;


### PR DESCRIPTION
### What is the context of this PR?
This PR introduces a SplitButton component.
The split button is just a wrapper which applies styles to a button and a Popout component. It is required as part of the acceptance criteria for the add "other" option for checkbox and radio Answers.

### How to review 
The split button component can be viewed in Storybook.
A code review is required and all existing tests and checks should pass.
