### PR TITLE
Typeahead component

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "apollo-link-error": "^1.1.0",
     "apollo-link-http": "^1.5.3",
     "connected-react-router": "^4.2.1",
+    "downshift": "^2.0.20",
     "draft-convert": "^2.0.0",
     "draft-js": "^0.10.5",
     "draft-js-raw-content-state": "^1.2.5",

--- a/src/components/Forms/Field/__snapshots__/Field.test.js.snap
+++ b/src/components/Forms/Field/__snapshots__/Field.test.js.snap
@@ -91,10 +91,10 @@ exports[`components/Forms/Field should render correctly 1`] = `
           </label>
         </Label__StyledLabel>
       </Label>
-      <withChangeHandler(Input)
+      <withChangeHandler(UncontrolledInput)
         id="name"
       >
-        <Input
+        <UncontrolledInput
           id="name"
           onChange={[Function]}
           type="text"
@@ -113,8 +113,8 @@ exports[`components/Forms/Field should render correctly 1`] = `
               type="text"
             />
           </Input__StyledInput>
-        </Input>
-      </withChangeHandler(Input)>
+        </UncontrolledInput>
+      </withChangeHandler(UncontrolledInput)>
     </div>
   </Field__StyledField>
 </Field>

--- a/src/components/Forms/Input/__snapshots__/Input.test.js.snap
+++ b/src/components/Forms/Input/__snapshots__/Input.test.js.snap
@@ -51,12 +51,12 @@ exports[`components/Forms/Input Text should render correctly 1`] = `
   pointer-events: none;
 }
 
-<withChangeHandler(Input)
+<withChangeHandler(UncontrolledInput)
   defaultValue="I am some text"
   id="text"
   onChange={[Function]}
 >
-  <Input
+  <UncontrolledInput
     defaultValue="I am some text"
     id="text"
     onChange={[Function]}
@@ -78,6 +78,6 @@ exports[`components/Forms/Input Text should render correctly 1`] = `
         type="text"
       />
     </Input__StyledInput>
-  </Input>
-</withChangeHandler(Input)>
+  </UncontrolledInput>
+</withChangeHandler(UncontrolledInput)>
 `;

--- a/src/components/Forms/Input/index.js
+++ b/src/components/Forms/Input/index.js
@@ -41,7 +41,12 @@ const StyledInput = styled.input`
   ${props => props.type === "radio" && radioButton};
 `;
 
-const Input = ({ type, defaultValue, id, ...otherProps }) => (
+export const UncontrolledInput = ({
+  type,
+  defaultValue,
+  id,
+  ...otherProps
+}) => (
   <StyledInput
     type={type}
     defaultValue={defaultValue}
@@ -51,11 +56,11 @@ const Input = ({ type, defaultValue, id, ...otherProps }) => (
   />
 );
 
-Input.defaultProps = {
+UncontrolledInput.defaultProps = {
   type: "text"
 };
 
-Input.propTypes = {
+UncontrolledInput.propTypes = {
   id: PropTypes.string,
   type: PropTypes.oneOf(["text", "checkbox", "radio", "number"]).isRequired,
   defaultValue: PropTypes.oneOfType([
@@ -65,4 +70,4 @@ Input.propTypes = {
   ])
 };
 
-export default withChangeHandler(Input);
+export default withChangeHandler(UncontrolledInput);

--- a/src/components/Forms/Number/__snapshots__/numberinput.test.js.snap
+++ b/src/components/Forms/Number/__snapshots__/numberinput.test.js.snap
@@ -102,7 +102,7 @@ exports[`components/Forms/Input Number should render correctly 1`] = `
         type="number"
         value={0}
       >
-        <withChangeHandler(Input)
+        <withChangeHandler(UncontrolledInput)
           aria-live="assertive"
           className="c1"
           id="number"
