### PR TITLE
Disable move section button based on number of sections 

### DIFF
--- a/cypress/integration/author_spec.js
+++ b/cypress/integration/author_spec.js
@@ -8,7 +8,8 @@ import {
   findByLabel,
   addSection,
   addQuestionPage,
-  testId
+  testId,
+  deleteSection
 } from "../utils";
 import { times, includes } from "lodash";
 import { Routes } from "../../src/utils/UrlUtils";
@@ -440,13 +441,26 @@ describe("eq-author", () => {
   });
 
   it("Can move sections", () => {
+    deleteSection({ index: 0 });
+
+    cy
+      .get(testId("nav-section-link"))
+      .should("have.length", 1)
+      .each($el => {
+        cy.wrap($el).click();
+        cy.get(testId("btn-move")).should("disabled");
+      });
+
     addSection();
     addSection();
 
     cy
       .get(testId("nav-section-link"))
-      .first()
-      .click();
+      .should("have.length", 3)
+      .each($el => {
+        cy.wrap($el).click();
+        cy.get(testId("btn-move")).should("not.be.disabled");
+      });
 
     typeIntoDraftEditor(testId("txt-section-title", "testid"), `Section 1`);
 

--- a/cypress/utils/index.js
+++ b/cypress/utils/index.js
@@ -34,7 +34,7 @@ export const addQuestionnaire = title => {
   setQuestionnaireSettings(title);
 };
 
-export const addSection = () =>
+export const addSection = () => {
   cy.get(testId("add-menu")).within(() => {
     cy
       .get("button")
@@ -44,6 +44,26 @@ export const addSection = () =>
       .contains("Section")
       .click();
   });
+
+  cy
+    .get(testId("nav-section-link"))
+    .last()
+    .should("contain", "Section Title");
+};
+
+export const deleteSection = ({ index }) => {
+  cy
+    .get(testId("nav-section-link"))
+    .eq(index)
+    .click();
+  cy.get(testId("btn-delete")).click();
+  cy.get(testId("delete-confirm-modal", "testid")).within(() => {
+    cy
+      .get("button")
+      .contains("Delete")
+      .click();
+  });
+};
 
 export const addQuestionPage = title => {
   let prevCount;

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "draftjs-filters": "^1.0.0",
     "draftjs-to-html": "^0.7.6",
     "enzyme-to-json": "^3.3.1",
-    "eq-author-graphql-schema": "0.18.0",
+    "eq-author-graphql-schema": "0.19.0",
     "eslint-config-eq-author": "^1.1.0",
     "firebase": "^4.6.2",
     "firebaseui": "2.4.1",

--- a/src/components/QuestionPageRoute/index.test.js
+++ b/src/components/QuestionPageRoute/index.test.js
@@ -48,7 +48,14 @@ const movePageMock = {
                 title: "blah",
                 position: 1
               }
-            ]
+            ],
+            questionnaire: {
+              __typename: "Questionnaire",
+              questionnaireInfo: {
+                __typename: "QuestionnaireInfo",
+                totalSectionCount: 1
+              }
+            }
           }
         ]
       }

--- a/src/components/SectionRoute/Section.graphql
+++ b/src/components/SectionRoute/Section.graphql
@@ -4,5 +4,10 @@ query GetSection($id: ID!) {
   section(id: $id) {
     ...Section
     position
+    questionnaire {
+      questionnaireInfo {
+        totalSectionCount
+      }
+    }
   }
 }

--- a/src/components/SectionRoute/index.js
+++ b/src/components/SectionRoute/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import CustomPropTypes from "custom-prop-types";
 import PropTypes from "prop-types";
 import { flowRight, isFunction, isNil } from "lodash";
+import fp from "lodash/fp";
 
 import SectionQuery from "./SectionQuery";
 import SectionEditor from "components/SectionEditor";
@@ -83,6 +84,11 @@ export class UnwrappedSectionRoute extends React.Component {
     return `${sectionTitle} - ${title}`;
   };
 
