### PR TITLE
autofocus on Option when adding a new MultipleChoiceAnswer

### DIFF
--- a/src/components/Answers/BasicAnswer/BasicAnswer.test.js
+++ b/src/components/Answers/BasicAnswer/BasicAnswer.test.js
@@ -10,10 +10,8 @@ describe("BasicAnswer", () => {
   let children;
   let props;
 
-  const createWrapper = (props, children, render = shallow) => {
-    return render(
-      <StatelessBasicAnswer {...props}>{children}</StatelessBasicAnswer>
-    );
+  const createWrapper = (props, render = shallow) => {
+    return render(<StatelessBasicAnswer {...props} />);
   };
 
   beforeEach(() => {
@@ -30,14 +28,23 @@ describe("BasicAnswer", () => {
       id: "1",
       answer,
       onChange,
-      onUpdate
+      onUpdate,
+      children: <div>This is the child component</div>
     };
-
-    children = <div>This is the child component</div>;
   });
 
   it("should render", () => {
     expect(createWrapper(props, children)).toMatchSnapshot();
+  });
+
+  it("can turn off auto-focus", () => {
+    let wrapper = createWrapper({ ...props, autoFocus: false }, mount);
+    const input = wrapper
+      .find(`[data-test="txt-answer-label"]`)
+      .first()
+      .getDOMNode();
+
+    expect(input.hasAttribute("data-autofocus")).toBe(false);
   });
 
   describe("event handling behaviour", () => {

--- a/src/components/Answers/BasicAnswer/index.js
+++ b/src/components/Answers/BasicAnswer/index.js
@@ -14,7 +14,8 @@ export const StatelessBasicAnswer = ({
   labelPlaceholder,
   descriptionPlaceholder,
   showDescription,
-  size
+  size,
+  autoFocus
 }) => (
   <div>
     <Field>
@@ -25,7 +26,7 @@ export const StatelessBasicAnswer = ({
         onChange={onChange}
         onBlur={onUpdate}
         value={answer.label}
-        data-autofocus
+        data-autofocus={autoFocus || null}
         data-test="txt-answer-label"
       />
     </Field>
@@ -55,14 +56,16 @@ StatelessBasicAnswer.propTypes = {
   labelPlaceholder: PropTypes.string,
   descriptionPlaceholder: PropTypes.string,
   showDescription: PropTypes.bool,
-  size: PropTypes.oneOf(["tiny", "small", "medium", "large"])
+  size: PropTypes.oneOf(["tiny", "small", "medium", "large"]),
+  autoFocus: PropTypes.bool
 };
 
 StatelessBasicAnswer.defaultProps = {
   labelPlaceholder: "Label",
   descriptionPlaceholder: "Enter a description (optional)…",
   showDescription: true,
-  size: "medium"
+  size: "medium",
+  autoFocus: true
 };
 
 export default withEntityEditor("answer", answerFragment)(StatelessBasicAnswer);

--- a/src/components/Answers/MultipleChoiceAnswer/Option.js
+++ b/src/components/Answers/MultipleChoiceAnswer/Option.js
@@ -111,11 +111,13 @@ export class StatelessOption extends Component {
     hasDeleteButton: PropTypes.bool.isRequired,
     type: PropTypes.oneOf([RADIO, CHECKBOX]).isRequired,
     children: PropTypes.node,
-    labelPlaceholder: PropTypes.string
+    labelPlaceholder: PropTypes.string,
+    autoFocus: PropTypes.bool
   };
 
   static defaultProps = {
-    labelPlaceholder: "Label"
+    labelPlaceholder: "Label",
+    autoFocus: true
   };
 
   handleDeleteClick = e => {
@@ -151,7 +153,8 @@ export class StatelessOption extends Component {
       onUpdate,
       type,
       children,
-      labelPlaceholder
+      labelPlaceholder,
+      autoFocus
     } = this.props;
 
     return (
@@ -167,7 +170,7 @@ export class StatelessOption extends Component {
             onBlur={onUpdate}
             onKeyDown={this.handleKeyDown}
             data-test="option-label"
-            data-autofocus
+            data-autofocus={autoFocus || null}
           />
         </LabelField>
         <Field>

--- a/src/components/Answers/MultipleChoiceAnswer/Option.test.js
+++ b/src/components/Answers/MultipleChoiceAnswer/Option.test.js
@@ -124,4 +124,14 @@ describe("Option", () => {
 
     expect(mockMutations.onEnterKey).not.toHaveBeenCalled();
   });
+
+  it("can turn off auto-focus", () => {
+    wrapper = render(mount, { autoFocus: false });
+    const input = wrapper
+      .find(`[data-test="option-label"]`)
+      .first()
+      .getDOMNode();
+
+    expect(input.hasAttribute("data-autofocus")).toBe(false);
+  });
 });

--- a/src/components/Answers/MultipleChoiceAnswer/__snapshots__/MultipleChoiceAnswer.test.js.snap
+++ b/src/components/Answers/MultipleChoiceAnswer/__snapshots__/MultipleChoiceAnswer.test.js.snap
@@ -37,6 +37,7 @@ exports[`MultipleChoiceAnswer other option and answer should render other 1`] = 
       },
     }
   }
+  autoFocus={false}
   labelPlaceholder="Label (optional)"
   onUpdate={[Function]}
 >
@@ -202,6 +203,7 @@ exports[`MultipleChoiceAnswer should match snapshot 1`] = `
       ],
     }
   }
+  autoFocus={false}
   labelPlaceholder="Label (optional)"
   onUpdate={[Function]}
 >

--- a/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -250,6 +250,7 @@ exports[`Option should render a checkbox 1`] = `
 }
 
 <StatelessOption
+  autoFocus={true}
   hasDeleteButton={true}
   labelPlaceholder="Label"
   onChange={[Function]}

--- a/src/components/Answers/MultipleChoiceAnswer/index.js
+++ b/src/components/Answers/MultipleChoiceAnswer/index.js
@@ -135,6 +135,7 @@ class MultipleChoiceAnswer extends Component {
         answer={answer}
         onUpdate={onUpdate}
         labelPlaceholder="Label (optional)"
+        autoFocus={false}
       >
         <AnswerWrapper>
           {answer.type === CHECKBOX && (


### PR DESCRIPTION
### What is the context of this PR?
We would previously autofocus on the `MultipleChoiceAnswer`'s Label field, but this is optional and rarely used. It is more convenient for user if the `Option`'s Label field is autofocused, as this aligns with the typical author workflow


### How to review 
Code good, tests pass, behaviour is as described
