### PR TITLE
Fix undelete position

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -26,7 +26,6 @@ Object {
           Symbol(id): "Section1",
         },
       ],
-      "theme": "default",
       "title": "Integration test questionnaire",
       Symbol(id): "Questionnaire1",
     },

--- a/src/graphql/createQuestionnaire.graphql
+++ b/src/graphql/createQuestionnaire.graphql
@@ -1,6 +1,11 @@
 mutation createQuestionnaire($input: CreateQuestionnaireInput!) {
   createQuestionnaire(input: $input) {
     id
+    title
+    createdAt
+    createdBy {
+      name
+    }
     sections {
       id
       pages {

--- a/src/graphql/getQuestionnaireList.graphql
+++ b/src/graphql/getQuestionnaireList.graphql
@@ -6,7 +6,6 @@ query GetQuestionnaireList {
     createdBy {
       name
     }
-    theme
     sections {
       id
       pages {

--- a/src/graphql/undeletePage.graphql
+++ b/src/graphql/undeletePage.graphql
@@ -1,5 +1,6 @@
 mutation UndeletePage($input: UndeleteQuestionPageInput!) {
   undeleteQuestionPage(input: $input) {
     id
+    position
   }
 }

--- a/src/graphql/undeleteQuestionnaire.graphql
+++ b/src/graphql/undeleteQuestionnaire.graphql
@@ -1,5 +1,6 @@
 mutation UndeleteQuestionnaire($input: UndeleteQuestionnaireInput!) {
   undeleteQuestionnaire(input: $input) {
     id
+    createdAt
   }
 }

--- a/src/redux/undelete/undeletePage.js
+++ b/src/redux/undelete/undeletePage.js
@@ -1,6 +1,5 @@
 import query from "graphql/undeletePage.graphql";
 import fragment from "graphql/sectionFragment.graphql";
-import { findUndeleteIndex } from "utils/findUndeleteIndex";
 import createMutate from "utils/createMutate";
 
 export const UNDELETE_PAGE_REQUEST = "UNDELETE_PAGE_REQUEST";
@@ -26,11 +25,11 @@ const undeleteFailure = () => {
 };
 
 export const createUpdate = context => (proxy, result) => {
+  const page = result.data.undeleteQuestionPage;
   const id = `Section${context.sectionId}`;
   const section = proxy.readFragment({ id, fragment });
 
-  const index = findUndeleteIndex(section.pages, context.pageId);
-  section.pages.splice(index, 0, result.data.undeleteQuestionPage);
+  section.pages.splice(page.position, 0, page);
 
   proxy.writeFragment({
     id,

--- a/src/redux/undelete/undeletePage.test.js
+++ b/src/redux/undelete/undeletePage.test.js
@@ -31,7 +31,8 @@ describe("undeletePage", () => {
     result = {
       data: {
         undeleteQuestionPage: {
-          id: 1
+          id: 1,
+          position: 1
         }
       }
     };
@@ -39,7 +40,7 @@ describe("undeletePage", () => {
     proxy = {
       readFragment: jest.fn(() => {
         return {
-          pages: []
+          pages: [{ id: 2, position: 0 }, { id: 3, position: 2 }]
         };
       }),
       writeFragment: jest.fn()
@@ -68,21 +69,23 @@ describe("undeletePage", () => {
   });
 
   describe("createUpdate", () => {
-    it("should call the correct query on the proxy", () => {
+    it("should insert the page at the correct position", () => {
       createUpdate(context)(proxy, result);
+
       expect(proxy.readFragment).toHaveBeenCalledWith({
         id: "Section1",
         fragment
       });
-    });
 
-    it("should write data back to the proxy", () => {
-      createUpdate(context)(proxy, result);
       expect(proxy.writeFragment).toHaveBeenCalledWith({
         id: "Section1",
         fragment,
         data: {
-          pages: [{ id: 1 }]
+          pages: [
+            { id: 2, position: 0 },
+            { id: 1, position: 1 },
+            { id: 3, position: 2 }
+          ]
         }
       });
     });

--- a/src/redux/undelete/undeleteQuestionnaire.test.js
+++ b/src/redux/undelete/undeleteQuestionnaire.test.js
@@ -30,7 +30,8 @@ describe("undeleteQuestionnaire", () => {
     result = {
       data: {
         undeleteQuestionnaire: {
-          id: 1
+          id: 2,
+          createdAt: "2018-04-02"
         }
       }
     };
@@ -38,7 +39,16 @@ describe("undeleteQuestionnaire", () => {
     proxy = {
       readQuery: jest.fn(() => {
         return {
-          questionnaires: []
+          questionnaires: [
+            {
+              id: 3,
+              createdAt: "2018-04-03"
+            },
+            {
+              id: 1,
+              createdAt: "2018-04-01"
+            }
+          ]
         };
       }),
       writeQuery: jest.fn()
@@ -69,17 +79,32 @@ describe("undeleteQuestionnaire", () => {
   describe("createUpdate", () => {
     it("should call the correct query on the proxy", () => {
       createUpdate(context)(proxy, result);
+    });
+
+    it("should insert the questionnaire at the correct position", () => {
+      createUpdate(context)(proxy, result);
+
       expect(proxy.readQuery).toHaveBeenCalledWith({
         query: GetQuestionnaireList
       });
-    });
 
-    it("should write data back to the proxy", () => {
-      createUpdate(context)(proxy, result);
       expect(proxy.writeQuery).toHaveBeenCalledWith({
         query: GetQuestionnaireList,
         data: {
-          questionnaires: [{ id: 1 }]
+          questionnaires: [
+            {
+              id: 3,
+              createdAt: "2018-04-03"
+            },
+            {
+              id: 2,
+              createdAt: "2018-04-02"
+            },
+            {
+              id: 1,
+              createdAt: "2018-04-01"
+            }
+          ]
         }
       });
     });


### PR DESCRIPTION
### What is the context of this PR?
Pages and Questionnaires would be inserted at incorrect position when un-deleting. This PR fixes that.

### How to review 
* Code looks good
* Tests pass
* After moving a page, then deleting a page, then undoing deletion of page, the page is returned to the correct position
* After deleting a questionnaire, and undoing deletion, the questionnaire should return to the correct place in the list (ordered by creation date DESC)

Fixes #349