### PR TITLE
pinned due to https://github.com/eslint/eslint-scope/issues/39

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "coverage": "yarn test -- --coverage",
     "cypress:open": "CYPRESS_baseUrl=${CYPRESS_baseUrl:=http://localhost:3000/} cypress open"
   },
+  "resolutions": {
+    "eslint-scope": "3.7.1"
+  }, 
   "lint-staged": {
     "*.js": [
       "prettier --write",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3689,7 +3689,7 @@ eslint-plugin-react@^7.0.1:
     jsx-ast-utils "^2.0.0"
     prop-types "^15.5.10"
 
-eslint-scope@^3.7.1:
+eslint-scope@3.7.1, eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:


### PR DESCRIPTION
Due to  https://github.com/eslint/eslint-scope/issues/39

###Yarn lock version should be at 3.7.1