### PR TITLE
390 move page modal improvements

### DIFF
--- a/src/components/MovePageModal/__snapshots__/index.test.js.snap
+++ b/src/components/MovePageModal/__snapshots__/index.test.js.snap
@@ -12,10 +12,13 @@ exports[`MovePageModal/MovePageModal should render 1`] = `
       </MovePageModal__CenteredHeading>
     </DialogMessage__Message>
   </DialogHeader___default>
-  <MovePageModal__Label>
+  <MovePageModal__Label
+    htmlFor="MovePageModal1"
+  >
     Section
   </MovePageModal__Label>
   <MovePageModal__Trigger
+    id="MovePageModal1"
     onClick={[Function]}
   >
     Section 1
@@ -49,10 +52,13 @@ exports[`MovePageModal/MovePageModal should render 1`] = `
       </Option>
     </withChangeHandler(ItemSelect)>
   </ItemSelectModal>
-  <MovePageModal__Label>
+  <MovePageModal__Label
+    htmlFor="MovePageModal2"
+  >
     Position
   </MovePageModal__Label>
   <MovePageModal__Trigger
+    id="MovePageModal2"
     onClick={[Function]}
   >
     Select

--- a/src/components/MovePageModal/index.js
+++ b/src/components/MovePageModal/index.js
@@ -63,28 +63,53 @@ class MovePageModal extends React.Component {
       isSectionSelectOpen: false,
       isPagePositionOpen: false,
       selectedSectionId: props.section.id,
-      selectedPagePosition: props.page.position
+      selectedPagePosition: props.page.position,
+      previousSelectedSectionId: null,
+      previousSelectedPagePosition: null
     };
   }
 
