### PR TITLE
Prevented description from showing for some answers

### DIFF
--- a/cypress/integration/author_spec.js
+++ b/cypress/integration/author_spec.js
@@ -9,7 +9,7 @@ import {
   addSection,
   addQuestionPage
 } from "../utils";
-import { times } from "lodash";
+import { times, includes } from "lodash";
 import { Routes } from "../../src/utils/UrlUtils";
 
 describe("eq-author", () => {
@@ -256,9 +256,11 @@ describe("eq-author", () => {
     answerTypes.forEach(answerType => {
       addAnswerType(answerType);
       cy.get("[data-test='txt-answer-label']").type(answerType + " label");
-      cy
-        .get("[data-test='txt-answer-description']")
-        .type(answerType + " description");
+      if (includes(["Currency"], answerType)) {
+        cy
+          .get("[data-test='txt-answer-description']")
+          .type(answerType + " description");
+      }
       cy.get("[data-test='btn-delete-answer']").click();
       cy.get("[data-test='btn-delete-answer']").should("not.exist");
     });

--- a/src/components/Answers/BasicAnswer/BasicAnswer.test.js
+++ b/src/components/Answers/BasicAnswer/BasicAnswer.test.js
@@ -33,8 +33,14 @@ describe("BasicAnswer", () => {
     };
   });
 
-  it("should render", () => {
+  it("should render without description", () => {
     expect(createWrapper(props, children)).toMatchSnapshot();
+  });
+
+  it("should render with description", () => {
+    expect(
+      createWrapper({ ...props, showDescription: true }, children)
+    ).toMatchSnapshot();
   });
 
   it("can turn off auto-focus", () => {
@@ -55,15 +61,17 @@ describe("BasicAnswer", () => {
     });
 
     it("should invoke update callback onBlur", () => {
-      wrapper.find(WrappingInput).forEach(input => input.simulate("blur"));
+      const inputFields = wrapper.find(WrappingInput);
+      inputFields.forEach(input => input.simulate("blur"));
 
-      expect(onUpdate).toHaveBeenCalledTimes(2);
+      expect(onUpdate).toHaveBeenCalledTimes(inputFields.length);
     });
 
     it("should invoke change callback onChange", () => {
-      wrapper.find(WrappingInput).forEach(input => input.simulate("change"));
+      const inputFields = wrapper.find(WrappingInput);
+      inputFields.forEach(input => input.simulate("change"));
 
-      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenCalledTimes(inputFields.length);
     });
   });
 });

--- a/src/components/Answers/BasicAnswer/__snapshots__/BasicAnswer.test.js.snap
+++ b/src/components/Answers/BasicAnswer/__snapshots__/BasicAnswer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BasicAnswer should render 1`] = `
+exports[`BasicAnswer should render with description 1`] = `
 <div>
   <Field
     last={false}
@@ -40,6 +40,34 @@ exports[`BasicAnswer should render 1`] = `
       onChange={[Function]}
       rows="5"
       value="Answer description"
+    />
+  </Field>
+  <div>
+    This is the child component
+  </div>
+</div>
+`;
+
+exports[`BasicAnswer should render without description 1`] = `
+<div>
+  <Field
+    last={false}
+  >
+    <Label
+      bold={true}
+      htmlFor="answer-label-undefined"
+    >
+      Label
+    </Label>
+    <withChangeHandler(WrappingInput)
+      bold={true}
+      data-autofocus={true}
+      data-test="txt-answer-label"
+      id="answer-label-undefined"
+      name="label"
+      onBlur={[Function]}
+      onChange={[Function]}
+      value=""
     />
   </Field>
   <div>

--- a/src/components/Answers/BasicAnswer/index.js
+++ b/src/components/Answers/BasicAnswer/index.js
@@ -71,7 +71,7 @@ StatelessBasicAnswer.propTypes = {
 StatelessBasicAnswer.defaultProps = {
   labelText: "Label",
   descriptionText: "Description (optional)",
-  showDescription: true,
+  showDescription: false,
   autoFocus: true
 };
 

--- a/src/components/Answers/CurrencyAnswer/__snapshots__/CurrencyAnswer.test.js.snap
+++ b/src/components/Answers/CurrencyAnswer/__snapshots__/CurrencyAnswer.test.js.snap
@@ -10,6 +10,7 @@ exports[`CurrencyAnswer should render 1`] = `
   }
   onChange={[Function]}
   onUpdate={[Function]}
+  showDescription={true}
   store={
     Object {
       "dispatch": [Function],

--- a/src/components/Answers/CurrencyAnswer/index.js
+++ b/src/components/Answers/CurrencyAnswer/index.js
@@ -42,7 +42,7 @@ CurrencyComponent.defaultProps = {
 };
 
 const CurrencyAnswer = props => (
-  <BasicAnswer {...props}>
+  <BasicAnswer showDescription {...props}>
     <FieldWrapper>
       <CurrencyComponent />
     </FieldWrapper>


### PR DESCRIPTION
### What is the context of this PR?
The Description for TextField, TextArea and Number answers weren't showing in Runner as the Runner templates do not currently support these fields. This Pr disables description inputs for those answers to prevent user confusion.

### How to review 
Tests pass and Description inputs should only be visible on the following answer types: Currency, Radio and Checkbox. 