+  isMoveSectionButtonDisabled = fp.flow(
+    fp.get("questionnaireInfo.totalSectionCount"),
+    fp.isEqual(1)
+  );
+
   renderContent() {
     const { loading, error, data } = this.props;
 
@@ -105,6 +111,9 @@ export class UnwrappedSectionRoute extends React.Component {
               data-test="btn-move"
               variant="tertiary"
               small
+              disabled={this.isMoveSectionButtonDisabled(
+                data.section.questionnaire
+              )}
             >
               <IconText icon={IconMove}>Move</IconText>
             </Button>

--- a/src/components/SectionRoute/index.test.js
+++ b/src/components/SectionRoute/index.test.js
@@ -6,6 +6,7 @@ import { buildSectionPath } from "utils/UrlUtils";
 import flushPromises from "tests/utils/flushPromises";
 import createRouterContext from "react-router-test-context";
 import PropTypes from "prop-types";
+import { byTestAttr } from "tests/utils/selectors";
 
 import query from "./Section.graphql";
 import moveSectionQuery from "graphql/getQuestionnaire.graphql";
@@ -48,7 +49,14 @@ const moveSectionMock = {
                 title: "blah",
                 position: 1
               }
-            ]
+            ],
+            questionnaire: {
+              __typename: "Questionnaire",
+              questionnaireInfo: {
+                __typename: "QuestionnaireInfo",
+                totalSectionCount: 1
+              }
+            }
           },
           {
             __typename: "Section",
@@ -68,7 +76,14 @@ const moveSectionMock = {
                 title: "blah",
                 position: 1
               }
-            ]
+            ],
+            questionnaire: {
+              __typename: "Questionnaire",
+              questionnaireInfo: {
+                __typename: "QuestionnaireInfo",
+                totalSectionCount: 1
+              }
+            }
           }
         ]
       }
@@ -125,7 +140,14 @@ describe("SectionRoute", () => {
               id: "1",
               title: "foo",
               description: "bar",
-              position: 0
+              position: 0,
+              questionnaire: {
+                __typename: "Questionnaire",
+                questionnaireInfo: {
+                  __typename: "QuestionnaireInfo",
+                  totalSectionCount: 1
+                }
+              }
             }
           }
         }
@@ -151,7 +173,14 @@ describe("SectionRoute", () => {
               id: "1",
               title: "foo",
               description: "bar",
-              position: 0
+              position: 0,
+              questionnaire: {
+                __typename: "Questionnaire",
+                questionnaireInfo: {
+                  __typename: "QuestionnaireInfo",
+                  totalSectionCount: 1
+                }
+              }
             }
           }
         }
@@ -299,6 +328,72 @@ describe("SectionRoute", () => {
         match.params.sectionId,
         0
       );
+    });
+
+    it("should disable move section button when one section", () => {
+      const data = {
+        section: {
+          id: "1",
+          title: "foo",
+          description: "bar",
+          questionnaire: {
+            questionnaireInfo: {
+              totalSectionCount: 1
+            }
+          }
+        }
+      };
+
+      const mockHandlers = {
+        onUpdateSection: jest.fn(),
+        onDeleteSection: jest.fn(),
+        onAddPage: jest.fn(),
+        onMoveSection: jest.fn()
+      };
+
+      const wrapper = render({
+        loading: false,
+        match,
+        data,
+        ...mockHandlers
+      });
+
+      expect(
+        wrapper.find(`Button${byTestAttr("btn-move")}`).prop("disabled")
+      ).toBe(true);
+    });
+
+    it("should enable move section button when multiple sections", () => {
+      const data = {
+        section: {
+          id: "1",
+          title: "foo",
+          description: "bar",
+          questionnaire: {
+            questionnaireInfo: {
+              totalSectionCount: 2
+            }
+          }
+        }
+      };
+
+      const mockHandlers = {
+        onUpdateSection: jest.fn(),
+        onDeleteSection: jest.fn(),
+        onAddPage: jest.fn(),
+        onMoveSection: jest.fn()
+      };
+
+      const wrapper = render({
+        loading: false,
+        match,
+        data,
+        ...mockHandlers
+      });
+
+      expect(
+        wrapper.find(`Button${byTestAttr("btn-move")}`).prop("disabled")
+      ).toBe(false);
     });
   });
 });

