### PR TITLE
Fixed table column widths

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -22,6 +22,7 @@ import shareIcon from "./icon-share.svg?inline";
 import previewIcon from "./icon-preview.svg?inline";
 
 import IconText from "components/IconText";
+import Truncated from "../Truncated";
 
 const StyledHeader = styled.header`
   display: flex;
@@ -41,16 +42,14 @@ const QuestionnaireTitle = styled.div`
   white-space: pre;
 `;
 
-const Title = styled.h1`
+const TruncatedTitle = Truncated.withComponent("h1");
+const Title = styled(TruncatedTitle)`
   font-size: 1em;
   font-weight: 600;
   margin: 0 2em;
   width: 100%;
   text-align: center;
   line-height: 1;
-  overflow: hidden;
-  white-space: pre;
-  text-overflow: ellipsis;
 `;
 
 const ShareButton = styled(Button)`

--- a/src/components/IconText/index.js
+++ b/src/components/IconText/index.js
@@ -9,9 +9,11 @@ const IconWithText = styled.span`
   padding-right: ${props => (props.hideText ? 0 : "0.5em")};
   line-height: 1.3;
   color: var(--color-text);
+  width: 100%;
 
   svg {
     pointer-events: none;
+    flex: 0 0 2em;
     path {
       fill: var(--color-text);
     }

--- a/src/components/IconText/index.js
+++ b/src/components/IconText/index.js
@@ -18,8 +18,8 @@ const IconWithText = styled.span`
   }
 `;
 
-const IconText = ({ icon: Icon, hideText, children }) => (
-  <IconWithText hideText={hideText}>
+const IconText = ({ icon: Icon, hideText, children, ...otherProps }) => (
+  <IconWithText hideText={hideText} {...otherProps}>
     <Icon />
     {hideText ? <VisuallyHidden>{children}</VisuallyHidden> : children}
   </IconWithText>

--- a/src/components/MovePageModal/ItemSelect.js
+++ b/src/components/MovePageModal/ItemSelect.js
@@ -7,18 +7,12 @@ import IconMoveIndicator from "./icon-move-indicator.svg?inline";
 import { uniqueId } from "lodash";
 import withChangeHandler from "../Forms/withChangeHandler";
 import IconText from "../IconText";
+import Truncated from "components/Truncated";
 
 const Input = VisuallyHidden.withComponent("input");
 Input.defaultProps = {
   type: "radio"
 };
-
-const Truncated = styled.span`
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
 
 const Label = styled.label`
   display: flex;

--- a/src/components/MovePageModal/__snapshots__/ItemSelect.test.js.snap
+++ b/src/components/MovePageModal/__snapshots__/ItemSelect.test.js.snap
@@ -14,14 +14,13 @@ exports[`MovePageModal/ItemSelect Option should render 1`] = `
     htmlFor="test"
     selected={true}
   >
-    <IconText
-      hideText={false}
+    <ItemSelect__StyledIconText
       icon={[Function]}
     >
-      <ItemSelect__Truncated>
+      <Truncated>
         bar
-      </ItemSelect__Truncated>
-    </IconText>
+      </Truncated>
+    </ItemSelect__StyledIconText>
   </ItemSelect__Label>
 </div>
 `;

--- a/src/components/MovePageModal/__snapshots__/ItemSelect.test.js.snap
+++ b/src/components/MovePageModal/__snapshots__/ItemSelect.test.js.snap
@@ -14,13 +14,14 @@ exports[`MovePageModal/ItemSelect Option should render 1`] = `
     htmlFor="test"
     selected={true}
   >
-    <ItemSelect__StyledIconText
+    <IconText
+      hideText={false}
       icon={[Function]}
     >
       <Truncated>
         bar
       </Truncated>
-    </ItemSelect__StyledIconText>
+    </IconText>
   </ItemSelect__Label>
 </div>
 `;

--- a/src/components/MovePageModal/__snapshots__/index.test.js.snap
+++ b/src/components/MovePageModal/__snapshots__/index.test.js.snap
@@ -22,7 +22,9 @@ exports[`MovePageModal/MovePageModal should render 1`] = `
     id="MovePageModal1"
     onClick={[Function]}
   >
-    Section 1
+    <Truncated>
+      Section 1
+    </Truncated>
   </MovePageModal__Trigger>
   <ItemSelectModal
     isOpen={false}

--- a/src/components/MovePageModal/index.js
+++ b/src/components/MovePageModal/index.js
@@ -12,6 +12,7 @@ import Icon from "assets/icon-select.svg";
 import ItemSelect, { Option } from "./ItemSelect";
 
 import { colors } from "constants/theme";
+import Truncated from "../Truncated";
 
 const StyledModal = styled(Modal)`
   .Modal {
@@ -44,6 +45,7 @@ const Trigger = styled.button.attrs({ type: "button" })`
   width: 100%;
   font-size: 1em;
   padding: 0.5rem;
+  padding-right: 2em;
   background: white url('${Icon}') no-repeat right center;
   border: solid 1px #aeaeae;
   text-align: left;
@@ -237,7 +239,9 @@ class MovePageModal extends React.Component {
 
         <Label htmlFor={sectionButtonId}>Section</Label>
         <Trigger id={sectionButtonId} onClick={this.handleOpenSectionSelect}>
-          {getTextFromHTML(section.title) || "Untitled Section"}
+          <Truncated>
+            {getTextFromHTML(section.title) || "Untitled Section"}
+          </Truncated>
         </Trigger>
         {this.renderSectionSelect(section)}
 

--- a/src/components/NavigationSidebar/PageNavItem.js
+++ b/src/components/NavigationSidebar/PageNavItem.js
@@ -8,6 +8,7 @@ import getTextFromHTML from "utils/getTextFromHTML";
 import pageIcon from "./icon-questionpage.svg";
 import { transparentize } from "polished";
 import { colors } from "constants/theme";
+import Truncated from "../Truncated";
 
 const duration = 300;
 
@@ -87,15 +88,12 @@ const Link = styled(NavLink)`
   }
 `;
 
-export const LinkText = styled.span`
+export const LinkText = styled(Truncated)`
   display: inline-block;
   vertical-align: middle;
   width: 100%;
   position: relative;
   z-index: 2;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   opacity: ${({ fade }) => (fade ? 0.5 : 1)};
   font-size: 0.75em;
 `;

--- a/src/components/NavigationSidebar/SectionNavLink.js
+++ b/src/components/NavigationSidebar/SectionNavLink.js
@@ -11,14 +11,13 @@ import getTextFromHTML from "utils/getTextFromHTML";
 import { rgba } from "polished";
 
 import CustomPropTypes from "custom-prop-types";
+import Truncated from "../Truncated";
 
 const textInverted = "#E1E1E1";
 
 const Link = styled(NavLink)`
   text-decoration: none;
   color: ${textInverted};
-  overflow: hidden;
-  text-overflow: ellipsis;
   display: block;
   width: 100%;
   padding: 0.3em 0.5em;
@@ -43,17 +42,13 @@ const Link = styled(NavLink)`
   }
 `;
 
-const Title = styled.span`
+const Title = styled(Truncated)`
   padding: 0.5em 2.5em 0.5em 0;
   font-size: 0.75em;
   margin: 0;
   font-weight: 900;
   position: relative;
-  width: 100%;
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+
   color: ${textInverted};
 
   &::before {

--- a/src/components/NavigationSidebar/__snapshots__/PageNavItem.test.js.snap
+++ b/src/components/NavigationSidebar/__snapshots__/PageNavItem.test.js.snap
@@ -7,14 +7,11 @@ exports[`PageNavItem LinkText should be opaque 1`] = `
   width: 100%;
   position: relative;
   z-index: 2;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   opacity: 1;
   font-size: 0.75em;
 }
 
-<span
+<Truncated
   className="c0"
 />
 `;
@@ -26,15 +23,13 @@ exports[`PageNavItem LinkText should be partially transparent if fade prop passe
   width: 100%;
   position: relative;
   z-index: 2;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   opacity: 0.5;
   font-size: 0.75em;
 }
 
