### PR TITLE
Tweak button styles

### DIFF
--- a/src/components/Button/__snapshots__/index.test.js.snap
+++ b/src/components/Button/__snapshots__/index.test.js.snap
@@ -193,12 +193,6 @@ exports[`components/Button renders according to variant 3`] = `
   --color-bg: #3B7A9E;
 }
 
-.c0:focus {
-  border-color: #3B7A9E;
-  box-shadow: 0 0 0 3px #FDBD56,inset 0 0 0 1px #3B7A9E;
-  outline: none;
-}
-
 <button
   className="c0"
   type="button"
@@ -264,12 +258,6 @@ exports[`components/Button renders according to variant 4`] = `
 .c0:hover {
   --color-text: #FFFFFF;
   --color-bg: #3B7A9E;
-}
-
-.c0:focus {
-  border-color: #3B7A9E;
-  box-shadow: 0 0 0 3px #FDBD56,inset 0 0 0 1px #3B7A9E;
-  outline: none;
 }
 
 .c0:hover {

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -40,12 +40,6 @@ export const tertiaryButton = css`
     --color-text: ${colors.white};
     --color-bg: ${colors.primary};
   }
-
-  &:focus {
-    border-color: ${colors.primary};
-    box-shadow: 0 0 0 3px ${colors.tertiary}, inset 0 0 0 1px ${colors.primary};
-    outline: none;
-  }
 `;
 
 export const tertiaryLightButton = css`

--- a/src/components/UserProfile/index.js
+++ b/src/components/UserProfile/index.js
@@ -37,7 +37,7 @@ export const LogoutButton = styled(Button)`
   }
 
   &:focus {
-    box-shadow: 0 0 0 3px ${colors.tertiary}, inset 0 0 0 2px ${colors.primary};
+    box-shadow: 0 0 0 3px ${colors.tertiary};
     outline: none;
   }
 `;


### PR DESCRIPTION
### What is the context of this PR?

Removed inner border from focus style of tertiary buttons.

Before

<img width="121" alt="screenshot 2018-05-23 11 50 51" src="https://user-images.githubusercontent.com/930398/40420228-a08d4308-5e7f-11e8-827f-f53e14a6f982.png">

<img width="108" alt="screenshot 2018-05-23 11 50 16" src="https://user-images.githubusercontent.com/930398/40420243-ae0ac28a-5e7f-11e8-8d6c-ec07be16e5bc.png">

After

<img width="121" alt="screenshot 2018-05-23 11 50 41" src="https://user-images.githubusercontent.com/930398/40420233-a59de096-5e7f-11e8-92d9-85c088ce882c.png">
<img width="111" alt="screenshot 2018-05-23 11 50 30" src="https://user-images.githubusercontent.com/930398/40420240-ac48313a-5e7f-11e8-8583-d685b299d59c.png">

### How to review 

- Check border is removed