@@ -114,7 +114,7 @@ exports[`components/Forms/Input Number should render correctly 1`] = `
           type="number"
           value={0}
         >
-          <Input
+          <UncontrolledInput
             aria-live="assertive"
             className="c1"
             id="number"
@@ -153,8 +153,8 @@ exports[`components/Forms/Input Number should render correctly 1`] = `
                 value={0}
               />
             </Input__StyledInput>
-          </Input>
-        </withChangeHandler(Input)>
+          </UncontrolledInput>
+        </withChangeHandler(UncontrolledInput)>
       </Number__StyledInput>
     </div>
   </Number__StyledDiv>

--- a/src/components/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
+++ b/src/components/QuestionnaireMeta/__snapshots__/QuestionnaireMeta.test.js.snap
@@ -13,7 +13,7 @@ exports[`QuestionnaireMeta should render 1`] = `
     >
       Questionnaire Title
     </Label>
-    <withChangeHandler(Input)
+    <withChangeHandler(UncontrolledInput)
       autoFocus={true}
       data-test="txt-questionnaire-title"
       defaultValue="I am the title"

--- a/src/components/ToggleSwitch/__snapshots__/toggleswitch.test.js.snap
+++ b/src/components/ToggleSwitch/__snapshots__/toggleswitch.test.js.snap
@@ -208,14 +208,14 @@ exports[`ToggleSwitch should render a large toggle button when mounted 1`] = `
         onChange={[Function]}
         type="checkbox"
       >
-        <withChangeHandler(Input)
+        <withChangeHandler(UncontrolledInput)
           checked={false}
           className="c1"
           id="toggle-3"
           onChange={[Function]}
           type="checkbox"
         >
-          <Input
+          <UncontrolledInput
             checked={false}
             className="c1"
             id="toggle-3"
@@ -239,8 +239,8 @@ exports[`ToggleSwitch should render a large toggle button when mounted 1`] = `
                 type="checkbox"
               />
             </Input__StyledInput>
-          </Input>
-        </withChangeHandler(Input)>
+          </UncontrolledInput>
+        </withChangeHandler(UncontrolledInput)>
       </ToggleSwitch__HiddenInput>
       <ToggleSwitch__ToggleSwitchBackground
         checked={false}
@@ -450,14 +450,14 @@ exports[`ToggleSwitch should render when checked and mounted 1`] = `
         onChange={[Function]}
         type="checkbox"
       >
-        <withChangeHandler(Input)
+        <withChangeHandler(UncontrolledInput)
           checked={true}
           className="c1"
           id="toggle-2"
           onChange={[Function]}
           type="checkbox"
         >
-          <Input
+          <UncontrolledInput
             checked={true}
             className="c1"
             id="toggle-2"
@@ -481,8 +481,8 @@ exports[`ToggleSwitch should render when checked and mounted 1`] = `
                 type="checkbox"
               />
             </Input__StyledInput>
-          </Input>
-        </withChangeHandler(Input)>
+          </UncontrolledInput>
+        </withChangeHandler(UncontrolledInput)>
       </ToggleSwitch__HiddenInput>
       <ToggleSwitch__ToggleSwitchBackground
         checked={true}
@@ -669,14 +669,14 @@ exports[`ToggleSwitch should render when mounted 1`] = `
         onChange={[Function]}
         type="checkbox"
       >
-        <withChangeHandler(Input)
+        <withChangeHandler(UncontrolledInput)
           checked={true}
           className="c1"
           id="toggle-2"
           onChange={[Function]}
           type="checkbox"
         >
-          <Input
+          <UncontrolledInput
             checked={true}
             className="c1"
             id="toggle-2"