-<span
+<Truncated
   className="c0"
+  fade={true}
 />
 `;
 

--- a/src/components/SignInForm/GuestSignInForm.js
+++ b/src/components/SignInForm/GuestSignInForm.js
@@ -4,8 +4,11 @@ import PropTypes from "prop-types";
 import Button from "components/Button";
 import { partial } from "lodash";
 
+const displayName =
+  process.env.NODE_ENV === "development" ? "Guesty McGuestFace" : "Guest";
+
 const GUEST_USER = {
-  displayName: "Guest",
+  displayName,
   email: "guest@example.org"
 };
 

--- a/src/components/ToggleChip/__snapshots__/ToggleChip.test.js.snap
+++ b/src/components/ToggleChip/__snapshots__/ToggleChip.test.js.snap
@@ -13,12 +13,12 @@ exports[`ToggleChip should render 1`] = `
     checked={false}
     htmlFor="test"
   >
-    <ToggleChip__Truncated
+    <ToggleChip__Text
       maxWidth={30}
       title="Test chip"
     >
       Test
-    </ToggleChip__Truncated>
+    </ToggleChip__Text>
   </ToggleChip__Label>
 </ToggleChip__Field>
 `;
@@ -36,12 +36,12 @@ exports[`ToggleChip should render checked 1`] = `
     checked={true}
     htmlFor="chiptoggle-1"
   >
