### PR TITLE
eq-187 Record cypress runs on Travis

### DIFF
--- a/scripts/run_e2e_tests_author.sh
+++ b/scripts/run_e2e_tests_author.sh
@@ -22,4 +22,4 @@ trap finish INT KILL TERM EXIT
 ./node_modules/.bin/wait-on $CYPRESS_baseUrl -t 10000
 
 # Run the tests
-node_modules/.bin/cypress run -s cypress/integration/author_spec.js --browser chrome
+node_modules/.bin/cypress run -s cypress/integration/author_spec.js --browser chrome --record 


### PR DESCRIPTION
### What is the context of this PR?

https://trello.com/c/OOHsXJKu/187-record-cypress-tests

- adds the `--record` flag to the `run_e2e_tests_author` script
- `CYPRESS_RECORD_KEY ` has been added to travis env vars

### How to review 

- check e2e tests show up in Cypress 'Runs'