@@ -700,8 +700,8 @@ exports[`ToggleSwitch should render when mounted 1`] = `
                 type="checkbox"
               />
             </Input__StyledInput>
-          </Input>
-        </withChangeHandler(Input)>
+          </UncontrolledInput>
+        </withChangeHandler(UncontrolledInput)>
       </ToggleSwitch__HiddenInput>
       <ToggleSwitch__ToggleSwitchBackground
         checked={true}

--- a/src/components/Typeahead/TypeaheadMenu.js
+++ b/src/components/Typeahead/TypeaheadMenu.js
@@ -1,0 +1,100 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import styled, { css } from "styled-components";
+import { colors, radius } from "constants/theme";
+
+const Menu = styled.div`
+  display: block;
+  box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.3);
+  max-height: 13em;
+  overflow: scroll;
+`;
+
+const MenuList = styled.ul`
+  list-style: none;
+  background: white;
+  padding: 0.05em 0.25em;
+  margin: 0;
+  &:empty {
+    padding: 0;
+  }
+`;
+
+const active = css`
+  background-color: #e4e8eb;
+`;
+
+const selected = css`
+  background-color: ${colors.primary};
+  color: white;
+`;
+
+const MenuItem = styled.li`
+  cursor: pointer;
+  display: block;
+  appearance: none;
+  border: none;
+  font-size: 1em;
+  width: 100%;
+  text-align: left;
+  line-height: 1;
+  position: relative;
+`;
+
+const MenuItemText = styled.div`
+  border-radius: ${radius};
+  margin: 0.25em 0.1em;
+  padding: 0.6em 1em;
+  line-height: 1;
+  ${props => props.isActive && active};
+  ${props => props.isSelected && selected};
+`;
+
+export const filterItemsByInputValue = (items, inputValue) =>
+  items.filter(item => !inputValue || item.value.includes(inputValue));
+
+const TypeaheadMenu = ({
+  getMenuProps,
+  getItemProps,
+  highlightedIndex,
+  selectedItem,
+  inputValue,
+  items
+}) => {
+  return (
+    <Menu>
+      <MenuList {...getMenuProps()}>
+        {filterItemsByInputValue(items, inputValue).map((item, index) => (
+          <MenuItem
+            key={item.value}
+            {...getItemProps({
+              index,
+              item
+            })}
+          >
+            <MenuItemText
+              isActive={highlightedIndex === index}
+              isSelected={selectedItem === item}
+            >
+              {item.value}
+            </MenuItemText>
+          </MenuItem>
+        ))}
+      </MenuList>
+    </Menu>
+  );
+};
+
+TypeaheadMenu.propTypes = {
+  getMenuProps: PropTypes.func.isRequired,
+  getItemProps: PropTypes.func.isRequired,
+  highlightedIndex: PropTypes.number,
+  selectedItem: PropTypes.shape({ value: PropTypes.string.isRequired }),
+  inputValue: PropTypes.string,
+  items: PropTypes.arrayOf(
+    PropTypes.shape({ value: PropTypes.string.isRequired })
+  )
+};
+
+export default TypeaheadMenu;

--- a/src/components/Typeahead/__snapshots__/test.js.snap
+++ b/src/components/Typeahead/__snapshots__/test.js.snap
@@ -1,0 +1,250 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Typeahead should render 1`] = `
+<Downshift
+  defaultHighlightedIndex={null}
+  defaultInputValue=""
+  defaultIsOpen={false}
+  defaultSelectedItem={null}
+  environment={Object {}}
+  getA11yStatusMessage={[Function]}
+  itemToString={[Function]}
+  onChange={[Function]}
+  onInputValueChange={[Function]}
+  onOuterClick={[Function]}
+  onSelect={[Function]}
+  onStateChange={[Function]}
+  onUserAction={[Function]}
+  selectedItemChanged={[Function]}
+  stateReducer={[Function]}
+  suppressRefError={false}
+/>
+`;
+
+exports[`TypeaheadMenu should handle the currently highlighted item 1`] = `
+<TypeaheadMenu__Menu>
+  <TypeaheadMenu__MenuList>
+    <TypeaheadMenu__MenuItem
+      key="apple"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={true}
+        isSelected={false}
+      >
+        apple
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="orange"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        orange
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="pear"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        pear
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="strawberry"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        strawberry
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="raspberry"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        raspberry
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+  </TypeaheadMenu__MenuList>
+</TypeaheadMenu__Menu>
+`;
+
+exports[`TypeaheadMenu should handle the currently selected item 1`] = `
+<TypeaheadMenu__Menu>
+  <TypeaheadMenu__MenuList>
+    <TypeaheadMenu__MenuItem
+      key="apple"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={true}
+        isSelected={false}
+      >
+        apple
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="orange"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        orange
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="pear"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={true}
+      >
+        pear
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="strawberry"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        strawberry
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="raspberry"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        raspberry
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+  </TypeaheadMenu__MenuList>
+</TypeaheadMenu__Menu>
+`;
+
+exports[`TypeaheadMenu should handle the menu being open 1`] = `
+<TypeaheadMenu__Menu>
+  <TypeaheadMenu__MenuList>
+    <TypeaheadMenu__MenuItem
+      key="apple"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        apple
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="orange"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        orange
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="pear"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        pear
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="strawberry"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        strawberry
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="raspberry"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        raspberry
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+  </TypeaheadMenu__MenuList>
+</TypeaheadMenu__Menu>
+`;
+
+exports[`TypeaheadMenu should render 1`] = `
+<TypeaheadMenu__Menu>
+  <TypeaheadMenu__MenuList>
+    <TypeaheadMenu__MenuItem
+      key="apple"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        apple
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="orange"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        orange
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="pear"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        pear
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="strawberry"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        strawberry
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+    <TypeaheadMenu__MenuItem
+      key="raspberry"
+    >
+      <TypeaheadMenu__MenuItemText
+        isActive={false}
+        isSelected={false}
+      >
+        raspberry
+      </TypeaheadMenu__MenuItemText>
+    </TypeaheadMenu__MenuItem>
+  </TypeaheadMenu__MenuList>
+</TypeaheadMenu__Menu>
+`;

