### PR TITLE
hide scrollbars on autoresize textarea

### DIFF
--- a/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -63,6 +63,7 @@ exports[`Option should render a checkbox 1`] = `
   transition: outline-color 100ms ease-in;
   outline: 1px solid transparent;
   outline-offset: 0.25rem;
+  overflow: hidden;
 }
 
 .c5:hover {
@@ -101,6 +102,7 @@ exports[`Option should render a checkbox 1`] = `
   transition: outline-color 100ms ease-in;
   outline: 1px solid transparent;
   outline-offset: 0.25rem;
+  overflow: hidden;
 }
 
 .c6:hover {

--- a/src/components/WrappingInput/__snapshots__/index.test.js.snap
+++ b/src/components/WrappingInput/__snapshots__/index.test.js.snap
@@ -13,6 +13,7 @@ exports[`WrappingInput should render 1`] = `
   transition: outline-color 100ms ease-in;
   outline: 1px solid transparent;
   outline-offset: 0.25rem;
+  overflow: hidden;
 }
 
 .c0:hover {

--- a/src/components/WrappingInput/index.js
+++ b/src/components/WrappingInput/index.js
@@ -47,6 +47,8 @@ const TextArea = styled(AutoResizeTextArea)`
   outline: 1px solid transparent;
   outline-offset: 0.25rem;
 
+  overflow: hidden; /* prevent scrollbars on Windows */
+
   &:hover {
     outline-color: ${rgba(colors.blue, 0.5)};
   }


### PR DESCRIPTION
### What is the context of this PR?
On Windows, a scrollbar was shown on the autoresize textarea, causing it not to grow with the content. This PR fixes that.

### How to review 
Change looks good, tests pass, confirmed that bug is fixed on Windows and hasn't introduced issues on OSX