-  handleToggleSectionSelect = () => {
-    this.setState({ isSectionSelectOpen: !this.state.isSectionSelectOpen });
+  handleCloseSectionSelect = () => {
+    this.setState({
+      isSectionSelectOpen: false,
+      selectedSectionId: this.state.previousSelectedSectionId
+    });
   };
 
-  handleTogglePagePosition = () => {
-    this.setState({ isPagePositionOpen: !this.state.isPagePositionOpen });
+  handleOpenSectionSelect = () => {
+    this.setState({
+      isSectionSelectOpen: true,
+      previousSelectedSectionId: this.state.selectedSectionId
+    });
+  };
+
+  handleClosePagePosition = () => {
+    this.setState({
+      isPagePositionOpen: false,
+      selectedPagePosition: this.state.previousSelectedPagePosition
+    });
+  };
+
+  handleOpenPagePosition = () => {
+    this.setState({
+      isPagePositionOpen: true,
+      previousSelectedPagePosition: this.state.selectedPagePosition
+    });
   };
 
   handleSectionChange = ({ value }) => {
     this.setState({
-      selectedSectionId: value,
-      selectedPagePosition: 0
+      selectedSectionId: value
     });
   };
 
   handleSectionConfirm = e => {
     e.preventDefault();
-    this.handleToggleSectionSelect();
+
+    this.setState({
+      isSectionSelectOpen: false,
+      selectedPagePosition: 0
+    });
   };
 
   handlePositionChange = ({ value }) => {
@@ -131,7 +156,7 @@ class MovePageModal extends React.Component {
         data-test="section-modal"
         title="Section"
         isOpen={isSectionSelectOpen}
-        onClose={this.handleToggleSectionSelect}
+        onClose={this.handleCloseSectionSelect}
         onConfirm={this.handleSectionConfirm}
       >
         <ItemSelect
@@ -159,7 +184,7 @@ class MovePageModal extends React.Component {
         title="Position"
         primaryText="Move page"
         isOpen={isPagePositionOpen}
-        onClose={this.handleTogglePagePosition}
+        onClose={this.handleClosePagePosition}
         onConfirm={this.handlePositionConfirm}
       >
         <ItemSelect
@@ -192,13 +217,13 @@ class MovePageModal extends React.Component {
         </DialogHeader>
 
         <Label>Section</Label>
-        <Trigger onClick={this.handleToggleSectionSelect}>
+        <Trigger onClick={this.handleOpenSectionSelect}>
           {getTextFromHTML(section.title)}
         </Trigger>
         {this.renderSectionSelect(section)}
 
         <Label>Position</Label>
-        <Trigger onClick={this.handleTogglePagePosition}>Select</Trigger>
+        <Trigger onClick={this.handleOpenPagePosition}>Select</Trigger>
         {this.renderPositionSelect(pages)}
       </StyledModal>
     );

--- a/src/components/MovePageModal/index.js
+++ b/src/components/MovePageModal/index.js
@@ -6,7 +6,7 @@ import { Message, Heading } from "components/Dialog/DialogMessage";
 import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
 import ItemSelectModal from "./ItemSelectModal";
-import { find, reject, parseInt } from "lodash";
+import { find, reject, parseInt, uniqueId } from "lodash";
 import getTextFromHTML from "utils/getTextFromHTML";
 import Icon from "assets/icon-select.svg";
 import ItemSelect, { Option } from "./ItemSelect";
@@ -29,7 +29,8 @@ const CenteredHeading = styled(Heading)`
   margin-bottom: 1rem;
 `;
 
-const Label = styled.p`
+const Label = styled.label`
+  display: block;
   font-size: 0.875em;
   font-weight: bold;
   margin-bottom: 0.25rem;
@@ -208,6 +209,9 @@ class MovePageModal extends React.Component {
     const section = this.getSelectedSection();
     const pages = this.getPagesForSection(section);
 
+    const sectionButtonId = uniqueId("MovePageModal");
+    const positionButtonId = uniqueId("MovePageModal");
+
     return (
       <StyledModal isOpen={isOpen} onClose={onClose}>
         <DialogHeader>
@@ -216,14 +220,16 @@ class MovePageModal extends React.Component {
           </Message>
         </DialogHeader>
 
-        <Label>Section</Label>
-        <Trigger onClick={this.handleOpenSectionSelect}>
+        <Label htmlFor={sectionButtonId}>Section</Label>
+        <Trigger id={sectionButtonId} onClick={this.handleOpenSectionSelect}>
           {getTextFromHTML(section.title)}
         </Trigger>
         {this.renderSectionSelect(section)}
 
-        <Label>Position</Label>
-        <Trigger onClick={this.handleOpenPagePosition}>Select</Trigger>
+        <Label htmlFor={positionButtonId}>Position</Label>
+        <Trigger id={positionButtonId} onClick={this.handleOpenPagePosition}>
+          Select
+        </Trigger>
         {this.renderPositionSelect(pages)}
       </StyledModal>
     );

--- a/src/components/MovePageModal/index.test.js
+++ b/src/components/MovePageModal/index.test.js
@@ -133,4 +133,35 @@ describe("MovePageModal/MovePageModal", () => {
       position
     });
   });
+
+  it("resets the section selection if modal is closed", () => {
+    const wrapper = createWrapper();
+
+    wrapper
+      .find("MovePageModal__Trigger")
+      .first()
+      .simulate("click");
+
+    const selectedSection = questionnaire.sections[1];
+    getSectionSelect(wrapper).simulate("change", { value: selectedSection.id });
+    expect(getSectionSelect(wrapper).prop("value")).toBe(selectedSection.id);
+
+    getSectionModal(wrapper).simulate("close");
+    expect(getSectionSelect(wrapper).prop("value")).toBe(currentSection.id);
+  });
+
+  it("reset the position if modal is closed", () => {
+    const wrapper = createWrapper();
+
+    wrapper
+      .find("MovePageModal__Trigger")
+      .last()
+      .simulate("click");
+
+    getPositionSelect(wrapper).simulate("change", { value: 1 });
+    expect(getPositionSelect(wrapper).prop("value")).toBe("1");
+
+    getPositionModal(wrapper).simulate("close");
+    expect(getPositionSelect(wrapper).prop("value")).toBe("0");
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?
This PR modifies MovePageModal so that selections are reset once section/position modal is closed. For example: open section modal, select a section, click "cancel" button. The selection should return back to what it was before opening the modal. 

This PR also includes a slight accessibility improvement: using an actual `label` for the modal trigger (and associating them with each other, via `for`/`id` attributes)

### How to review 
Changes look good