--- a/src/containers/enhancers/withCreateSection.js
+++ b/src/containers/enhancers/withCreateSection.js
@@ -21,10 +21,18 @@ export const createUpdater = questionnaireId => (proxy, result) => {
 
   questionnaire.sections.push(result.data.createSection);
 
+  const sections = questionnaire.sections.map(section => ({
+    ...section,
+    questionnaire: result.data.createSection.questionnaire
+  }));
+
   proxy.writeFragment({
     id,
     fragment,
-    data: questionnaire
+    data: {
+      ...questionnaire,
+      sections
+    }
   });
 };
 

--- a/src/containers/enhancers/withCreateSection.test.js
+++ b/src/containers/enhancers/withCreateSection.test.js
@@ -57,14 +57,20 @@ describe("withCreateSection", () => {
       const writeFragment = jest.fn();
 
       const updater = createUpdater(questionnaire.id);
+
       updater({ readFragment, writeFragment }, result);
 
       expect(readFragment).toHaveBeenCalledWith({ id, fragment });
+
       expect(writeFragment).toHaveBeenCalledWith({
         id,
         fragment,
-        data: questionnaire
+        data: {
+          ...questionnaire,
+          sections: [newSection]
+        }
       });
+
       expect(questionnaire.sections).toContain(newSection);
     });
   });

--- a/src/containers/enhancers/withDeleteSection.js
+++ b/src/containers/enhancers/withDeleteSection.js
@@ -52,10 +52,18 @@ export const deleteUpdater = (questionnaireId, sectionId) => (
 
   remove(questionnaire.sections, { id: sectionId });
 
+  const sections = questionnaire.sections.map(section => ({
+    ...section,
+    questionnaire: result.data.deleteSection.questionnaire
+  }));
+
   proxy.writeFragment({
     id,
     fragment,
-    data: questionnaire
+    data: {
+      ...questionnaire,
+      sections
+    }
   });
 };
 

--- a/src/graphql/createSection.graphql
+++ b/src/graphql/createSection.graphql
@@ -17,5 +17,10 @@ mutation CreateSection($input: CreateSectionInput!) {
         }
       }
     }
+    questionnaire {
+      questionnaireInfo {
+        totalSectionCount
+      }
+    }
   }
 }

--- a/src/graphql/deleteSection.graphql
+++ b/src/graphql/deleteSection.graphql
@@ -1,5 +1,10 @@
 mutation DeleteSection($input: DeleteSectionInput!) {
   deleteSection(input: $input) {
-    id
+    id,
+    questionnaire {
+      questionnaireInfo {
+        totalSectionCount
+      }
+    }
   }
 }

--- a/src/graphql/getQuestionnaire.graphql
+++ b/src/graphql/getQuestionnaire.graphql
@@ -12,6 +12,11 @@ query GetQuestionnaire($id: ID!) {
         title
         position
       }
+      questionnaire {
+        questionnaireInfo {
+          totalSectionCount
+        }
+      }
     }
   }
 }

--- a/src/graphql/questionnaireFragment.graphql
+++ b/src/graphql/questionnaireFragment.graphql
@@ -1,5 +1,10 @@
 fragment MinimalQuestionnaire on Questionnaire {
   sections {
     id
+    questionnaire {
+      questionnaireInfo {
+        totalSectionCount
+      }
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3537,9 +3537,9 @@ enzyme@^3.3.0:
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
 
-eq-author-graphql-schema@0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.18.0.tgz#6ed6a26a3d57f059c7fa68c7065d706f93eb0aa1"
+eq-author-graphql-schema@0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.19.0.tgz#2f262270682f1d5bbb88f82752579cb00bf3cc1f"
 
 errno@^0.1.3, errno@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
### What is the context of this PR?
- Disables 'Move Section' button when there is only one section in a questionnaire
- https://trello.com/c/18p5lgJP/533-disable-move-section-button-if-there-is-only-one-section

### How to review
- Run Tests 
- Ensure button is correctly disabled and enabled

### Dependancies
- https://github.com/ONSdigital/eq-author-api/pull/97