### PR TITLE
Added secondary label to allow date ranges to have labels

### DIFF
--- a/cypress/integration/author_spec.js
+++ b/cypress/integration/author_spec.js
@@ -197,6 +197,10 @@ describe("eq-author", () => {
 
   it("Can create and delete date ranges", () => {
     addAnswerType("Date range");
+    cy.get("[data-test='date-answer-label']").type("Date Range label");
+    cy
+      .get("[data-test='date-answer-secondary-label']")
+      .type("Date Range label 2");
     cy.get("[data-test='btn-delete-answer']").click();
     cy.get("[data-test='btn-delete-answer']").should("not.exist");
   });

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "draft-js-raw-content-state": "^1.2.5",
     "draftjs-to-html": "^0.7.6",
     "enzyme-to-json": "^3.3.1",
-    "eq-author-graphql-schema": "^0.8.0",
+    "eq-author-graphql-schema": "0.9.0",
     "eq-author-mock-api": "ONSdigital/eq-author-mock-api#4342f6a",
     "eslint-config-eq-author": "^1.1.0",
     "firebase": "^4.6.2",

--- a/src/components/AnswerEditor/__snapshots__/answereditor.test.js.snap
+++ b/src/components/AnswerEditor/__snapshots__/answereditor.test.js.snap
@@ -71,7 +71,7 @@ exports[`Answer Editor should render Currency 1`] = `
 
 exports[`Answer Editor should render DateRange 1`] = `
 <div>
-  <DateRange
+  <withEntityEditor(DateRange)
     answer={
       Object {
         "description": "",
@@ -80,8 +80,6 @@ exports[`Answer Editor should render DateRange 1`] = `
         "type": "DateRange",
       }
     }
-    legendFrom="Period from"
-    legendTo="Period to"
     onAddOption={[Function]}
     onChange={[Function]}
     onDeleteAnswer={[Function]}

--- a/src/components/Answers/DateRange/__snapshots__/index.test.js.snap
+++ b/src/components/Answers/DateRange/__snapshots__/index.test.js.snap
@@ -1,35 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DateRange should render 1`] = `
-<DateRange__Wrapper>
-  <DateRange__Fieldset>
-    <DateRange__Legend>
-      Period from
-    </DateRange__Legend>
-    <Date />
-  </DateRange__Fieldset>
-  <DateRange__Fieldset>
-    <DateRange__Legend>
-      Period to
-    </DateRange__Legend>
-    <Date />
-  </DateRange__Fieldset>
-</DateRange__Wrapper>
-`;
-
-exports[`DateRange should render legendTo/legendFrom props 1`] = `
-<DateRange__Wrapper>
-  <DateRange__Fieldset>
-    <DateRange__Legend>
-      Period from
-    </DateRange__Legend>
-    <Date />
-  </DateRange__Fieldset>
-  <DateRange__Fieldset>
-    <DateRange__Legend>
-      Foo
-    </DateRange__Legend>
-    <Date />
-  </DateRange__Fieldset>
-</DateRange__Wrapper>
+<DateRange
+  answer={
+    Object {
+      "label": "Lorem ipsum",
+      "secondaryLabel": "dolor sit amet",
+    }
+  }
+  id={null}
+  onChange={[Function]}
+  onSubmit={[Function]}
+  onUpdate={[Function]}
+/>
 `;

--- a/src/components/Answers/DateRange/index.js
+++ b/src/components/Answers/DateRange/index.js
@@ -1,9 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
+import CustomPropTypes from "custom-prop-types";
 import DummyDate from "components/Answers/Dummy/Date";
 import styled from "styled-components";
-
-import { colors } from "constants/theme";
+import { Field } from "components/Forms";
+import WrappingInput from "components/WrappingInput";
+import withEntityEditor from "components/withEntityEditor";
+import answerFragment from "graphql/fragments/answer.graphql";
 
 const Wrapper = styled.div`
   width: 100%;
@@ -17,35 +20,45 @@ const Fieldset = styled.div`
   }
 `;
 
-const Legend = styled.p`
-  font-size: 1em;
-  font-weight: bold;
-  color: ${colors.text};
-  margin-top: 0;
-  margin-bottom: 0.8em;
-`;
-
-const DateRange = ({ legendFrom, legendTo, ...otherProps }) => (
+const DateRange = ({ answer, onChange, onUpdate, ...otherProps }) => (
   <Wrapper>
     <Fieldset>
-      <Legend>{legendFrom}</Legend>
+      <Field>
+        <WrappingInput
+          name="label"
+          placeholder="From"
+          size="medium"
+          onChange={onChange}
+          onBlur={onUpdate}
+          value={answer.label}
+          data-autofocus
+          data-test="date-answer-label"
+        />
+      </Field>
       <DummyDate />
     </Fieldset>
     <Fieldset>
-      <Legend>{legendTo}</Legend>
+      <Field>
+        <WrappingInput
+          name="secondaryLabel"
+          placeholder="To"
+          size="medium"
+          onChange={onChange}
+          onBlur={onUpdate}
+          value={answer.secondaryLabel}
+          data-autofocus
+          data-test="date-answer-secondary-label"
+        />
+      </Field>
       <DummyDate />
     </Fieldset>
   </Wrapper>
 );
 
 DateRange.propTypes = {
-  legendFrom: PropTypes.string.isRequired,
-  legendTo: PropTypes.string.isRequired
+  answer: CustomPropTypes.answer.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired
 };
 
-DateRange.defaultProps = {
-  legendFrom: "Period from",
-  legendTo: "Period to"
-};
-
-export default DateRange;
+export default withEntityEditor("answer", answerFragment)(DateRange);

--- a/src/components/Answers/DateRange/index.test.js
+++ b/src/components/Answers/DateRange/index.test.js
@@ -2,14 +2,28 @@ import React from "react";
 import { shallow } from "enzyme";
 import DateRange from "./index";
 
+const answer = {
+  label: "Lorem ipsum",
+  secondaryLabel: "dolor sit amet"
+};
+
 describe("DateRange", () => {
-  it("should render", () => {
-    const wrapper = shallow(<DateRange />);
-    expect(wrapper).toMatchSnapshot();
+  let handleChange;
+  let handleUpdate;
+
+  beforeEach(() => {
+    handleChange = jest.fn();
+    handleUpdate = jest.fn();
   });
 
-  it("should render legendTo/legendFrom props", () => {
-    const wrapper = shallow(<DateRange legendTo="Foo" legendBar="Bar" />);
+  it("should render", () => {
+    const wrapper = shallow(
+      <DateRange
+        onChange={handleChange}
+        onUpdate={handleUpdate}
+        answer={answer}
+      />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/containers/enhancers/withCreateAnswer.js
+++ b/src/containers/enhancers/withCreateAnswer.js
@@ -27,7 +27,8 @@ export const mapMutateToProps = ({ mutate, ownProps }) => ({
       description: "",
       guidance: "",
       qCode: "",
-      label: ""
+      label: "",
+      secondaryLabel: ""
     };
 
     const update = createUpdater(ownProps.page.id);

--- a/src/graphql/createAnswer.graphql
+++ b/src/graphql/createAnswer.graphql
@@ -4,6 +4,9 @@
 mutation createAnswer($input: CreateAnswerInput!) {
   createAnswer(input: $input) {
     ...Answer
+    ... on BasicAnswer {
+      secondaryLabel
+    }
     ... on MultipleChoiceAnswer {
       options {
         ...Option

--- a/src/graphql/fragments/answer.graphql
+++ b/src/graphql/fragments/answer.graphql
@@ -3,6 +3,9 @@ fragment Answer on Answer {
   description
   guidance
   label
+  ... on BasicAnswer {
+    secondaryLabel
+  }
   type
   mandatory
 }

--- a/src/graphql/getAnswers.graphql
+++ b/src/graphql/getAnswers.graphql
@@ -1,6 +1,9 @@
 query GetAnswers($ids: [ID]!) {
   answers(ids: $ids) {
     label
+    ... on BasicAnswer {
+      secondaryLabel
+    }
     id
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3386,9 +3386,9 @@ enzyme@^3.1.0:
     raf "^3.3.2"
     rst-selector-parser "^2.2.2"
 
-eq-author-graphql-schema@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.8.0.tgz#e6dd0efeaf708cdb326255f4b3231e4bc7f4450d"
+eq-author-graphql-schema@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.9.0.tgz#09908b0e4007ea58f98e969c1186462849fde935"
 
 eq-author-mock-api@ONSdigital/eq-author-mock-api#4342f6a:
   version "1.0.0"


### PR DESCRIPTION
### What is the context of this PR?
Added a secondary label to the basic answer queries and made the relevant front-end changes to allow users to input a from and to label on date ranges.
 
### How to review 
Tests should pass and user inputted values for Date range label should show up in the publisher json.

Dependencies: 
 - ~ONSdigital/eq-author-graphql-schema#28~,
 - ONSdigital/eq-author-api#61,
 - ONSdigital/eq-publisher#53

	

