### PR TITLE
Display answer properties

### DIFF
--- a/cypress/integration/author_spec.js
+++ b/cypress/integration/author_spec.js
@@ -1,4 +1,6 @@
 import {
+  addQuestionnaire,
+  answerTypes,
   setQuestionnaireSettings,
   addAnswerType,
   assertHash,
@@ -22,8 +24,7 @@ describe("eq-author", () => {
   });
 
   it("Can create a questionnaire", () => {
-    cy.get("[data-test='create-questionnaire']").click();
-    setQuestionnaireSettings("My Questionnaire Title");
+    addQuestionnaire("My Questionnaire Title");
   });
 
   it("Should show questionnaire on listing page", () => {
@@ -252,8 +253,6 @@ describe("eq-author", () => {
   });
 
   it("Can create and delete the different types of textbox", () => {
-    const answerTypes = ["Text", "Textarea", "Currency", "Number"];
-
     answerTypes.forEach(answerType => {
       addAnswerType(answerType);
       cy.get("[data-test='txt-answer-label']").type(answerType + " label");

--- a/cypress/integration/properties_spec.js
+++ b/cypress/integration/properties_spec.js
@@ -1,0 +1,224 @@
+import { toUpper } from "lodash";
+
+import {
+  addAnswerType,
+  addQuestionnaire,
+  answerTypes,
+  findByLabel,
+  removeAnswer
+} from "../utils";
+
+describe("Answer Properties", () => {
+  it("Can create a questionnaire", () => {
+    cy.visit("/");
+    cy.contains("Sign in as Guest").click();
+    addQuestionnaire("Answer Properties Question Test");
+  });
+  describe("Title", () => {
+    it("Should show answer type as uppercase text", () => {
+      answerTypes.forEach(answerType => {
+        addAnswerType(answerType);
+        cy
+          .get(`[data-test="properties-title-0"]`)
+          .contains(toUpper(answerType));
+        removeAnswer({ multiple: false });
+      });
+    });
+    it("Should show numbered answer types", () => {
+      const answerTypeTitles = [
+        {
+          type: "Number",
+          title: "NUMBER"
+        },
+        {
+          type: "Number",
+          title: "NUMBER 2"
+        },
+        {
+          type: "Text",
+          title: "TEXTFIELD"
+        },
+        {
+          type: "Number",
+          title: "NUMBER 3"
+        },
+        {
+          type: "Text",
+          title: "TEXTFIELD"
+        }
+      ];
+
+      answerTypeTitles.forEach(({ title, type }, index) => {
+        addAnswerType(type);
+        cy.get(`[data-test="properties-title-${index}"]`).contains(title);
+      });
+
+      removeAnswer({ multiple: true });
+    });
+  });
+  describe("Answer Type", () => {
+    describe("Text", () => {
+      beforeEach(() => {
+        addAnswerType("Text");
+        cy.get('[data-test="properties-0"]').as("answerProperty");
+        cy.get("@answerProperty").should("be.visible");
+      });
+      describe("Required", () => {
+        const labelText = "Required";
+        it("Should be first in list of properties", () => {
+          cy.get("@answerProperty").within(() => {
+            cy
+              .get("label")
+              .first()
+              .contains(labelText);
+          });
+        });
+        it("Should show 'Required' label", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText);
+          });
+        });
+        it("Should default to off", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText).should("not.be.checked");
+          });
+        });
+        it("Can toggle 'Required' property on and off", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText)
+              .click({ force: true })
+              .should("be.checked");
+            findByLabel(labelText)
+              .click({ force: true })
+              .should("not.be.checked");
+          });
+        });
+      });
+      afterEach(() => {
+        removeAnswer();
+      });
+    });
+    describe("Number", () => {
+      beforeEach(() => {
+        addAnswerType("Number");
+        cy.get('[data-test="properties-0"]').as("answerProperty");
+        cy.get("@answerProperty").should("be.visible");
+      });
+      describe("Required", () => {
+        const labelText = "Required";
+        it("Should be first in list of properties", () => {
+          cy.get("@answerProperty").within(() => {
+            cy
+              .get("label")
+              .first()
+              .contains("Required");
+          });
+        });
+        it("Should show 'Required' label", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText);
+          });
+        });
+        it("Should default to off", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText).should("not.be.checked");
+          });
+        });
+        it("Can toggle 'Required' property on and off", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText)
+              .click({ force: true })
+              .should("be.checked");
+            findByLabel(labelText)
+              .click({ force: true })
+              .should("not.be.checked");
+          });
+        });
+      });
+      describe("Decimals", () => {
+        const labelText = "Decimals";
+        it("Should show 'Decimals' label", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText);
+          });
+        });
+        it("Should default to 0", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText).should("have.value", "0");
+          });
+        });
+        it("Can change value", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText)
+              .type("3")
+              .should("have.value", "3");
+          });
+        });
+      });
+      afterEach(() => {
+        removeAnswer();
+      });
+    });
+    describe("Currency", () => {
+      beforeEach(() => {
+        addAnswerType("Currency");
+        cy.get('[data-test="properties-0"]').as("answerProperty");
+        cy.get("@answerProperty").should("be.visible");
+      });
+      describe("Required", () => {
+        const labelText = "Required";
+        it("Should be first in list of properties", () => {
+          cy.get("@answerProperty").within(() => {
+            cy
+              .get("label")
+              .first()
+              .contains(labelText);
+          });
+        });
+        it("Should show 'Required' label", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText);
+          });
+        });
+        it("Should default to off", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText).should("not.be.checked");
+          });
+        });
+        it("Can toggle 'Required' property on and off", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText)
+              .click({ force: true })
+              .should("be.checked");
+            findByLabel(labelText)
+              .click({ force: true })
+              .should("not.be.checked");
+          });
+        });
+      });
+      describe("Decimals", () => {
+        const labelText = "Decimals";
+        it("Should show 'Decimals' label", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText);
+          });
+        });
+        it("Should default to 0", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText).should("have.value", "0");
+          });
+        });
+        it("Can change value", () => {
+          cy.get("@answerProperty").within(() => {
+            findByLabel(labelText)
+              .type("3")
+              .should("have.value", "3");
+          });
+        });
+      });
+      afterEach(() => {
+        removeAnswer();
+      });
+    });
+  });
+});

