### PR TITLE
Update Author to enable adding/removing of "other" option

### DIFF
--- a/cypress/integration/author_spec.js
+++ b/cypress/integration/author_spec.js
@@ -30,7 +30,7 @@ describe("eq-author", () => {
     cy.get(`[data-test="username"]`).then($name => {
       cy
         .get("tbody tr")
-        .last()
+        .first()
         .should("contain", "My Questionnaire Title")
         .and("contain", $name.text())
         .find("a")
@@ -373,5 +373,50 @@ describe("eq-author", () => {
       .find(`[data-test="page-item"]`)
       .first()
       .should("contain", "Page 2");
+  });
+
+  describe('Checkbox/Radio with "other" option', () => {
+    it("should goto questionnaire design page", () => {
+      cy.visit("/");
+      cy.contains("Sign in as Guest").click();
+      cy.get("[data-test='create-questionnaire']").click();
+      setQuestionnaireSettings("My Questionnaire Title");
+    });
+
+    it('should add an "other" answer', () => {
+      addAnswerType("Checkbox");
+      cy.get("[data-test='btn-add-option-menu']").click();
+      cy.get("[data-test='btn-add-option-other']").click();
+      cy.get("[data-test='option-label']").should("have.length", 2);
+      cy.get("[data-test='other-answer']").should("have.length", 1);
+    });
+
+    it("should update the other option and answer values", () => {
+      cy
+        .get("[data-test='option-label']")
+        .last()
+        .type("Other label");
+      cy
+        .get("[data-test='option-description']")
+        .last()
+        .type("Other description");
+      cy
+        .get("[data-test='txt-answer-label']")
+        .last()
+        .type("Text answer label");
+      cy
+        .get("[data-test='option-label']")
+        .first()
+        .click();
+    });
+
+    it('should remove the "other" option.', () => {
+      cy
+        .get("[data-test='btn-delete-option']")
+        .last()
+        .click();
+      cy.get("[data-test='option-label']").should("have.length", 1);
+      cy.get("[data-test='other-answer']").should("have.length", 0);
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "draft-js-raw-content-state": "^1.2.5",
     "draftjs-to-html": "^0.7.6",
     "enzyme-to-json": "^3.3.1",
-    "eq-author-graphql-schema": "0.9.0",
+    "eq-author-graphql-schema": "^0.12.0",
     "eq-author-mock-api": "ONSdigital/eq-author-mock-api#4342f6a",
     "eslint-config-eq-author": "^1.1.0",
     "firebase": "^4.6.2",

--- a/src/components/AnswerEditor/__snapshots__/answereditor.test.js.snap
+++ b/src/components/AnswerEditor/__snapshots__/answereditor.test.js.snap
@@ -20,9 +20,11 @@ exports[`Answer Editor should render Checkbox 1`] = `
     }
     minOptions={1}
     onAddOption={[Function]}
+    onAddOther={[Function]}
     onChange={[Function]}
     onDeleteAnswer={[Function]}
     onDeleteOption={[Function]}
+    onDeleteOther={[Function]}
     onUpdate={[Function]}
     onUpdateOption={[Function]}
     type="Checkbox"
@@ -51,9 +53,11 @@ exports[`Answer Editor should render Currency 1`] = `
       }
     }
     onAddOption={[Function]}
+    onAddOther={[Function]}
     onChange={[Function]}
     onDeleteAnswer={[Function]}
     onDeleteOption={[Function]}
+    onDeleteOther={[Function]}
     onUpdate={[Function]}
     onUpdateOption={[Function]}
   />
@@ -81,9 +85,11 @@ exports[`Answer Editor should render DateRange 1`] = `
       }
     }
     onAddOption={[Function]}
+    onAddOther={[Function]}
     onChange={[Function]}
     onDeleteAnswer={[Function]}
     onDeleteOption={[Function]}
+    onDeleteOther={[Function]}
     onUpdate={[Function]}
     onUpdateOption={[Function]}
   />
@@ -111,9 +117,11 @@ exports[`Answer Editor should render Number 1`] = `
       }
     }
     onAddOption={[Function]}
+    onAddOther={[Function]}
     onChange={[Function]}
     onDeleteAnswer={[Function]}
     onDeleteOption={[Function]}
+    onDeleteOther={[Function]}
     onUpdate={[Function]}
     onUpdateOption={[Function]}
   />
@@ -149,9 +157,11 @@ exports[`Answer Editor should render Radio 1`] = `
     }
     minOptions={2}
     onAddOption={[Function]}
+    onAddOther={[Function]}
     onChange={[Function]}
     onDeleteAnswer={[Function]}
     onDeleteOption={[Function]}
+    onDeleteOther={[Function]}
     onUpdate={[Function]}
     onUpdateOption={[Function]}
     type="Radio"
@@ -180,9 +190,11 @@ exports[`Answer Editor should render TextArea 1`] = `
       }
     }
     onAddOption={[Function]}
+    onAddOther={[Function]}
     onChange={[Function]}
     onDeleteAnswer={[Function]}
     onDeleteOption={[Function]}
+    onDeleteOther={[Function]}
     onUpdate={[Function]}
     onUpdateOption={[Function]}
   />
@@ -210,9 +222,11 @@ exports[`Answer Editor should render TextField 1`] = `
       }
     }
     onAddOption={[Function]}
+    onAddOther={[Function]}
     onChange={[Function]}
     onDeleteAnswer={[Function]}
     onDeleteOption={[Function]}
+    onDeleteOther={[Function]}
     onUpdate={[Function]}
     onUpdateOption={[Function]}
   />

--- a/src/components/AnswerEditor/answereditor.story.js
+++ b/src/components/AnswerEditor/answereditor.story.js
@@ -42,6 +42,8 @@ class AnswerEditorWrapper extends React.Component {
         onDeleteAnswer={action("deleteAnswer")}
         onUpdateOption={action("onUpdateOption")}
         onDeleteOption={action("deleteOption")}
+        onAddOther={action("addOther")}
+        onDeleteOther={action("deleteOther")}
       />
     );
   }

--- a/src/components/AnswerEditor/answereditor.test.js
+++ b/src/components/AnswerEditor/answereditor.test.js
@@ -29,7 +29,9 @@ describe("Answer Editor", () => {
       onUpdate: jest.fn(),
       onAddOption: jest.fn(),
       onUpdateOption: jest.fn(),
-      onDeleteOption: jest.fn()
+      onDeleteOption: jest.fn(),
+      onAddOther: jest.fn(),
+      onDeleteOther: jest.fn()
     };
 
     mockAnswer = {

--- a/src/components/AnswerEditor/index.js
+++ b/src/components/AnswerEditor/index.js
@@ -89,6 +89,8 @@ AnswerEditor.propTypes = {
   onUpdate: PropTypes.func.isRequired,
   onDeleteAnswer: PropTypes.func.isRequired,
   onAddOption: PropTypes.func.isRequired,
+  onAddOther: PropTypes.func.isRequired,
+  onDeleteOther: PropTypes.func.isRequired,
   onUpdateOption: PropTypes.func.isRequired,
   onDeleteOption: PropTypes.func.isRequired
 };

--- a/src/components/Answers/BasicAnswer/index.js
+++ b/src/components/Answers/BasicAnswer/index.js
@@ -12,14 +12,16 @@ export const StatelessBasicAnswer = ({
   onUpdate,
   children,
   labelPlaceholder,
-  descriptionPlaceholder
+  descriptionPlaceholder,
+  showDescription,
+  size
 }) => (
   <div>
     <Field>
       <WrappingInput
         name="label"
         placeholder={labelPlaceholder}
-        size="medium"
+        size={size}
         onChange={onChange}
         onBlur={onUpdate}
         value={answer.label}
@@ -27,18 +29,20 @@ export const StatelessBasicAnswer = ({
         data-test="txt-answer-label"
       />
     </Field>
-    <Field>
-      <WrappingInput
-        name="description"
-        cols="30"
-        rows="5"
-        placeholder={descriptionPlaceholder}
-        onChange={onChange}
-        onBlur={onUpdate}
-        value={answer.description}
-        data-test="txt-answer-description"
-      />
-    </Field>
+    {showDescription && (
+      <Field>
+        <WrappingInput
+          name="description"
+          cols="30"
+          rows="5"
+          placeholder={descriptionPlaceholder}
+          onChange={onChange}
+          onBlur={onUpdate}
+          value={answer.description}
+          data-test="txt-answer-description"
+        />
+      </Field>
+    )}
     {children}
   </div>
 );
@@ -49,12 +53,16 @@ StatelessBasicAnswer.propTypes = {
   onUpdate: PropTypes.func.isRequired,
   children: PropTypes.element.isRequired,
   labelPlaceholder: PropTypes.string,
-  descriptionPlaceholder: PropTypes.string
+  descriptionPlaceholder: PropTypes.string,
+  showDescription: PropTypes.bool,
+  size: PropTypes.oneOf(["tiny", "small", "medium", "large"])
 };
 
 StatelessBasicAnswer.defaultProps = {
   labelPlaceholder: "Label",
-  descriptionPlaceholder: "Enter a description (optional)…"
+  descriptionPlaceholder: "Enter a description (optional)…",
+  showDescription: true,
+  size: "medium"
 };
 
 export default withEntityEditor("answer", answerFragment)(StatelessBasicAnswer);

--- a/src/components/Answers/MultipleChoiceAnswer/MultipleChoiceAnswer.story.js
+++ b/src/components/Answers/MultipleChoiceAnswer/MultipleChoiceAnswer.story.js
@@ -89,6 +89,8 @@ class MultipleChoiceAnswerWrapper extends React.Component {
           onChange={action("change")}
           onAddOption={this.handleAddOption}
           onDeleteOption={this.handleDeleteOption}
+          onAddOther={action("addOther")}
+          onDeleteOther={action("deleteOther")}
         />
       </Wrapper>
     );

--- a/src/components/Answers/MultipleChoiceAnswer/Option.js
+++ b/src/components/Answers/MultipleChoiceAnswer/Option.js
@@ -109,7 +109,13 @@ export class StatelessOption extends Component {
     onDelete: PropTypes.func.isRequired,
     onEnterKey: PropTypes.func,
     hasDeleteButton: PropTypes.bool.isRequired,
-    type: PropTypes.oneOf([RADIO, CHECKBOX]).isRequired
+    type: PropTypes.oneOf([RADIO, CHECKBOX]).isRequired,
+    children: PropTypes.node,
+    labelPlaceholder: PropTypes.string
+  };
+
+  static defaultProps = {
+    labelPlaceholder: "Label"
   };
 
   handleDeleteClick = e => {
@@ -138,7 +144,15 @@ export class StatelessOption extends Component {
   }
 
   render() {
-    const { hasDeleteButton, option, onChange, onUpdate, type } = this.props;
+    const {
+      hasDeleteButton,
+      option,
+      onChange,
+      onUpdate,
+      type,
+      children,
+      labelPlaceholder
+    } = this.props;
 
     return (
       <StyledOption id={getIdForObject(option)} key={option.id}>
@@ -146,7 +160,7 @@ export class StatelessOption extends Component {
           <DummyInput type={type} />
           <SeamlessLabel
             name="label"
-            placeholder="Label"
+            placeholder={labelPlaceholder}
             size="medium"
             value={option.label}
             onChange={onChange}
@@ -167,6 +181,7 @@ export class StatelessOption extends Component {
             data-test="option-description"
           />
         </Field>
+        {children}
         {hasDeleteButton && this.renderDeleteButton()}
       </StyledOption>
     );

--- a/src/components/Answers/MultipleChoiceAnswer/__snapshots__/MultipleChoiceAnswer.test.js.snap
+++ b/src/components/Answers/MultipleChoiceAnswer/__snapshots__/MultipleChoiceAnswer.test.js.snap
@@ -1,5 +1,192 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`MultipleChoiceAnswer other option and answer should render other 1`] = `
+<Connect(withEntityEditor(StatelessBasicAnswer))
+  answer={
+    Object {
+      "id": "0",
+      "options": Array [
+        Object {
+          "description": "",
+          "id": 0,
+          "label": "",
+        },
+        Object {
+          "description": "",
+          "id": 1,
+          "label": "",
+        },
+      ],
+      "other": Object {
+        "answer": Object {
+          "id": "1",
+          "options": Array [
+            Object {
+              "__typename": "Option",
+              "description": "",
+              "id": "1",
+              "label": "",
+            },
+          ],
+          "type": "TextField",
+        },
+        "option": Object {
+          "__typename": "Option",
+          "id": "2",
+        },
+      },
+    }
+  }
+  labelPlaceholder="Label (optional)"
+  onUpdate={[Function]}
+>
+  <MultipleChoiceAnswer__AnswerWrapper>
+    <TransitionGroup
+      childFactory={[Function]}
+      component={[Function]}
+    >
+      <CSSTransition
+        classNames="option"
+        key="0"
+        timeout={200}
+      >
+        <Connect(withEntityEditor(StatelessOption))
+          hasDeleteButton={true}
+          onAddOption={[Function]}
+          onAddOther={[Function]}
+          onChange={[Function]}
+          onDelete={[Function]}
+          onDeleteOption={[Function]}
+          onDeleteOther={[Function]}
+          onEnterKey={[Function]}
+          onUpdate={[Function]}
+          option={
+            Object {
+              "description": "",
+              "id": 0,
+              "label": "",
+            }
+          }
+          store={
+            Object {
+              "dispatch": [Function],
+              "getState": [Function],
+              "subscribe": [Function],
+            }
+          }
+        />
+      </CSSTransition>
+      <CSSTransition
+        classNames="option"
+        key="1"
+        timeout={200}
+      >
+        <Connect(withEntityEditor(StatelessOption))
+          hasDeleteButton={true}
+          onAddOption={[Function]}
+          onAddOther={[Function]}
+          onChange={[Function]}
+          onDelete={[Function]}
+          onDeleteOption={[Function]}
+          onDeleteOther={[Function]}
+          onEnterKey={[Function]}
+          onUpdate={[Function]}
+          option={
+            Object {
+              "description": "",
+              "id": 1,
+              "label": "",
+            }
+          }
+          store={
+            Object {
+              "dispatch": [Function],
+              "getState": [Function],
+              "subscribe": [Function],
+            }
+          }
+        />
+      </CSSTransition>
+      <CSSTransition
+        classNames="option"
+        key="2"
+        timeout={200}
+      >
+        <Connect(withEntityEditor(StatelessOption))
+          hasDeleteButton={true}
+          labelPlaceholder="Other"
+          onAddOption={[Function]}
+          onAddOther={[Function]}
+          onChange={[Function]}
+          onDelete={[Function]}
+          onDeleteOption={[Function]}
+          onDeleteOther={[Function]}
+          onEnterKey={[Function]}
+          onUpdate={[Function]}
+          option={
+            Object {
+              "__typename": "Option",
+              "id": "2",
+            }
+          }
+          store={
+            Object {
+              "dispatch": [Function],
+              "getState": [Function],
+              "subscribe": [Function],
+            }
+          }
+        >
+          <MultipleChoiceAnswer__OtherAnswerWrapper
+            data-test="other-answer"
+          >
+            <TextAnswer
+              answer={
+                Object {
+                  "id": "1",
+                  "options": Array [
+                    Object {
+                      "__typename": "Option",
+                      "description": "",
+                      "id": "1",
+                      "label": "",
+                    },
+                  ],
+                  "type": "TextField",
+                }
+              }
+              labelPlaceholder="Please specify"
+              onUpdate={[Function]}
+              showDescription={false}
+              size="tiny"
+            />
+          </MultipleChoiceAnswer__OtherAnswerWrapper>
+        </Connect(withEntityEditor(StatelessOption))>
+      </CSSTransition>
+    </TransitionGroup>
+    <div>
+      <SplitButton
+        dataTest="btn-add-option"
+        onPrimaryAction={[Function]}
+        onToggleOpen={[Function]}
+        open={false}
+        primaryText="Add another option"
+      >
+        <Dropdown>
+          <MenuItem
+            data-test="btn-add-option-other"
+            disabled={true}
+            onClick={[Function]}
+          >
+            Add "other" option
+          </MenuItem>
+        </Dropdown>
+      </SplitButton>
+    </div>
+  </MultipleChoiceAnswer__AnswerWrapper>
+</Connect(withEntityEditor(StatelessBasicAnswer))>
+`;
+
 exports[`MultipleChoiceAnswer should match snapshot 1`] = `
 <Connect(withEntityEditor(StatelessBasicAnswer))
   answer={
@@ -31,9 +218,11 @@ exports[`MultipleChoiceAnswer should match snapshot 1`] = `
         <Connect(withEntityEditor(StatelessOption))
           hasDeleteButton={false}
           onAddOption={[Function]}
+          onAddOther={[Function]}
           onChange={[Function]}
           onDelete={[Function]}
           onDeleteOption={[Function]}
+          onDeleteOther={[Function]}
           onEnterKey={[Function]}
           onUpdate={[Function]}
           option={
@@ -55,14 +244,23 @@ exports[`MultipleChoiceAnswer should match snapshot 1`] = `
       </CSSTransition>
     </TransitionGroup>
     <div>
-      <Button
-        data-test="btn-add-option"
-        onClick={[Function]}
-        type="button"
-        variant="secondary"
+      <SplitButton
+        dataTest="btn-add-option"
+        onPrimaryAction={[Function]}
+        onToggleOpen={[Function]}
+        open={false}
+        primaryText="Add another option"
       >
-        Add another option
-      </Button>
+        <Dropdown>
+          <MenuItem
+            data-test="btn-add-option-other"
+            disabled={true}
+            onClick={[Function]}
+          >
+            Add "other" option
+          </MenuItem>
+        </Dropdown>
+      </SplitButton>
     </div>
   </MultipleChoiceAnswer__AnswerWrapper>
 </Connect(withEntityEditor(StatelessBasicAnswer))>

--- a/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -251,6 +251,7 @@ exports[`Option should render a checkbox 1`] = `
 
 <StatelessOption
   hasDeleteButton={true}
+  labelPlaceholder="Label"
   onChange={[Function]}
   onDelete={[Function]}
   onEnterKey={[Function]}

--- a/src/components/EditorSurface/__snapshots__/EditorSurface.test.js.snap
+++ b/src/components/EditorSurface/__snapshots__/EditorSurface.test.js.snap
@@ -13,7 +13,7 @@ exports[`EditorSurface should render 1`] = `
       duration={300}
       key="Page2"
     >
-      <Connect(withRouter(Apollo(Apollo(Apollo(Apollo(Apollo(Apollo(Apollo(QPE)))))))))
+      <Connect(withRouter(Apollo(Apollo(Apollo(Apollo(Apollo(Apollo(Apollo(Apollo(Apollo(QPE)))))))))))
         onDeletePage={[Function]}
         onUpdatePage={[Function]}
         page={

--- a/src/components/QuestionPageEditor/QuestionPageEditor.test.js
+++ b/src/components/QuestionPageEditor/QuestionPageEditor.test.js
@@ -27,7 +27,9 @@ describe("Question Page Editor", () => {
       onDeleteAnswer: jest.fn(),
       onUpdateOption: jest.fn(),
       onFocus: jest.fn(),
-      onMovePage: jest.fn()
+      onMovePage: jest.fn(),
+      onAddOther: jest.fn(),
+      onDeleteOther: jest.fn()
     };
 
     page = {

--- a/src/components/QuestionPageEditor/index.js
+++ b/src/components/QuestionPageEditor/index.js
@@ -28,6 +28,8 @@ import withCreateOption from "containers/enhancers/withCreateOption";
 import withUpdateOption from "containers/enhancers/withUpdateOption";
 import withDeleteOption from "containers/enhancers/withDeleteOption";
 import withMovePage from "containers/enhancers/withMovePage";
+import withCreateOther from "containers/enhancers/withCreateOther";
+import withDeleteOther from "containers/enhancers/withDeleteOther";
 
 import { raiseToast } from "redux/toast/actions";
 import EntityToolbar from "components/EntityToolbar";
@@ -61,6 +63,8 @@ export class QPE extends React.Component {
     onDeletePage: PropTypes.func.isRequired,
     onUpdateOption: PropTypes.func.isRequired,
     onMovePage: PropTypes.func.isRequired,
+    onAddOther: PropTypes.func.isRequired,
+    onDeleteOther: PropTypes.func.isRequired,
     page: CustomPropTypes.page,
     section: CustomPropTypes.section,
     questionnaire: CustomPropTypes.questionnaire
@@ -110,7 +114,9 @@ export class QPE extends React.Component {
       onUpdateAnswer,
       onAddOption,
       onUpdateOption,
-      onDeleteOption
+      onDeleteOption,
+      onAddOther,
+      onDeleteOther
     } = this.props;
 
     return (
@@ -120,6 +126,8 @@ export class QPE extends React.Component {
             answer={answer}
             onUpdate={onUpdateAnswer}
             onAddOption={onAddOption}
+            onAddOther={onAddOther}
+            onDeleteOther={onDeleteOther}
             onUpdateOption={onUpdateOption}
             onDeleteOption={onDeleteOption}
             onDeleteAnswer={this.handleDeleteAnswer}
@@ -197,5 +205,7 @@ export default flowRight(
   withCreateOption,
   withUpdateOption,
   withDeleteOption,
-  withMovePage
+  withMovePage,
+  withCreateOther,
+  withDeleteOther
 )(QPE);

--- a/src/components/SplitButton/Dropdown.js
+++ b/src/components/SplitButton/Dropdown.js
@@ -3,8 +3,9 @@ import styled from "styled-components";
 const Dropdown = styled.div`
   display: flex;
   flex-direction: column;
-  width: 23em;
+  width: 22.5em;
   padding: 0.25em;
+  background-color: white;
   margin-top: 0.25em;
   box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.3);
 `;

--- a/src/components/SplitButton/MenuButton.test.js
+++ b/src/components/SplitButton/MenuButton.test.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { shallow } from "enzyme";
+import MenuButton from "components/SplitButton/MenuButton";
+
+describe("SplitButton/MenuButton", () => {
+  it("should render", () => {
+    const wrapper = shallow(<MenuButton />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/SplitButton/MenuItem.js
+++ b/src/components/SplitButton/MenuItem.js
@@ -1,10 +1,13 @@
 import styled from "styled-components";
 import { colors } from "constants/theme";
 
-const MenuItem = styled.button`
+const MenuItem = styled.button.attrs({
+  type: "button"
+})`
+  font-size: 1em;
   border: none;
   text-align: left;
-  border-radius: 0.5em;
+  border-radius: 8px;
   padding: 0.75em 1.5em;
   margin-bottom: 0.25em;
   outline: none;

--- a/src/components/SplitButton/PrimaryButton.js
+++ b/src/components/SplitButton/PrimaryButton.js
@@ -1,7 +1,9 @@
 import styled from "styled-components";
 import Button from "../Button";
 
-const PrimaryButton = styled(Button).attrs({ variant: "secondary" })`
+const PrimaryButton = styled(Button).attrs({
+  variant: "secondary"
+})`
   border-radius: 4px 0 0 4px;
   border-right: 0;
   flex: 1;

--- a/src/components/SplitButton/SplitButton.story.js
+++ b/src/components/SplitButton/SplitButton.story.js
@@ -19,7 +19,7 @@ const UncontrolledSplitButton = uncontrollable(SplitButton, {
 storiesOf("SplitButton", module).add("Default", () => (
   <Wrapper>
     <UncontrolledSplitButton
-      primaryAction={action("Primary action")}
+      onPrimaryAction={action("Primary action")}
       primaryText="Add checkbox"
     >
       <Dropdown>

--- a/src/components/SplitButton/SplitButton.test.js
+++ b/src/components/SplitButton/SplitButton.test.js
@@ -12,10 +12,11 @@ const createWrapper = (
 ) =>
   render(
     <SplitButton
-      primaryAction={primaryAction}
+      onPrimaryAction={primaryAction}
       primaryText={primaryText}
       onToggleOpen={onToggleOpen}
       open={open}
+      dataTest="splitbutton"
     >
       {children}
     </SplitButton>

--- a/src/components/SplitButton/__snapshots__/MenuButton.test.js.snap
+++ b/src/components/SplitButton/__snapshots__/MenuButton.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SplitButton/MenuButton should render 1`] = `
+<MenuButton__StyledButton>
+  <IconText
+    hideText={true}
+    icon={[Function]}
+  >
+    Show additional options
+  </IconText>
+</MenuButton__StyledButton>
+`;

--- a/src/components/SplitButton/__snapshots__/SplitButton.test.js.snap
+++ b/src/components/SplitButton/__snapshots__/SplitButton.test.js.snap
@@ -3,6 +3,7 @@
 exports[`SplitButton should render when closed 1`] = `
 <SplitButton__FlexContainer>
   <PrimaryButton
+    data-test="splitbutton"
     onClick={[Function]}
   >
     Add checkbox
@@ -13,7 +14,11 @@ exports[`SplitButton should render when closed 1`] = `
     onToggleOpen={[Function]}
     open={false}
     transition={[Function]}
-    trigger={<MenuButton />}
+    trigger={
+      <MenuButton
+        data-test="splitbutton-menu"
+      />
+    }
     verticalAlignment="top"
   >
     <ButtonGroup>
@@ -33,6 +38,7 @@ exports[`SplitButton should render when closed 1`] = `
 exports[`SplitButton should render when open 1`] = `
 <SplitButton__FlexContainer>
   <PrimaryButton
+    data-test="splitbutton"
     onClick={[Function]}
   >
     Add checkbox
@@ -43,7 +49,11 @@ exports[`SplitButton should render when open 1`] = `
     onToggleOpen={[Function]}
     open={true}
     transition={[Function]}
-    trigger={<MenuButton />}
+    trigger={
+      <MenuButton
+        data-test="splitbutton-menu"
+      />
+    }
     verticalAlignment="top"
   >
     <ButtonGroup>

--- a/src/components/SplitButton/index.js
+++ b/src/components/SplitButton/index.js
@@ -12,11 +12,12 @@ const FlexContainer = styled.div`
 
 class SplitButton extends React.Component {
   static propTypes = {
-    primaryAction: PropTypes.func.isRequired,
+    onPrimaryAction: PropTypes.func.isRequired,
     primaryText: PropTypes.string.isRequired,
     onToggleOpen: PropTypes.func.isRequired,
     open: PropTypes.bool,
-    children: PropTypes.node
+    children: PropTypes.node,
+    dataTest: PropTypes.string
   };
 
   static defaultProps = {
@@ -28,11 +29,19 @@ class SplitButton extends React.Component {
   };
 
   render() {
-    const { primaryAction, primaryText, open, children } = this.props;
-    const trigger = <MenuButton />;
+    const {
+      onPrimaryAction,
+      primaryText,
+      open,
+      children,
+      dataTest
+    } = this.props;
+    const trigger = <MenuButton data-test={`${dataTest}-menu`} />;
     return (
       <FlexContainer>
-        <PrimaryButton onClick={primaryAction}>{primaryText}</PrimaryButton>
+        <PrimaryButton onClick={onPrimaryAction} data-test={dataTest}>
+          {primaryText}
+        </PrimaryButton>
         <Popout
           trigger={trigger}
           horizontalAlignment="right"

--- a/src/components/WrappingInput/index.js
+++ b/src/components/WrappingInput/index.js
@@ -27,6 +27,11 @@ const sizes = {
 
   small: css`
     font-size: 0.875em;
+  `,
+
+  tiny: css`
+    font-size: 0.75em;
+    font-weight: 700;
   `
 };
 

--- a/src/containers/enhancers/withCreateOther.js
+++ b/src/containers/enhancers/withCreateOther.js
@@ -1,0 +1,55 @@
+import { graphql } from "react-apollo";
+import createOtherMutation from "graphql/createOther.graphql";
+import fragment from "graphql/answerFragment.graphql";
+import optionFragment from "graphql/fragments/option.graphql";
+
+export const createUpdater = answerId => (proxy, result) => {
+  const parentAnswerId = `MultipleChoiceAnswer${answerId}`;
+  const other = result.data.createOther;
+  const otherAnswerId = `BasicAnswer${other.answer.id}`;
+  const otherOptionId = `Option${other.option.id}`;
+
+  const parentAnswer = proxy.readFragment({
+    id: parentAnswerId,
+    fragment
+  });
+
+  parentAnswer.other = other;
+
+  proxy.writeFragment({
+    id: otherAnswerId,
+    fragment,
+    data: other.answer
+  });
+
+  proxy.writeFragment({
+    id: otherOptionId,
+    fragment: optionFragment,
+    data: other.option
+  });
+
+  proxy.writeFragment({
+    id: parentAnswerId,
+    fragment,
+    data: parentAnswer
+  });
+};
+
+export const mapMutateToProps = ({ mutate, ownProps }) => ({
+  onAddOther({ id }) {
+    const input = {
+      parentAnswerId: id
+    };
+
+    const update = createUpdater(id);
+
+    return mutate({
+      variables: { input },
+      update
+    }).then(res => res.data.createOther);
+  }
+});
+
+export default graphql(createOtherMutation, {
+  props: mapMutateToProps
+});

--- a/src/containers/enhancers/withCreateOther.test.js
+++ b/src/containers/enhancers/withCreateOther.test.js
@@ -1,0 +1,102 @@
+import { mapMutateToProps, createUpdater } from "./withCreateOther";
+import fragment from "graphql/answerFragment.graphql";
+import optionFragment from "graphql/fragments/option.graphql";
+
+describe("containers/enhancers/withCreateOther", () => {
+  const checkboxAnswer = {
+    id: "1",
+    options: [
+      {
+        id: 1
+      }
+    ]
+  };
+
+  let mutate, result, other;
+
+  beforeEach(() => {
+    other = {
+      option: {
+        id: 2
+      },
+      answer: {
+        id: 2,
+        type: "TextField"
+      }
+    };
+
+    result = {
+      data: {
+        createOther: other
+      }
+    };
+
+    mutate = jest.fn(() => Promise.resolve(result));
+  });
+
+  describe("createUpdater", () => {
+    let id;
+    let writeFragment;
+    let readFragment;
+    let updater;
+
+    beforeEach(() => {
+      id = `MultipleChoiceAnswer${checkboxAnswer.id}`;
+      writeFragment = jest.fn();
+      readFragment = jest.fn(() => checkboxAnswer);
+      updater = createUpdater(checkboxAnswer.id);
+    });
+
+    it("should update the apollo cache", () => {
+      updater({ readFragment, writeFragment }, result);
+      expect(readFragment).toHaveBeenCalledWith({ id, fragment });
+      expect(writeFragment).toHaveBeenCalledWith({
+        id,
+        fragment,
+        data: checkboxAnswer
+      });
+
+      expect(writeFragment).toHaveBeenCalledWith({
+        id: `BasicAnswer${other.answer.id}`,
+        fragment,
+        data: other.answer
+      });
+
+      expect(writeFragment).toHaveBeenCalledWith({
+        id: `Option${other.option.id}`,
+        fragment: optionFragment,
+        data: other.option
+      });
+
+      expect(checkboxAnswer.other).toMatchObject(other);
+    });
+  });
+
+  describe("mapMutateToProps", () => {
+    let props;
+
+    beforeEach(() => {
+      props = mapMutateToProps({ mutate });
+    });
+
+    it("should have a onAddOther prop", () => {
+      expect(props.onAddOther).toBeInstanceOf(Function);
+    });
+
+    it("should call mutate", () => {
+      return props.onAddOther(checkboxAnswer).then(() => {
+        expect(mutate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: {
+              input: { parentAnswerId: checkboxAnswer.id }
+            }
+          })
+        );
+      });
+    });
+
+    it("should unwrap the entity from the apollo result", () => {
+      expect(props.onAddOther(checkboxAnswer)).resolves.toBe(other);
+    });
+  });
+});

--- a/src/containers/enhancers/withDeleteOther.js
+++ b/src/containers/enhancers/withDeleteOther.js
@@ -1,0 +1,33 @@
+import { graphql } from "react-apollo";
+import deleteOtherMutation from "graphql/deleteOther.graphql";
+import fragment from "graphql/answerFragment.graphql";
+
+export const deleteUpdater = answerId => (proxy, result) => {
+  const id = `MultipleChoiceAnswer${answerId}`;
+  const parentAnswer = proxy.readFragment({ id, fragment });
+
+  parentAnswer.other = null;
+
+  proxy.writeFragment({
+    id,
+    fragment,
+    data: parentAnswer
+  });
+};
+
+export const mapMutateToProps = ({ ownProps, mutate }) => ({
+  onDeleteOther({ id }) {
+    const answer = { parentAnswerId: id };
+
+    const update = deleteUpdater(id);
+
+    return mutate({
+      variables: { input: answer },
+      update
+    });
+  }
+});
+
+export default graphql(deleteOtherMutation, {
+  props: mapMutateToProps
+});

--- a/src/containers/enhancers/withDeleteOther.test.js
+++ b/src/containers/enhancers/withDeleteOther.test.js
@@ -1,0 +1,91 @@
+import {
+  mapMutateToProps,
+  deleteUpdater
+} from "containers/enhancers/withDeleteOther";
+import fragment from "graphql/answerFragment.graphql";
+
+describe("containers/enhancers/withDeleteOther", () => {
+  let mutate, result, raiseToast, ownProps;
+  let other, checkboxAnswer;
+
+  beforeEach(() => {
+    other = {
+      option: {
+        id: 2
+      },
+      answer: {
+        id: 2,
+        type: "TextField"
+      }
+    };
+
+    checkboxAnswer = {
+      id: "1",
+      sectionId: "1",
+      options: [
+        {
+          id: 1,
+          label: "one"
+        }
+      ],
+      other
+    };
+
+    result = {
+      data: {
+        deleteOther: other
+      }
+    };
+
+    raiseToast = jest.fn(() => Promise.resolve());
+
+    ownProps = {
+      raiseToast
+    };
+
+    mutate = jest.fn(() => Promise.resolve(result));
+  });
+
+  describe("deleteUpdater", () => {
+    it("should remove the other from the cache", () => {
+      const id = `MultipleChoiceAnswer${checkboxAnswer.id}`;
+      const writeFragment = jest.fn();
+      const readFragment = jest.fn(() => checkboxAnswer);
+
+      const updater = deleteUpdater(checkboxAnswer.id);
+      updater({ readFragment, writeFragment }, result);
+
+      expect(readFragment).toHaveBeenCalledWith({ id, fragment });
+      expect(writeFragment).toHaveBeenCalledWith({
+        id,
+        fragment,
+        data: checkboxAnswer
+      });
+      expect(checkboxAnswer.other).toBeNull();
+    });
+  });
+
+  describe("mapMutateToProps", () => {
+    let props;
+
+    beforeEach(() => {
+      props = mapMutateToProps({ ownProps, mutate });
+    });
+
+    it("should call mutate when onDeleteOther is invoked", () => {
+      return props.onDeleteOther(checkboxAnswer).then(() => {
+        expect(mutate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variables: {
+              input: { parentAnswerId: checkboxAnswer.id }
+            }
+          })
+        );
+      });
+    });
+
+    it("should return promise that resolves to deleteOther result", () => {
+      return expect(props.onDeleteOther(checkboxAnswer)).resolves.toBe(result);
+    });
+  });
+});

--- a/src/graphql/answerFragment.graphql
+++ b/src/graphql/answerFragment.graphql
@@ -3,5 +3,13 @@ fragment MinimalAnswer on Answer {
     options {
       id
     }
+    other {
+      option {
+        id
+      }
+      answer {
+        id
+      }
+    }
   }
 }

--- a/src/graphql/createAnswer.graphql
+++ b/src/graphql/createAnswer.graphql
@@ -11,6 +11,14 @@ mutation createAnswer($input: CreateAnswerInput!) {
       options {
         ...Option
       }
+      other {
+        option {
+          ...Option
+        }
+        answer {
+          ...Answer
+        }
+      }
     }
   }
 }

--- a/src/graphql/createOther.graphql
+++ b/src/graphql/createOther.graphql
@@ -1,0 +1,13 @@
+#import "./fragments/answer.graphql"
+#import "./fragments/option.graphql"
+
+mutation createOther($input: CreateOtherInput!) {
+  createOther(input: $input) {
+    answer {
+      ...Answer
+    }
+    option {
+      ...Option
+    }
+  }
+}

--- a/src/graphql/deleteOther.graphql
+++ b/src/graphql/deleteOther.graphql
@@ -1,0 +1,13 @@
+#import "./fragments/answer.graphql"
+#import "./fragments/option.graphql"
+
+mutation DeleteOther($input: DeleteOtherInput!) {
+  deleteOther(input: $input) {
+    option {
+      ...Option
+    }
+    answer {
+      ...Answer
+    }
+  }
+}

--- a/src/graphql/getQuestionnaire.graphql
+++ b/src/graphql/getQuestionnaire.graphql
@@ -22,6 +22,14 @@ query GetQuestionnaire($id: ID!) {
               options {
                 ...Option
               }
+              other {
+                option {
+                  ...Option
+                }
+                answer {
+                  ...Answer
+                }
+              }
             }
           }
         }

--- a/src/tests/utils/MockResolvers.js
+++ b/src/tests/utils/MockResolvers.js
@@ -137,6 +137,12 @@ export default {
     },
     deleteOption: (root, args, ctx) => {
       return persistMutation(DataStore.deleteOption(merge({}, args.input)));
+    },
+    createOther: (root, args, ctx) => {
+      return persistMutation(DataStore.createOther(merge({}, args.input)));
+    },
+    deleteOther: (root, args, ctx) => {
+      return persistMutation(DataStore.deleteOther(merge({}, args.input)));
     }
   }),
 
@@ -171,6 +177,7 @@ export default {
 
   MultipleChoiceAnswer: () => ({
     page: (answer, args, ctx) => DataStore.getPage(answer.questionPageId),
-    options: (answer, args, ctx) => DataStore.getOptions(answer.id)
+    options: (answer, args, ctx) => DataStore.getOptions(answer.id),
+    other: (answer, args, ctx) => DataStore.getOther(answer.id)
   })
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3446,9 +3446,9 @@ enzyme@^3.1.0:
     raf "^3.3.2"
     rst-selector-parser "^2.2.2"
 
-eq-author-graphql-schema@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.9.0.tgz#09908b0e4007ea58f98e969c1186462849fde935"
+eq-author-graphql-schema@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.12.0.tgz#1013b6efbe13856f15bb30328c2e07a0561200a8"
 
 eq-author-mock-api@ONSdigital/eq-author-mock-api#4342f6a:
   version "1.0.0"


### PR DESCRIPTION
### What is the context of this PR?
This PR makes changes to the Author application to allow an author to add and remove "other" option to Checkbox/Radio answers.

### How to review 
Should be able to add/remove other option. The values entered for the label/description of the other option and text field answer should be persisted.
Should pass all existing tests and checks and generally behave as expected.

### Dependencies
 - [x] https://github.com/ONSdigital/eq-author-graphql-schema/pull/32
 - [x] https://github.com/ONSdigital/eq-author-api/pull/64
 - [x] https://github.com/ONSdigital/eq-publisher/pull/59