--- a/src/components/Typeahead/index.js
+++ b/src/components/Typeahead/index.js
@@ -1,0 +1,17 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Downshift from "downshift";
+
+const Typeahead = ({ onChange, ...otherProps }) => (
+  <Downshift
+    itemToString={item => (item ? item.value : "")}
+    onChange={selection => onChange(selection.value)}
+    {...otherProps}
+  />
+);
+
+Typeahead.propTypes = {
+  onChange: PropTypes.func.isRequired
+};
+
+export default Typeahead;

--- a/src/components/Typeahead/story.js
+++ b/src/components/Typeahead/story.js
@@ -1,0 +1,48 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import Typeahead from "components/Typeahead";
+import TypeaheadMenu from "./TypeaheadMenu";
+
+import styled from "styled-components";
+import { action } from "@storybook/addon-actions";
+
+import { Label } from "components/Forms";
+import { UncontrolledInput as Input } from "components/Forms/Input";
+
+const Wrapper = styled.div`
+  position: absolute;
+  padding: 2em;
+`;
+
+const Decorator = storyFn => <Wrapper>{storyFn()}</Wrapper>;
+
+const items = [
+  { value: "apple" },
+  { value: "pear" },
+  { value: "orange" },
+  { value: "grape" },
+  { value: "banana" },
+  { value: "kiwi" },
+  { value: "mango" },
+  { value: "lime" },
+  { value: "lemon" },
+  { value: "starfruit" },
+  { value: "melon" },
+  { value: "strawberry" },
+  { value: "raspberry" },
+  { value: "blackberry" }
+];
+
+storiesOf("Typeahead", module)
+  .addDecorator(Decorator)
+  .add("Default", () => (
+    <Typeahead onChange={action("change")}>
+      {({ getInputProps, getLabelProps, isOpen, openMenu, ...otherProps }) => (
+        <div>
+          <Label {...getLabelProps()}>Enter a fruit</Label>
+          <Input {...getInputProps({ onFocus: openMenu })} />
+          {isOpen && <TypeaheadMenu items={items} {...otherProps} />}
+        </div>
+      )}
+    </Typeahead>
+  ));