-    <ToggleChip__Truncated
+    <ToggleChip__Text
       maxWidth={30}
       title="Test chip"
     >
       Test
-    </ToggleChip__Truncated>
+    </ToggleChip__Text>
   </ToggleChip__Label>
 </ToggleChip__Field>
 `;

--- a/src/components/ToggleChip/index.js
+++ b/src/components/ToggleChip/index.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import styled, { css } from "styled-components";
 import { colors } from "constants/theme";
 import checkedIcon from "./checked.svg";
+import Truncated from "components/Truncated";
 
 const labelStyles = {
   checked: css`
@@ -68,15 +69,12 @@ export const Label = styled.label`
   ${props => (props.checked ? labelStyles.checked : labelStyles.unchecked)};
 `;
 
-const Truncated = styled.span`
+const Text = styled(Truncated)`
   display: inline-block;
   max-width: ${props => props.maxWidth}em;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 `;
 
-Truncated.defaultProps = {
+Text.defaultProps = {
   maxWidth: 30
 };
 
@@ -134,9 +132,9 @@ class ToggleChip extends React.Component {
           onChange={this.handleToggle}
         />
         <Label htmlFor={id} checked={checked}>
-          <Truncated title={title} maxWidth={maxWidth}>
+          <Text title={title} maxWidth={maxWidth}>
             {children}
-          </Truncated>
+          </Text>
         </Label>
       </Field>
     );

--- a/src/components/Truncated/index.js
+++ b/src/components/Truncated/index.js
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+const Truncated = styled.span`
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export default Truncated;

--- a/src/components/Truncated/index.js
+++ b/src/components/Truncated/index.js
@@ -5,6 +5,7 @@ const Truncated = styled.span`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1;
 `;
 
 export default Truncated;

--- a/src/containers/QuestionnairesPage/QuestionnaireLink.js
+++ b/src/containers/QuestionnairesPage/QuestionnaireLink.js
@@ -1,3 +1,4 @@
+import React from "react";
 import styled from "styled-components";
 import { NavLink } from "react-router-dom";
 import { getLink } from "utils/UrlUtils";
@@ -5,27 +6,24 @@ import { colors } from "constants/theme";
 import CustomPropTypes from "custom-prop-types";
 import { get } from "lodash";
 
-const QuestionnaireLink = styled(NavLink).attrs({
-  to: ({ questionnaire }) =>
-    getLink(
-      questionnaire.id,
-      get(questionnaire, "sections[0].id"),
-      get(questionnaire, "sections[0].pages[0].id")
-    )
-})`
+const StyledLink = styled(NavLink)`
   text-decoration: none;
   color: ${colors.blue};
-  width: 100%;
-  max-width: 33em;
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 
   &:hover {
     text-decoration: underline;
   }
 `;
+
+const QuestionnaireLink = ({ questionnaire, ...otherProps }) => {
+  const to = getLink(
+    questionnaire.id,
+    get(questionnaire, "sections[0].id"),
+    get(questionnaire, "sections[0].pages[0].id")
+  );
+
+  return <StyledLink {...otherProps} to={to} />;
+};
 
 QuestionnaireLink.propTypes = {
   questionnaire: CustomPropTypes.questionnaire

--- a/src/containers/QuestionnairesPage/QuestionnairesTable.js
+++ b/src/containers/QuestionnairesPage/QuestionnairesTable.js
@@ -3,10 +3,11 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
-import { partial } from "lodash";
+import { partial, isEmpty } from "lodash";
 import IconButtonDelete from "components/IconButtonDelete";
 import QuestionnaireLink from "./QuestionnaireLink";
 import FormattedDate from "./FormattedDate";
+import Truncated from "components/Truncated";
 
 const Table = styled.table`
   width: 100%;
