### PR TITLE
use key prop at route level to force new RichTextEditor instances

### DIFF
--- a/src/components/QuestionPageEditor/index.js
+++ b/src/components/QuestionPageEditor/index.js
@@ -126,7 +126,7 @@ export default class QuestionPageEditor extends React.Component {
 
     return (
       <div data-test="question-page-editor">
-        <div key={id}>
+        <div>
           <QuestionSegment id={id}>
             <MetaEditor onUpdate={onUpdatePage} page={page} />
             <DeleteConfirmDialog

--- a/src/components/QuestionPageRoute/index.js
+++ b/src/components/QuestionPageRoute/index.js
@@ -133,6 +133,7 @@ export class UnwrappedQuestionPageRoute extends React.Component {
           </Buttons>
         </Toolbar>
         <QuestionPageEditor
+          key={data.questionPage.id} // this is needed to reset the state of the RichTextEditors when moving between pages
           {...this.props}
           page={data.questionPage}
           showMovePageDialog={showMovePageDialog}

--- a/src/components/SectionRoute/index.js
+++ b/src/components/SectionRoute/index.js
@@ -96,6 +96,7 @@ export class UnwrappedSectionRoute extends React.Component {
           </Buttons>
         </Toolbar>
         <SectionEditor
+          key={data.section.id} // this is needed to reset the state of the RichTextEditors when moving between sections
           section={data.section}
           onUpdate={this.props.onUpdateSection}
           showDeleteConfirmDialog={this.state.showDeleteConfirmDialog}


### PR DESCRIPTION
This fixes the issue where the internal state of the `RichTextEditor` falls out of sync with the its props. 

There are other approaches such as using `getDerivedStateFromProps`, but they are more complex. This is a simple solution, which is [recommended by the React docs](https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops):

> If you want to “reset” some state when a prop changes, consider either making a component fully controlled or **fully uncontrolled with a key** instead

Fixes #372 

### What is the context of this PR?
See #372

### How to review 
Bug no longer reproducible