--- a/cypress/utils/index.js
+++ b/cypress/utils/index.js
@@ -1,5 +1,7 @@
 import { matchPath } from "../../src/utils/UrlUtils";
 
+export const answerTypes = ["Text", "Textarea", "Currency", "Number"];
+
 export function setQuestionnaireSettings(name) {
   cy.get(`[data-testid="questionnaire-settings-modal"]`).within(() => {
     cy
@@ -11,6 +13,11 @@ export function setQuestionnaireSettings(name) {
     cy.get("form").submit();
   });
 }
+
+export const addQuestionnaire = title => {
+  cy.get("[data-test='create-questionnaire']").click();
+  setQuestionnaireSettings(title);
+};
 
 export const addSection = () =>
   cy.get("[data-test='add-menu']").within(() => {
@@ -35,8 +42,10 @@ export const addQuestionPage = () =>
   });
 
 export function addAnswerType(answerType) {
-  cy.get("[data-test='btn-add-answer']").click();
-  cy.contains(answerType).click();
+  cy.get("[data-test='btn-add-answer']").click({ force: true });
+  cy.get("[role='menu']").within(() => {
+    cy.contains(answerType).click({ force: true });
+  });
 }
 
 export function assertHash({
@@ -100,3 +109,6 @@ export const findByLabel = text =>
     .get("label")
     .contains(text)
     .then($label => $label.prop("control"));
+
+export const removeAnswer = params =>
+  cy.get("[data-test='btn-delete-answer']").click(params);

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "draftjs-filters": "^1.0.0",
     "draftjs-to-html": "^0.7.6",
     "enzyme-to-json": "^3.3.1",
-    "eq-author-graphql-schema": "^0.12.0",
+    "eq-author-graphql-schema": "^0.16.0",
     "eslint-config-eq-author": "^1.1.0",
     "firebase": "^4.6.2",
     "firebaseui": "2.4.1",

--- a/src/components/AnswerProperties/AnswerProperties.test.js
+++ b/src/components/AnswerProperties/AnswerProperties.test.js
@@ -1,13 +1,12 @@
 import React from "react";
-import Input from "components/Forms/Input";
-
-import { TEXTFIELD } from "constants/answer-types";
+import { Input } from "components/Forms";
+import { HiddenInput } from "components/ToggleSwitch";
+import { NUMBER } from "constants/answer-types";
 
 import AnswerProperties from "components/AnswerProperties";
 import { shallow, mount } from "enzyme";
 
 let wrapper;
-
 let handleUpdate;
 let handleSubmit;
 let handleChange;
@@ -19,8 +18,11 @@ const answer = {
   index: "0",
   title: "answer-title",
   description: "answer-description",
-  type: TEXTFIELD,
-  mandatory: false
+  type: NUMBER,
+  properties: {
+    required: true,
+    decimals: 2
+  }
 };
 
 describe("Answer Properties", () => {
@@ -51,13 +53,30 @@ describe("Answer Properties", () => {
       wrapper = mount(answerProperties());
     });
 
-    it("should handle change event for mandatory checkbox", () => {
+    it("should handle change event for 'Required' toggle input", () => {
       wrapper
-        .find(Input)
-        .simulate("change", { target: { type: "checkbox", checked: true } });
+        .find(HiddenInput)
+        .simulate("change", { target: { value: false } });
       expect(handleChange).toHaveBeenCalledWith({
         id: "1",
-        mandatory: true
+        properties: {
+          decimals: 2,
+          required: false
+        }
+      });
+    });
+
+    it("should handle change event for 'Decimals' number input", () => {
+      wrapper
+        .find(Input)
+        .at(1)
+        .simulate("change", { target: { value: 3 } });
+      expect(handleChange).toHaveBeenCalledWith({
+        id: "1",
+        properties: {
+          required: true,
+          decimals: 3
+        }
       });
     });
   });

--- a/src/components/AnswerProperties/__snapshots__/AnswerProperties.test.js.snap
+++ b/src/components/AnswerProperties/__snapshots__/AnswerProperties.test.js.snap
@@ -1,19 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Answer Properties should render 1`] = `
-<AnswerProperties__InlineField>
-  <Label
-    htmlFor="answer-1-mandatory"
-    inline={true}
-    small={true}
+<div>
+  <AnswerProperties__InlineField
+    key="answer-1-required"
   >
-    Answer 01 required
-  </Label>
-  <ToggleSwitch
-    checked={false}
-    id="answer-1-mandatory"
-    name="answer-1-mandatory"
-    onChange={[Function]}
-  />
-</AnswerProperties__InlineField>
+    <Label
+      bold={false}
+      htmlFor="answer-1-required"
+      inline={true}
+    >
+      Required
+    </Label>
+    <ToggleSwitch
+      checked={true}
+      id="answer-1-required"
+      name="answer-1-required"
+      onChange={[Function]}
+    />
+  </AnswerProperties__InlineField>
+  <AnswerProperties__InlineField
+    key="answer-1-decimals"
+  >
+    <Label
+      bold={false}
+      htmlFor="answer-1-decimals"
+      inline={true}
+    >
+      Decimals
+    </Label>
+    <Number
+      id="answer-1-decimals"
+      max={6}
+      min={0}
+      name="answer-1-decimals"
+      onChange={[Function]}
+      step={1}
+      value={2}
+    />
+  </AnswerProperties__InlineField>
+</div>
 `;

--- a/src/components/AnswerProperties/story.js
+++ b/src/components/AnswerProperties/story.js
@@ -3,6 +3,7 @@ import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import AnswerProperties from "components/AnswerProperties";
 import styled from "styled-components";
+import { NUMBER } from "constants/answer-types";
 
 const Background = styled.div`
   padding: 1em;
@@ -10,9 +11,19 @@ const Background = styled.div`
   max-width: 20em;
 `;
 
-const answer = {};
+const answer = {
+  id: "1",
+  index: "0",
+  title: "answer-title",
+  description: "answer-description",
+  type: NUMBER,
+  properties: {
+    decimals: 2,
+    required: true
+  }
+};
 
-storiesOf("Properties/Answer", module).add("Default", () => (
+storiesOf("Properties/Answer", module).add("With multiple properties", () => (
   <Background>
     <AnswerProperties answer={answer} onUpdateAnswer={action} />
   </Background>

--- a/src/components/Answers/BasicAnswer/__snapshots__/BasicAnswer.test.js.snap
+++ b/src/components/Answers/BasicAnswer/__snapshots__/BasicAnswer.test.js.snap
@@ -7,7 +7,6 @@ exports[`BasicAnswer should render 1`] = `
   >
     <Label
       htmlFor="answer-label-undefined"
-      small={false}
     >
       Label
     </Label>
@@ -27,7 +26,6 @@ exports[`BasicAnswer should render 1`] = `
   >
     <Label
       htmlFor="answer-description-undefined"
-      small={false}
     >
       Description (optional)
     </Label>

--- a/src/components/Answers/BasicAnswer/__snapshots__/BasicAnswer.test.js.snap
+++ b/src/components/Answers/BasicAnswer/__snapshots__/BasicAnswer.test.js.snap
@@ -6,6 +6,7 @@ exports[`BasicAnswer should render 1`] = `
     last={false}
   >
     <Label
+      bold={true}
       htmlFor="answer-label-undefined"
     >
       Label
@@ -25,6 +26,7 @@ exports[`BasicAnswer should render 1`] = `
     last={false}
   >
     <Label
+      bold={true}
       htmlFor="answer-description-undefined"
     >
       Description (optional)

--- a/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -24,7 +24,6 @@ exports[`Option should match snapshot 1`] = `
       <Option__OptionField>
         <Label
           htmlFor="option-label-1"
-          small={false}
         >
           Label
         </Label>
@@ -45,7 +44,6 @@ exports[`Option should match snapshot 1`] = `
     <Option__OptionField>
       <Label
         htmlFor="option-description-1"
-        small={false}
       >
         Description (optional)
       </Label>
@@ -146,7 +144,6 @@ exports[`Option should render a checkbox 1`] = `
 
 .c5 {
   display: block;
-  font-size: 1em;
   margin-bottom: 0.4em;
   font-weight: bold;
   vertical-align: middle;
@@ -318,11 +315,9 @@ exports[`Option should render a checkbox 1`] = `
                   >
                     <Label
                       htmlFor="option-label-1"
-                      small={false}
                     >
                       <Label__StyledLabel
                         htmlFor="option-label-1"
-                        small={false}
                       >
                         <label
                           className="c5"
@@ -434,11 +429,9 @@ exports[`Option should render a checkbox 1`] = `
               >
                 <Label
                   htmlFor="option-description-1"
-                  small={false}
                 >
                   <Label__StyledLabel
                     htmlFor="option-description-1"
-                    small={false}
                   >
                     <label
                       className="c5"
@@ -639,7 +632,6 @@ exports[`Option shouldn't render delete button if not applicable 1`] = `
       <Option__OptionField>
         <Label
           htmlFor="option-label-1"
-          small={false}
         >
           Label
         </Label>
@@ -660,7 +652,6 @@ exports[`Option shouldn't render delete button if not applicable 1`] = `
     <Option__OptionField>
       <Label
         htmlFor="option-description-1"
-        small={false}
       >
         Description (optional)
       </Label>

--- a/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
+++ b/src/components/Answers/MultipleChoiceAnswer/__snapshots__/Option.test.js.snap
@@ -23,6 +23,7 @@ exports[`Option should match snapshot 1`] = `
       />
       <Option__OptionField>
         <Label
+          bold={true}
           htmlFor="option-label-1"
         >
           Label
@@ -43,6 +44,7 @@ exports[`Option should match snapshot 1`] = `
     </Option__Flex>
     <Option__OptionField>
       <Label
+        bold={true}
         htmlFor="option-description-1"
       >
         Description (optional)
@@ -314,9 +316,11 @@ exports[`Option should render a checkbox 1`] = `
                     className="c3 c4"
                   >
                     <Label
+                      bold={true}
                       htmlFor="option-label-1"
                     >
                       <Label__StyledLabel
+                        bold={true}
                         htmlFor="option-label-1"
                       >
                         <label
@@ -428,9 +432,11 @@ exports[`Option should render a checkbox 1`] = `
                 className="c3 c4"
               >
                 <Label
+                  bold={true}
                   htmlFor="option-description-1"
                 >
                   <Label__StyledLabel
+                    bold={true}
                     htmlFor="option-description-1"
                   >
                     <label
@@ -631,6 +637,7 @@ exports[`Option shouldn't render delete button if not applicable 1`] = `
       />
       <Option__OptionField>
         <Label
+          bold={true}
           htmlFor="option-label-1"
         >
           Label
@@ -651,6 +658,7 @@ exports[`Option shouldn't render delete button if not applicable 1`] = `
     </Option__Flex>
     <Option__OptionField>
       <Label
+        bold={true}
         htmlFor="option-description-1"
       >
         Description (optional)

--- a/src/components/Forms/Field/__snapshots__/Field.test.js.snap
+++ b/src/components/Forms/Field/__snapshots__/Field.test.js.snap
@@ -10,7 +10,6 @@ exports[`components/Forms/Field should render correctly 1`] = `
 
 .c1 {
   display: block;
-  font-size: 1em;
   margin-bottom: 0.4em;
   font-weight: bold;
   vertical-align: middle;
@@ -78,11 +77,9 @@ exports[`components/Forms/Field should render correctly 1`] = `
     >
       <Label
         htmlFor="name"
-        small={false}
       >
         <Label__StyledLabel
           htmlFor="name"
-          small={false}
         >
           <label
             className="c1"

--- a/src/components/Forms/Field/__snapshots__/Field.test.js.snap
+++ b/src/components/Forms/Field/__snapshots__/Field.test.js.snap
@@ -76,9 +76,11 @@ exports[`components/Forms/Field should render correctly 1`] = `
       className="c0"
     >
       <Label
+        bold={true}
         htmlFor="name"
       >
         <Label__StyledLabel
+          bold={true}
           htmlFor="name"
         >
           <label

--- a/src/components/Forms/Label/__snapshots__/Label.test.js.snap
+++ b/src/components/Forms/Label/__snapshots__/Label.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/Forms/Label should render correctly 1`] = `
-<Label__StyledLabel>
+<Label__StyledLabel
+  bold={true}
+>
   Name
 </Label__StyledLabel>
 `;

--- a/src/components/Forms/Label/__snapshots__/Label.test.js.snap
+++ b/src/components/Forms/Label/__snapshots__/Label.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`components/Forms/Label should render correctly 1`] = `
-<Label__StyledLabel
-  small={false}
->
+<Label__StyledLabel>
   Name
 </Label__StyledLabel>
 `;

--- a/src/components/Forms/Label/index.js
+++ b/src/components/Forms/Label/index.js
@@ -6,7 +6,7 @@ import { colors } from "constants/theme";
 const StyledLabel = styled.label`
   display: ${props => (props.inline ? "inline-block" : "block")};
   margin-bottom: ${props => (props.inline ? "0" : "0.4em")};
-  font-weight: bold;
+  font-weight: ${props => (props.bold ? "bold" : "normal")};
   vertical-align: middle;
   color: ${colors.darkGrey};
 `;
@@ -19,9 +19,12 @@ const Label = ({ htmlFor, children, ...otherProps }) => (
 
 Label.propTypes = {
   htmlFor: PropTypes.string,
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  bold: PropTypes.bool
 };
 
-Label.defaultProps = {};
+Label.defaultProps = {
+  bold: true
+};
 
 export default Label;

--- a/src/components/Forms/Label/index.js
+++ b/src/components/Forms/Label/index.js
@@ -5,7 +5,6 @@ import { colors } from "constants/theme";
 
 const StyledLabel = styled.label`
   display: ${props => (props.inline ? "inline-block" : "block")};
-  font-size: ${props => (props.small ? "0.75" : "1")}em;
   margin-bottom: ${props => (props.inline ? "0" : "0.4em")};
   font-weight: bold;
   vertical-align: middle;
@@ -20,12 +19,9 @@ const Label = ({ htmlFor, children, ...otherProps }) => (
 
 Label.propTypes = {
   htmlFor: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  small: PropTypes.bool
+  children: PropTypes.node.isRequired
 };
 
-Label.defaultProps = {
-  small: false
-};
+Label.defaultProps = {};
 
 export default Label;

--- a/src/components/Forms/Number/__snapshots__/numberinput.test.js.snap
+++ b/src/components/Forms/Number/__snapshots__/numberinput.test.js.snap
@@ -85,7 +85,7 @@ exports[`components/Forms/Input Number should render correctly 1`] = `
   min={-10}
   onChange={[Function]}
   step={1}
-  value="0"
+  value={0}
 >
   <Number__StyledDiv>
     <div
@@ -100,7 +100,7 @@ exports[`components/Forms/Input Number should render correctly 1`] = `
         role="alert"
         step={1}
         type="number"
-        value="0"
+        value={0}
       >
         <withChangeHandler(Input)
           aria-live="assertive"
@@ -112,7 +112,7 @@ exports[`components/Forms/Input Number should render correctly 1`] = `
           role="alert"
           step={1}
           type="number"
-          value="0"
+          value={0}
         >
           <Input
             aria-live="assertive"
@@ -124,7 +124,7 @@ exports[`components/Forms/Input Number should render correctly 1`] = `
             role="alert"
             step={1}
             type="number"
-            value="0"
+            value={0}
           >
             <Input__StyledInput
               aria-live="assertive"
@@ -137,7 +137,7 @@ exports[`components/Forms/Input Number should render correctly 1`] = `
               role="alert"
               step={1}
               type="number"
-              value="0"
+              value={0}
             >
               <input
                 aria-live="assertive"
@@ -150,7 +150,7 @@ exports[`components/Forms/Input Number should render correctly 1`] = `
                 role="alert"
                 step={1}
                 type="number"
-                value="0"
+                value={0}
               />
             </Input__StyledInput>
           </Input>

--- a/src/components/Forms/Number/index.js
+++ b/src/components/Forms/Number/index.js
@@ -26,13 +26,13 @@ const StyledInput = styled(Input)`
 class Number extends React.Component {
   handleUp = () => {
     const name = this.props.name || this.props.id;
-    const value = parseInt(this.props.value, 10) + 1;
+    const value = this.props.value + 1;
     this.handleChange({ name, value });
   };
 
   handleDown = () => {
     const name = this.props.name || this.props.id;
-    const value = parseInt(this.props.value, 10) - 1;
+    const value = this.props.value - 1;
     this.handleChange({ name, value });
   };
 
@@ -48,7 +48,7 @@ class Number extends React.Component {
         ? this.props.min
         : enteredValue;
 
-    this.props.onChange({ name, value: newValue.toString() });
+    this.props.onChange({ name, value: newValue });
   };
 
   render() {
@@ -75,7 +75,7 @@ Number.propTypes = {
   id: PropTypes.string,
   name: PropTypes.string,
   onChange: PropTypes.func,
-  value: PropTypes.string,
+  value: PropTypes.number,
   step: PropTypes.number,
   min: PropTypes.number,
   max: PropTypes.number.isRequired

--- a/src/components/Forms/Number/numberinput.test.js
+++ b/src/components/Forms/Number/numberinput.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { mount } from "enzyme";
 import Number from "components/Forms/Number";
 
-const defaultValue = "0";
+const defaultValue = 0;
 
 let handleChange;
 
@@ -38,10 +38,10 @@ describe("components/Forms/Input", () => {
     });
 
     it("should call onChange with appropriate args", () => {
-      number.find("input").simulate("change", { target: { value: "3" } });
+      number.find("input").simulate("change", { target: { value: 3 } });
       expect(handleChange).toHaveBeenCalledWith({
         name: "number",
-        value: "3"
+        value: 3
       });
     });
 
@@ -49,20 +49,20 @@ describe("components/Forms/Input", () => {
       it("should not go over the max when changed", () => {
         numberWithMinMax
           .find("input")
-          .simulate("change", { name: "number", target: { value: "101" } });
+          .simulate("change", { name: "number", target: { value: 101 } });
         expect(handleChange).toBeCalledWith({
           name: "number",
-          value: "100"
+          value: 100
         });
       });
 
       it("should not go under the min when changed", () => {
         numberWithMinMax
           .find("input")
-          .simulate("change", { name: "number", target: { value: "-1" } });
+          .simulate("change", { name: "number", target: { value: -1 } });
         expect(handleChange).toBeCalledWith({
           name: "number",
-          value: "0"
+          value: 0
         });
       });
 
@@ -72,7 +72,7 @@ describe("components/Forms/Input", () => {
           .simulate("change", { name: "number", target: { value: " " } });
         expect(handleChange).toBeCalledWith({
           name: "number",
-          value: "0"
+          value: 0
         });
       });
 
@@ -82,7 +82,7 @@ describe("components/Forms/Input", () => {
           .simulate("change", { name: "number", target: { value: " " } });
         expect(handleChange).toBeCalledWith({
           name: "number",
-          value: "0"
+          value: 0
         });
       });
     });

--- a/src/components/Forms/story.js
+++ b/src/components/Forms/story.js
@@ -22,7 +22,7 @@ class NumberWrapper extends React.Component {
   constructor(props) {
     super();
     this.state = {
-      "number.input": props.min.toString()
+      "number.input": props.min
     };
   }
 

--- a/src/components/Forms/withChangeHandler.js
+++ b/src/components/Forms/withChangeHandler.js
@@ -5,7 +5,7 @@ const withChangeHandler = WrappedComponent => {
   return class extends React.Component {
     static propTypes = {
       onChange: PropTypes.func,
-      value: PropTypes.string,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
       id: PropTypes.string,
       name: PropTypes.string,
       className: PropTypes.string

--- a/src/components/PropertiesPanel/PropertiesPanel.test.js
+++ b/src/components/PropertiesPanel/PropertiesPanel.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropertiesPanel from "components/PropertiesPanel";
+import { NUMBER, TEXTFIELD } from "constants/answer-types";
 import { shallow } from "enzyme";
 import { merge } from "lodash";
 
@@ -42,11 +43,13 @@ describe("PropertiesPanel", () => {
           {
             id: "1",
             index: 0,
+            type: NUMBER,
             __typename: "Answer"
           },
           {
             id: "2",
             index: 1,
+            type: TEXTFIELD,
             __typename: "Answer"
           }
         ]

--- a/src/components/PropertiesPanel/__snapshots__/PropertiesPanel.test.js.snap
+++ b/src/components/PropertiesPanel/__snapshots__/PropertiesPanel.test.js.snap
@@ -7,40 +7,51 @@ exports[`PropertiesPanel should render when there are answers 1`] = `
       permanentScrollBar={false}
     >
       <div>
-        <PropertiesPanel__PropertiesPanelTitle>
-          Answer properties
-        </PropertiesPanel__PropertiesPanelTitle>
         <PropertiesPanel__PropertiesGroup>
-          <div
+          <PropertiesPanel__AnswerProperties
+            data-test="properties-0"
             key="Answer1"
           >
+            <PropertiesPanel__PropertiesPanelTitle
+              data-test="properties-title-0"
+            >
+              NUMBER
+            </PropertiesPanel__PropertiesPanelTitle>
             <Apollo(AnswerProperties)
               answer={
                 Object {
                   "__typename": "Answer",
                   "id": "1",
                   "index": 0,
+                  "type": "Number",
                 }
               }
               id="Answer1"
               onSubmit={[Function]}
             />
-          </div>
-          <div
+          </PropertiesPanel__AnswerProperties>
+          <PropertiesPanel__AnswerProperties
+            data-test="properties-1"
             key="Answer2"
           >
+            <PropertiesPanel__PropertiesPanelTitle
+              data-test="properties-title-1"
+            >
+              TEXTFIELD
+            </PropertiesPanel__PropertiesPanelTitle>
             <Apollo(AnswerProperties)
               answer={
                 Object {
                   "__typename": "Answer",
                   "id": "2",
                   "index": 1,
+                  "type": "TextField",
                 }
               }
               id="Answer2"
               onSubmit={[Function]}
             />
-          </div>
+          </PropertiesPanel__AnswerProperties>
         </PropertiesPanel__PropertiesGroup>
       </div>
     </ScrollPane>

--- a/src/components/PropertiesPanel/index.js
+++ b/src/components/PropertiesPanel/index.js
@@ -3,7 +3,7 @@ import CustomPropTypes from "custom-prop-types";
 import styled from "styled-components";
 import { colors } from "constants/theme";
 import ScrollPane from "components/ScrollPane";
-import { noop } from "lodash";
+import { noop, filter, findIndex, flow, toUpper } from "lodash/fp";
 import getIdForObject from "utils/getIdForObject";
 import AnswerPropertiesContainer from "containers/AnswerPropertiesContainer";
 
@@ -20,13 +20,11 @@ const PropertiesPane = styled.div`
 `;
 
 const PropertiesPanelTitle = styled.h2`
-  font-size: 0.6em;
-  text-transform: uppercase;
-  font-weight: 900;
-  margin: 0;
-  line-height: 1.5em;
-  position: relative;
-  padding: 1.7em 1.4em 0;
+  font-size: 0.8em;
+  letter-spacing: 0.05em;
+  vertical-align: middle;
+  color: ${colors.darkGrey};
+  text-align: center;
 `;
 
 const PropertiesPaneBody = styled.div`
@@ -40,8 +38,20 @@ const PropertiesPaneBody = styled.div`
 
 const PropertiesGroup = styled.div`
   border-bottom: 1px solid ${colors.lightGrey};
-  padding: 1em 1em 0;
 `;
+
+const AnswerProperties = styled.div`
+  padding: 0 1em 1em;
+  border-bottom: 8px solid ${colors.lightGrey};
+`;
+
+const filterByType = type => filter({ type });
+const findIndexById = ({ id }) => findIndex({ id });
+const numberTitle = title => index =>
+  index > 0 ? `${title} ${index + 1}` : title;
+
+const getTitle = ({ answer, answer: { type } }) =>
+  flow(filterByType(type), findIndexById(answer), numberTitle(type), toUpper);
 
 class PropertiesPanel extends React.Component {
   static propTypes = {
@@ -59,16 +69,23 @@ class PropertiesPanel extends React.Component {
             {page &&
               page.answers.length > 0 && (
                 <div>
-                  <PropertiesPanelTitle>Answer properties</PropertiesPanelTitle>
                   <PropertiesGroup>
                     {page.answers.map((answer, index) => (
-                      <div key={getIdForObject(answer)}>
+                      <AnswerProperties
+                        key={getIdForObject(answer)}
+                        data-test={`properties-${index}`}
+                      >
+                        <PropertiesPanelTitle
+                          data-test={`properties-title-${index}`}
+                        >
+                          {getTitle({ answer })(page.answers)}
+                        </PropertiesPanelTitle>
                         <AnswerPropertiesContainer
                           id={getIdForObject(answer)}
                           answer={{ ...answer, index }}
                           onSubmit={this.handleSubmit}
                         />
-                      </div>
+                      </AnswerProperties>
                     ))}
                   </PropertiesGroup>
                 </div>

--- a/src/components/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
+++ b/src/components/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
@@ -9,7 +9,6 @@ exports[`QuestionnaireMeta should render 1`] = `
   >
     <Label
       htmlFor="title"
-      small={false}
     >
       Questionnaire Title
     </Label>
@@ -27,7 +26,6 @@ exports[`QuestionnaireMeta should render 1`] = `
       <Label
         htmlFor="navigation"
         inline={true}
-        small={false}
       >
         <QuestionnaireMeta__Icon
           alt=""
@@ -47,7 +45,6 @@ exports[`QuestionnaireMeta should render 1`] = `
       <Label
         htmlFor="summary"
         inline={true}
-        small={false}
       >
         <QuestionnaireMeta__Icon
           alt=""

--- a/src/components/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
+++ b/src/components/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
@@ -8,6 +8,7 @@ exports[`QuestionnaireMeta should render 1`] = `
     last={false}
   >
     <Label
+      bold={true}
       htmlFor="title"
     >
       Questionnaire Title
@@ -24,6 +25,7 @@ exports[`QuestionnaireMeta should render 1`] = `
   <QuestionnaireMeta__ToggleWrapper>
     <QuestionnaireMeta__InlineField>
       <Label
+        bold={true}
         htmlFor="navigation"
         inline={true}
       >
@@ -43,6 +45,7 @@ exports[`QuestionnaireMeta should render 1`] = `
     </QuestionnaireMeta__InlineField>
     <QuestionnaireMeta__InlineField>
       <Label
+        bold={true}
         htmlFor="summary"
         inline={true}
       >

--- a/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
+++ b/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
@@ -14,7 +14,6 @@ exports[`components/RichTextEditor should allow multiline input 1`] = `
   >
     <Label
       id="label-test"
-      small={false}
     >
       I am a label
     </Label>
@@ -300,7 +299,6 @@ exports[`components/RichTextEditor should render 1`] = `
   >
     <Label
       id="label-test"
-      small={false}
     >
       I am a label
     </Label>
@@ -588,7 +586,6 @@ exports[`components/RichTextEditor should render existing content 1`] = `
   >
     <Label
       id="label-test"
-      small={false}
     >
       I am a label
     </Label>

--- a/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
+++ b/src/components/RichTextEditor/__snapshots__/RichTextEditor.test.js.snap
@@ -13,6 +13,7 @@ exports[`components/RichTextEditor should allow multiline input 1`] = `
     onMouseDown={[Function]}
   >
     <Label
+      bold={true}
       id="label-test"
     >
       I am a label
@@ -298,6 +299,7 @@ exports[`components/RichTextEditor should render 1`] = `
     onMouseDown={[Function]}
   >
     <Label
+      bold={true}
       id="label-test"
     >
       I am a label
@@ -585,6 +587,7 @@ exports[`components/RichTextEditor should render existing content 1`] = `
     onMouseDown={[Function]}
   >
     <Label
+      bold={true}
       id="label-test"
     >
       I am a label

--- a/src/containers/enhancers/withCreateAnswer.js
+++ b/src/containers/enhancers/withCreateAnswer.js
@@ -22,7 +22,6 @@ export const mapMutateToProps = ({ mutate }) => ({
   onAddAnswer(pageId, type) {
     const answer = {
       type,
-      mandatory: false,
       questionPageId: pageId,
       description: "",
       guidance: "",

--- a/src/graphql/fragments/answer.graphql
+++ b/src/graphql/fragments/answer.graphql
@@ -7,5 +7,5 @@ fragment Answer on Answer {
     secondaryLabel
   }
   type
-  mandatory
+  properties
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3432,9 +3432,9 @@ enzyme@^3.3.0:
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
 
-eq-author-graphql-schema@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.12.0.tgz#1013b6efbe13856f15bb30328c2e07a0561200a8"
+eq-author-graphql-schema@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.16.0.tgz#c99f616db429ccc8f8720d323bcc6ac5a8d4d3cd"
 
 errno@^0.1.3, errno@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
### What is the context of this PR?
This is part of a wider piece of work to introduce answer properties to help the quality of the respondent's input.  

Prior to this work, the concept of answer properties was limited to capturing whether or not an answer is 'mandatory'.  This concept has been refactored to support multiple properties and this PR specifically introduces 'decimal' properties.

[Trello Ticket](https://trello.com/c/f978JRq6/402-properties-decimals-1) 

This PR works in conjunction with the following PR's:

API - https://github.com/ONSdigital/eq-author-api/pull/88
Schema - https://github.com/ONSdigital/eq-author-graphql-schema/pull/46

### How to review 
- Run Tests
- Manually create new answers and ensure UI appears as per attached screenshot. 
<img width="1279" alt="screen shot 2018-07-02 at 13 55 50" src="https://user-images.githubusercontent.com/2471296/42165793-ff9a5570-7e00-11e8-84a9-b2fe28c7d111.png">
