### PR TITLE
Pull latest docker images for e2e tests.

### DIFF
--- a/scripts/run_e2e_tests_author.sh
+++ b/scripts/run_e2e_tests_author.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euf -o pipefail
+set -evuf -o pipefail
 
 function read_vars {
   if [ -f $1 ]; then
@@ -41,6 +41,7 @@ trap finish INT KILL TERM EXIT
 ./node_modules/.bin/wait-on $CYPRESS_baseUrl -t 10000
 
 # start API/DB, and wait until running
+docker-compose -f ./scripts/e2e.yml pull
 docker-compose -f ./scripts/e2e.yml up -d
 ./node_modules/.bin/wait-on tcp:4000
 

--- a/scripts/run_e2e_tests_author.sh
+++ b/scripts/run_e2e_tests_author.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -evuf -o pipefail
+set -euf -o pipefail
 
 function read_vars {
   if [ -f $1 ]; then
@@ -38,7 +38,7 @@ function finish {
 trap finish INT KILL TERM EXIT
 
 # Wait for server to start listening
-./node_modules/.bin/wait-on $CYPRESS_baseUrl -t 10000
+./node_modules/.bin/wait-on $CYPRESS_baseUrl -t 20000
 
 # start API/DB, and wait until running
 docker-compose -f ./scripts/e2e.yml pull


### PR DESCRIPTION
### What is the context of this PR?
I ran into an issue when running the e2e tests locally where the tests were being run against an outdated version of the API. The potential for this happening probably warrants
warrants that we do an explicit pull to get the latest images.

### How to review 
Changes should look sensible.
All tests and checks should pass.
