### PR TITLE
Improve UX around disabled split button menu items.

### DIFF
--- a/src/components/SplitButton/MenuItem.js
+++ b/src/components/SplitButton/MenuItem.js
@@ -15,10 +15,11 @@ const MenuItem = styled.button.attrs({
     margin: 0;
   }
 
-  &:focus,
-  &:hover {
+  &:focus:not(:disabled),
+  &:hover:not(:disabled) {
     background: ${colors.blue};
     color: ${colors.white};
+    cursor: pointer;
   }
 `;
 


### PR DESCRIPTION
### What is the context of this PR?
After some feedback on the add other option functionality, it became clear that there wasn't a big enough visual distinction to show that the menu option becomes disabled.

I have added a tweak to the styles below so that non-disabled menu items have a pointer cursor (to br consistent with other buttons) and to remove the hover/focus style for disabled split button menu items.

### How to review 
Style changes should indicate more clearly that the add other option menu item becomes disabled after adding an other option.
