### PR TITLE
Added a style filter to the RTE's

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "draft-convert": "^2.0.0",
     "draft-js": "^0.10.5",
     "draft-js-raw-content-state": "^1.2.5",
+    "draftjs-filters": "^1.0.0",
     "draftjs-to-html": "^0.7.6",
     "enzyme-to-json": "^3.3.1",
     "eq-author-graphql-schema": "^0.12.0",

--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -19,6 +19,9 @@ import PipedValueDecorator, {
   insertPipedValue
 } from "./entities/PipedValue";
 
+import { filterEditorState } from "draftjs-filters";
+import { mapControlsToFilterConfig } from "./utils/mapControlsToFilterConfig";
+
 import { flow, uniq, map, keyBy, mapValues } from "lodash/fp";
 import { sharedStyles } from "../Forms/css";
 import { Field, Label } from "../Forms";
@@ -127,13 +130,17 @@ class RichTextEditor extends React.Component {
     size: PropTypes.oneOf(Object.keys(sizes)),
     fetchAnswers: PropTypes.func,
     testSelector: PropTypes.string,
-    autoFocus: PropTypes.bool
+    autoFocus: PropTypes.bool,
+    // eslint-disable-next-line react/forbid-prop-types
+    controls: PropTypes.object
   };
 
   constructor(props) {
     super(props);
 
     const decorator = new CompositeDecorator([PipedValueDecorator]);
+
+    this.filterConfig = mapControlsToFilterConfig(this.props.controls);
 
     const editorState = props.value
       ? convertFromHTML(props.value, decorator)
@@ -233,7 +240,11 @@ class RichTextEditor extends React.Component {
   };
 
   handleChange = (editorState, callback) => {
-    return this.setState({ editorState }, callback);
+    let filteredState = editorState;
+    if (this.props.controls) {
+      filteredState = filterEditorState(this.filterConfig, filteredState);
+    }
+    return this.setState({ editorState: filteredState }, callback);
   };
 
   handleToggle = ({ id, type, style }) => {

--- a/src/components/RichTextEditor/utils/mapControlsToFilterConfig.js
+++ b/src/components/RichTextEditor/utils/mapControlsToFilterConfig.js
@@ -1,0 +1,25 @@
+import { mapKeys } from "lodash";
+
+const mapper = {
+  bold: { format: "BOLD", type: "styles" },
+  emphasis: { format: "ITALIC", type: "styles" },
+  list: { format: "unordered-list-item", type: "blocks" },
+  heading: { format: "header-two", type: "blocks" }
+};
+
+export function mapControlsToFilterConfig(controls) {
+  const filterConfiguration = {
+    blocks: [],
+    styles: [],
+    entities: [],
+    maxNesting: 0,
+    whitespacedCharacters: []
+  };
+
+  mapKeys(controls, (value, key) => {
+    if (mapper[key]) {
+      filterConfiguration[mapper[key].type].push(mapper[key].format);
+    }
+  });
+  return filterConfiguration;
+}

--- a/src/components/SectionEditor/index.js
+++ b/src/components/SectionEditor/index.js
@@ -75,7 +75,6 @@ export class UnwrappedSectionEditor extends React.Component {
             testSelector="txt-section-title"
             autoFocus={!sectionTitleText}
           />
-
           <RichTextEditor
             id="description"
             value={section.description}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3270,6 +3270,10 @@ draft-js@^0.10.5:
     immutable "~3.7.4"
     object-assign "^4.1.0"
 
+draftjs-filters@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/draftjs-filters/-/draftjs-filters-1.0.0.tgz#4dd8e2943f15edbdc28de961bf3445db0ea6631c"
+
 draftjs-to-html@^0.7.6:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/draftjs-to-html/-/draftjs-to-html-0.7.6.tgz#95bc55aeeca6c6a7abc242c5616946704c6685c9"


### PR DESCRIPTION
### What is the context of this PR?
There was a bug where the Rich text editors weren't stripping out unsupported styles meaning that you could get styles like a list bullet stuck in the editor. This PR adds a filter package to filter out unwanted styles.

### How to review 
Try pasting a bullet list into the description or title boxes and make sure that the unwanted styles are not present.