@@ -15,6 +16,9 @@ const Table = styled.table`
   table-layout: fixed;
   text-align: left;
 `;
+
+const TruncatedQuestionnaireLink = Truncated.withComponent(QuestionnaireLink);
+TruncatedQuestionnaireLink.displayName = "TruncatedQuestionnaireLink";
 
 const TH = styled.th`
   padding: 1.5em 1em;
@@ -80,7 +84,7 @@ const QuestionnairesTable = ({
   questionnaires,
   onDeleteQuestionnaire: handleDelete
 }) => {
-  if (!questionnaires || questionnaires.length === 0) {
+  if (isEmpty(questionnaires)) {
     return <p>You have no questionnaires</p>;
   }
 
@@ -100,13 +104,12 @@ const QuestionnairesTable = ({
             <TR>
               <TD>
                 <Collapsible>
-                  <QuestionnaireLink
+                  <TruncatedQuestionnaireLink
                     questionnaire={questionnaire}
                     title={questionnaire.title}
-                    aria-label={questionnaire.title}
                   >
                     {questionnaire.title}
-                  </QuestionnaireLink>
+                  </TruncatedQuestionnaireLink>
                 </Collapsible>
               </TD>
               <TD>
@@ -116,7 +119,9 @@ const QuestionnairesTable = ({
               </TD>
               <TD>
                 <Collapsible>
-                  {questionnaire.createdBy.name || "Unknown"}
+                  <Truncated>
+                    {questionnaire.createdBy.name || "Unknown"}
+                  </Truncated>
                 </Collapsible>
               </TD>
               <TD textAlign="center">

--- a/src/containers/QuestionnairesPage/QuestionnairesTable.js
+++ b/src/containers/QuestionnairesPage/QuestionnairesTable.js
@@ -8,21 +8,23 @@ import IconButtonDelete from "components/IconButtonDelete";
 import QuestionnaireLink from "./QuestionnaireLink";
 import FormattedDate from "./FormattedDate";
 
-export const DeleteButton = styled(IconButtonDelete)`
-  padding: 0;
-`;
-
 const Table = styled.table`
   width: 100%;
   font-size: 0.9em;
   border-collapse: collapse;
+  table-layout: fixed;
   text-align: left;
 `;
 
 const TH = styled.th`
   padding: 1.5em 1em;
   color: #8e8e8e;
+  width: ${props => props.colWidth};
 `;
+
+TH.propTypes = {
+  colWidth: PropTypes.string.isRequired
+};
 
 const TR = styled.tr`
   border-top: 1px solid #e2e2e2;
@@ -31,7 +33,16 @@ const TR = styled.tr`
 
 const TD = styled.td`
   line-height: 2;
+  text-align: ${props => props.textAlign};
 `;
+
+TD.propTypes = {
+  textAlign: PropTypes.oneOf(["left", "center", "right"])
+};
+
+TD.defaultProps = {
+  textAlign: "left"
+};
 
 const Collapsible = styled.div`
   height: 3.75em;