--- a/src/components/Typeahead/test.js
+++ b/src/components/Typeahead/test.js
@@ -1,0 +1,85 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Typeahead from "components/Typeahead";
+import TypeaheadMenu, {
+  filterItemsByInputValue
+} from "components/Typeahead/TypeaheadMenu";
+
+const apple = { value: "apple" };
+const pear = { value: "pear" };
+const orange = { value: "orange" };
+const strawberry = { value: "strawberry" };
+const raspberry = { value: "raspberry" };
+const items = [apple, orange, pear, strawberry, raspberry];
+
+window.toJSON = () => ({});
+
+describe("Typeahead", () => {
+  let wrapper;
+
+  it("should render", () => {
+    wrapper = shallow(<Typeahead onChange={jest.fn()} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should handle change", () => {
+    const handleChange = jest.fn();
+
+    wrapper = shallow(<Typeahead onChange={handleChange} />);
+
+    wrapper.simulate("change", apple);
+    expect(handleChange).toHaveBeenCalledWith(apple.value);
+    wrapper.simulate("change", orange);
+    expect(handleChange).toHaveBeenCalledWith(orange.value);
+  });
+});
+
+describe("TypeaheadMenu", () => {
+  let wrapper;
+  let props;
+
+  beforeEach(() => {
+    props = {
+      items,
+      getMenuProps: jest.fn(),
+      getItemProps: jest.fn()
+    };
+  });
+
+  it("should render", () => {
+    wrapper = shallow(<TypeaheadMenu {...props} />);
+    expect(wrapper).toMatchSnapshot();
+    expect(props.getMenuProps).toHaveBeenCalled();
+    expect(props.getItemProps).toHaveBeenCalledTimes(items.length);
+  });
+
+  it("should handle the currently highlighted item", () => {
+    wrapper = shallow(<TypeaheadMenu {...props} highlightedIndex={0} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should handle the currently selected item", () => {
+    const apple = items[2];
+
+    wrapper = shallow(
+      <TypeaheadMenu {...props} highlightedIndex={0} selectedItem={apple} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should handle the menu being open", () => {
+    wrapper = shallow(<TypeaheadMenu {...props} openMenu />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should filter the menu items by the value of input", () => {
+    expect(filterItemsByInputValue(items, "app")).toEqual([apple]);
+    expect(filterItemsByInputValue(items, "berry")).toEqual([
+      strawberry,
+      raspberry
+    ]);
+    expect(filterItemsByInputValue(items, "")).toEqual(items);
+    expect(filterItemsByInputValue(items, "blah")).toEqual([]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2646,6 +2646,10 @@ compression@^1.5.2:
     safe-buffer "5.1.1"
     vary "~1.1.2"
 
+compute-scroll-into-view@^1.0.2:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.7.tgz#ad8dbe51093c31d60cf6c2df497b2c077bd9e7d2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -3366,6 +3370,13 @@ dot-prop@^4.1.0:
 dotenv@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.0.0.tgz#24e37c041741c5f4b25324958ebbc34bca965935"
+
+downshift@^2.0.20:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-2.0.20.tgz#34275a8f6eb6fa54605cf0dca77010dc83ea4cc7"
+  dependencies:
+    compute-scroll-into-view "^1.0.2"
+    prop-types "^15.6.0"
 
 draft-convert@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### What is the context of this PR?

[Trello card](https://trello.com/c/POnn9CQN/483-survey-data-typeahead-component)

Adds `Typeahead` component that takes a list of objects with values and handles the filtering of those values according to user input as well as the dropdown menu displaying options for selection.

<img width="254" alt="screenshot 2018-08-06 13 57 33" src="https://user-images.githubusercontent.com/930398/43717878-d588477e-9980-11e8-8cff-9f6a22de22a0.png">

This component uses [Downshift](https://github.com/paypal/downshift) and exposes two components: 

- `Typeahead` exposes a Downshift component and simply handles mapping `onChange` and `itemToString` props, the latter handles the mapping of `value` of items into strings.
- `TypeaheadMenu` contains logic for filtering menu items by user input and all the styling associated with the menu and items.

A11y concerns are handled by Downshift itself.

### How to review 

- Check component works in storybook
- Tests pass
