### PR TITLE
Remove redundant section description field

### DIFF
--- a/cypress/integration/author_spec.js
+++ b/cypress/integration/author_spec.js
@@ -164,21 +164,12 @@ describe("eq-author", () => {
       });
   });
 
-  it("Can edit section title and description", () => {
+  it("Can edit section title", () => {
     typeIntoDraftEditor(
       testId("txt-section-title", "testid"),
       "my new section"
     );
     cy.get(testId("nav-section-link")).should("contain", "my new section");
-
-    typeIntoDraftEditor(
-      testId("txt-section-description", "testid"),
-      "section description"
-    );
-
-    cy
-      .get(testId("txt-section-description", "testid"))
-      .should("contain", "section description");
   });
 
   it("Can delete a section", () => {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "draftjs-filters": "^1.0.0",
     "draftjs-to-html": "^0.7.6",
     "enzyme-to-json": "^3.3.1",
-    "eq-author-graphql-schema": "0.19.0",
+    "eq-author-graphql-schema": "0.20.0",
     "eslint-config-eq-author": "^1.1.0",
     "firebase": "^4.6.2",
     "firebaseui": "2.4.1",

--- a/src/components/SectionEditor/__snapshots__/SectionEditor.test.js.snap
+++ b/src/components/SectionEditor/__snapshots__/SectionEditor.test.js.snap
@@ -34,21 +34,6 @@ exports[`SectionEditor should render 1`] = `
       testSelector="txt-section-title"
       value="Section 1"
     />
-    <RichTextEditor
-      autoFocus={false}
-      controls={
-        Object {
-          "bold": true,
-          "emphasis": true,
-        }
-      }
-      id="description"
-      label="Description"
-      multiline={true}
-      onUpdate={[Function]}
-      placeholder=""
-      testSelector="txt-section-description"
-    />
   </SectionEditor__Padding>
 </SectionEditor__SectionCanvas>
 `;
@@ -86,21 +71,6 @@ exports[`SectionEditor should render 2`] = `
       size="large"
       testSelector="txt-section-title"
       value="Section 2"
-    />
-    <RichTextEditor
-      autoFocus={false}
-      controls={
-        Object {
-          "bold": true,
-          "emphasis": true,
-        }
-      }
-      id="description"
-      label="Description"
-      multiline={true}
-      onUpdate={[Function]}
-      placeholder=""
-      testSelector="txt-section-description"
     />
   </SectionEditor__Padding>
 </SectionEditor__SectionCanvas>

--- a/src/components/SectionEditor/index.js
+++ b/src/components/SectionEditor/index.js
@@ -19,11 +19,6 @@ const titleControls = {
   emphasis: true
 };
 
-const descriptionControls = {
-  bold: true,
-  emphasis: true
-};
-
 const Padding = styled.div`
   padding: 0 2em 2em;
 `;
@@ -105,15 +100,6 @@ export class UnwrappedSectionEditor extends React.Component {
             size="large"
             testSelector="txt-section-title"
             autoFocus={!sectionTitleText}
-          />
-          <RichTextEditor
-            id="description"
-            value={section.description}
-            onUpdate={handleUpdate}
-            label="Description"
-            controls={descriptionControls}
-            multiline
-            testSelector="txt-section-description"
           />
         </Padding>
       </SectionCanvas>

--- a/src/graphql/fragments/section.graphql
+++ b/src/graphql/fragments/section.graphql
@@ -1,5 +1,4 @@
 fragment Section on Section {
   id
   title
-  description
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3537,9 +3537,9 @@ enzyme@^3.3.0:
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
 
-eq-author-graphql-schema@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.19.0.tgz#2f262270682f1d5bbb88f82752579cb00bf3cc1f"
+eq-author-graphql-schema@0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.20.0.tgz#96ba25a2986e9931651ade66658a7cfe5670a054"
 
 errno@^0.1.3, errno@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
### What is the context of this PR?
- Upgrades graphql schema which deprecates section description field as it is redundant and never used by eq-runner
- Stops displaying section description content when creating a questionnaire

### How to review 
- Run tests

### Dependancies
GraphQL Schema - https://github.com/ONSdigital/eq-author-graphql-schema/pull/51