@@ -77,10 +88,10 @@ const QuestionnairesTable = ({
     <Table>
       <thead>
         <tr>
-          <TH>Questionnaire name</TH>
-          <TH>Date</TH>
-          <TH>Created by</TH>
-          <TH />
+          <TH colWidth="50%">Questionnaire name</TH>
+          <TH colWidth="15%">Date</TH>
+          <TH colWidth="25%">Created by</TH>
+          <TH colWidth="10%" />
         </tr>
       </thead>
       <TransitionGroup enter={false} component={TBody}>
@@ -108,13 +119,11 @@ const QuestionnairesTable = ({
                   {questionnaire.createdBy.name || "Unknown"}
                 </Collapsible>
               </TD>
-              <TD>
+              <TD textAlign="center">
                 <Collapsible>
-                  <DeleteButton
+                  <IconButtonDelete
                     onClick={partial(handleDelete, questionnaire.id)}
-                  >
-                    Delete {questionnaire.title}
-                  </DeleteButton>
+                  />
                 </Collapsible>
               </TD>
             </TR>

--- a/src/containers/QuestionnairesPage/QuestionnairesTables.test.js
+++ b/src/containers/QuestionnairesPage/QuestionnairesTables.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
-import QuestionnairesTable, { DeleteButton } from "./QuestionnairesTable";
+import QuestionnairesTable from "./QuestionnairesTable";
+import IconButtonDelete from "components/IconButtonDelete";
 
 describe("QuestionnairesTable", () => {
   const questionnaires = [
@@ -53,7 +54,7 @@ describe("QuestionnairesTable", () => {
 
   it("should allow deletion of Questionnaire", () => {
     wrapper
-      .find(DeleteButton)
+      .find(IconButtonDelete)
       .first()
       .simulate("click");
 

--- a/src/containers/QuestionnairesPage/__snapshots__/QuestionnaireLink.test.js.snap
+++ b/src/containers/QuestionnairesPage/__snapshots__/QuestionnaireLink.test.js.snap
@@ -3,45 +3,7 @@
 exports[`QuestionnaireLink should link to section if cannot link to page 1`] = `"/questionnaire/1/design/1"`;
 
 exports[`QuestionnaireLink should render 1`] = `
-.c0 {
-  text-decoration: none;
-  color: #3B7A9E;
-  width: 100%;
-  max-width: 33em;
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.c0:hover {
-  text-decoration: underline;
-}
-
-<NavLink
-  activeClassName="active"
-  ariaCurrent="true"
-  className="c0"
-  questionnaire={
-    Object {
-      "createdAt": "2017/01/02",
-      "createdBy": Object {
-        "name": "Alan",
-      },
-      "id": "1",
-      "sections": Array [
-        Object {
-          "id": "1",
-          "pages": Array [
-            Object {
-              "id": "1",
-            },
-          ],
-        },
-      ],
-      "title": "Foo",
-    }
-  }
+<QuestionnaireLink__StyledLink
   to="/questionnaire/1/design/1/1"
 />
 `;

--- a/src/containers/QuestionnairesPage/__snapshots__/QuestionnairesTables.test.js.snap
+++ b/src/containers/QuestionnairesPage/__snapshots__/QuestionnairesTables.test.js.snap
@@ -38,8 +38,7 @@ exports[`QuestionnairesTable should render 1`] = `
           textAlign="left"
         >
           <QuestionnairesTable__Collapsible>
-            <QuestionnaireLink
-              aria-label="Foo"
+            <TruncatedQuestionnaireLink
               questionnaire={
                 Object {
                   "createdAt": "2017/01/02",
@@ -63,7 +62,7 @@ exports[`QuestionnairesTable should render 1`] = `
               title="Foo"
             >
               Foo
-            </QuestionnaireLink>
+            </TruncatedQuestionnaireLink>
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
         <QuestionnairesTable__TD
@@ -79,7 +78,9 @@ exports[`QuestionnairesTable should render 1`] = `
           textAlign="left"
         >
           <QuestionnairesTable__Collapsible>
-            Alan
+            <Truncated>
+              Alan
+            </Truncated>
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
         <QuestionnairesTable__TD
@@ -102,8 +103,7 @@ exports[`QuestionnairesTable should render 1`] = `
           textAlign="left"
         >
           <QuestionnairesTable__Collapsible>
-            <QuestionnaireLink
-              aria-label="Bar"
+            <TruncatedQuestionnaireLink
               questionnaire={
                 Object {
                   "createdAt": "2017/03/04",
@@ -127,7 +127,7 @@ exports[`QuestionnairesTable should render 1`] = `
               title="Bar"
             >
               Bar
-            </QuestionnaireLink>
+            </TruncatedQuestionnaireLink>
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
         <QuestionnairesTable__TD
@@ -143,7 +143,9 @@ exports[`QuestionnairesTable should render 1`] = `
           textAlign="left"
         >
           <QuestionnairesTable__Collapsible>
-            Lynn
+            <Truncated>
+              Lynn
+            </Truncated>
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
         <QuestionnairesTable__TD

--- a/src/containers/QuestionnairesPage/__snapshots__/QuestionnairesTables.test.js.snap
+++ b/src/containers/QuestionnairesPage/__snapshots__/QuestionnairesTables.test.js.snap
@@ -4,16 +4,24 @@ exports[`QuestionnairesTable should render 1`] = `
 <QuestionnairesTable__Table>
   <thead>
     <tr>
-      <QuestionnairesTable__TH>
+      <QuestionnairesTable__TH
+        colWidth="50%"
+      >
         Questionnaire name
       </QuestionnairesTable__TH>
-      <QuestionnairesTable__TH>
+      <QuestionnairesTable__TH
+        colWidth="15%"
+      >
         Date
       </QuestionnairesTable__TH>
-      <QuestionnairesTable__TH>
+      <QuestionnairesTable__TH
+        colWidth="25%"
+      >
         Created by
       </QuestionnairesTable__TH>
-      <QuestionnairesTable__TH />
+      <QuestionnairesTable__TH
+        colWidth="10%"
+      />
     </tr>
   </thead>
   <TransitionGroup
@@ -26,7 +34,9 @@ exports[`QuestionnairesTable should render 1`] = `
       timeout={200}
     >
       <QuestionnairesTable__TR>
-        <QuestionnairesTable__TD>
+        <QuestionnairesTable__TD
+          textAlign="left"
+        >
           <QuestionnairesTable__Collapsible>
             <QuestionnaireLink
               aria-label="Foo"
@@ -56,26 +66,29 @@ exports[`QuestionnairesTable should render 1`] = `
             </QuestionnaireLink>
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
-        <QuestionnairesTable__TD>
+        <QuestionnairesTable__TD
+          textAlign="left"
+        >
           <QuestionnairesTable__Collapsible>
             <FormattedDate
               date="2017/01/02"
             />
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
-        <QuestionnairesTable__TD>
+        <QuestionnairesTable__TD
+          textAlign="left"
+        >
           <QuestionnairesTable__Collapsible>
             Alan
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
-        <QuestionnairesTable__TD>
+        <QuestionnairesTable__TD
+          textAlign="center"
+        >
           <QuestionnairesTable__Collapsible>
-            <QuestionnairesTable__DeleteButton
+            <IconButtonDelete
               onClick={[Function]}
-            >
-              Delete 
-              Foo
-            </QuestionnairesTable__DeleteButton>
+            />
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
       </QuestionnairesTable__TR>
@@ -85,7 +98,9 @@ exports[`QuestionnairesTable should render 1`] = `
       timeout={200}
     >
       <QuestionnairesTable__TR>
-        <QuestionnairesTable__TD>
+        <QuestionnairesTable__TD
+          textAlign="left"
+        >
           <QuestionnairesTable__Collapsible>
             <QuestionnaireLink
               aria-label="Bar"
@@ -115,26 +130,29 @@ exports[`QuestionnairesTable should render 1`] = `
             </QuestionnaireLink>
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
-        <QuestionnairesTable__TD>
+        <QuestionnairesTable__TD
+          textAlign="left"
+        >
           <QuestionnairesTable__Collapsible>
             <FormattedDate
               date="2017/03/04"
             />
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
-        <QuestionnairesTable__TD>
+        <QuestionnairesTable__TD
+          textAlign="left"
+        >
           <QuestionnairesTable__Collapsible>
             Lynn
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
-        <QuestionnairesTable__TD>
+        <QuestionnairesTable__TD
+          textAlign="center"
+        >
           <QuestionnairesTable__Collapsible>
-            <QuestionnairesTable__DeleteButton
+            <IconButtonDelete
               onClick={[Function]}
-            >
-              Delete 
-              Bar
-            </QuestionnairesTable__DeleteButton>
+            />
           </QuestionnairesTable__Collapsible>
         </QuestionnairesTable__TD>
       </QuestionnairesTable__TR>


### PR DESCRIPTION
### What is the context of this PR?
The Questionnaires listing previoulsy had flexible columns, and we didn't truncate text in the Created By column. This meant that usernames could awkwardly wrap, as seen below

### How to review 
* Code looks good
* Tests pass
* Table handles long title and long user names
* Check truncation works correctly throughout app (since there is now a single component for this purpose)

**Before**

![image](https://user-images.githubusercontent.com/1091390/39317452-85e22f44-4973-11e8-9e22-7c23b844d010.png)

**After**

![image](https://user-images.githubusercontent.com/1091390/39317421-75a5ca78-4973-11e8-85d7-92b6147adaba.png)

**TODO**

- [x] work out why truncation is broken for MovePageModal

Fixes #347 