### PR TITLE
persist selected tab when navigating between pages

### DIFF
--- a/src/components/NavigationSidebar/PageNavItem.js
+++ b/src/components/NavigationSidebar/PageNavItem.js
@@ -1,12 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { buildPagePath } from "utils/UrlUtils";
+import { buildQuestionnairePath } from "utils/UrlUtils";
 import NavLink from "./NavLink";
 import getTextFromHTML from "utils/getTextFromHTML";
 import PageIcon from "./icon-questionpage.svg?inline";
+import { withRouter } from "react-router-dom";
+import CustomPropTypes from "custom-prop-types";
 
-export const StyledPageItem = styled.li`
+const StyledPageItem = styled.li`
   padding: 0;
   margin: 0;
   position: relative;
@@ -14,16 +16,22 @@ export const StyledPageItem = styled.li`
   align-items: center;
 `;
 
-const PageNavItem = ({
+export const UnwrappedPageNavItem = ({
   sectionId,
   questionnaireId,
   pageId,
   title,
+  match,
   ...otherProps
 }) => (
   <StyledPageItem data-test="page-item" {...otherProps}>
     <NavLink
-      to={buildPagePath({ questionnaireId, sectionId, pageId })}
+      to={buildQuestionnairePath({
+        questionnaireId,
+        sectionId,
+        pageId,
+        tab: match.params.tab || "design"
+      })}
       title={getTextFromHTML(title)}
       icon={PageIcon}
       data-test="nav-page-link"
@@ -33,11 +41,12 @@ const PageNavItem = ({
   </StyledPageItem>
 );
 
-PageNavItem.propTypes = {
+UnwrappedPageNavItem.propTypes = {
   sectionId: PropTypes.string.isRequired,
   questionnaireId: PropTypes.string.isRequired,
   pageId: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  match: CustomPropTypes.match
 };
 
-export default PageNavItem;
+export default withRouter(UnwrappedPageNavItem);

--- a/src/components/NavigationSidebar/PageNavItem.test.js
+++ b/src/components/NavigationSidebar/PageNavItem.test.js
@@ -1,17 +1,20 @@
 import React from "react";
 import { shallow } from "enzyme";
-import PageNavItem from "./PageNavItem";
+import { UnwrappedPageNavItem } from "./PageNavItem";
 
 describe("PageNavItem", () => {
   let component;
 
   beforeEach(() => {
     component = shallow(
-      <PageNavItem
+      <UnwrappedPageNavItem
         questionnaireId={"1"}
         sectionId={"2"}
         pageId={"3"}
         title="Title"
+        match={{
+          params: { questionnaireId: "1", sectionId: "2", pageId: "3" }
+        }}
       />
     );
   });

--- a/src/components/NavigationSidebar/__snapshots__/PageNav.test.js.snap
+++ b/src/components/NavigationSidebar/__snapshots__/PageNav.test.js.snap
@@ -11,7 +11,7 @@ exports[`PageNav should render 1`] = `
     onEntered={[Function]}
     timeout={300}
   >
-    <PageNavItem
+    <withRouter(UnwrappedPageNavItem)
       pageId="2"
       questionnaireId="1"
       sectionId="3"

--- a/src/containers/App/__snapshots__/index.test.js.snap
+++ b/src/containers/App/__snapshots__/index.test.js.snap
@@ -47,7 +47,7 @@ exports[`containers/App Routes should render  1`] = `
       component={[Function]}
       exact={false}
       isSignedIn={true}
-      path="/questionnaire/:questionnaireId/:sectionId?/:pageId?"
+      path="/questionnaire/:questionnaireId/:sectionId?/:pageId?/:tab?"
     />
     <Route
       component={[Function]}

--- a/src/custom-prop-types/index.js
+++ b/src/custom-prop-types/index.js
@@ -41,7 +41,8 @@ export default {
     params: PropTypes.shape({
       questionnaireId: PropTypes.string.isRequired,
       sectionId: PropTypes.string,
-      pageId: PropTypes.string
+      pageId: PropTypes.string,
+      tab: PropTypes.string
     }).isRequired
   }).isRequired,
   questionnaireList: PropTypes.arrayOf(

--- a/src/utils/UrlUtils.js
+++ b/src/utils/UrlUtils.js
@@ -12,7 +12,7 @@ export const generatePath = curry((path, params) => compile(path)(params));
 export const Routes = {
   HOME: "/",
   SIGN_IN: "/sign-in",
-  QUESTIONNAIRE: `/questionnaire/:questionnaireId/:sectionId?/:pageId?`,
+  QUESTIONNAIRE: `/questionnaire/:questionnaireId/:sectionId?/:pageId?/:tab?`,
   SECTION: `/questionnaire/:questionnaireId/:sectionId(\\d+)/design`,
   PAGE: `/questionnaire/:questionnaireId/:sectionId(\\d+)/:pageId(\\d+)/design`
 };


### PR DESCRIPTION
### What is the context of this PR?
It would be more convenient for users if the selected tab (builder or routing) was preserved when navigating between pages. This PR adds such a feature

### How to review 
Code looks good. Feature works as described