### PR TITLE
Make navigation and properties sidebars wider

### DIFF
--- a/src/components/EditorLayout/index.js
+++ b/src/components/EditorLayout/index.js
@@ -25,7 +25,7 @@ const Margin = styled.div`
 
 const EditorLayout = ({ children, onAddPage, page, ...otherProps }) => (
   <Grid {...otherProps}>
-    <Column gutters={false}>
+    <Column cols={9} gutters={false}>
       <ScrollPane permanentScrollBar>
         <Margin>
           <MainCanvas>
@@ -47,7 +47,7 @@ const EditorLayout = ({ children, onAddPage, page, ...otherProps }) => (
         )}
       </ScrollPane>
     </Column>
-    <Column cols={2} gutters={false}>
+    <Column cols={3} gutters={false}>
       <PropertiesPanel page={page} />
     </Column>
   </Grid>

--- a/src/components/MainCanvas/__snapshots__/index.test.js.snap
+++ b/src/components/MainCanvas/__snapshots__/index.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`MainCanvas should render 1`] = `
 .c0 {
-  max-width: 50em;
+  max-width: 42em;
   margin-left: auto;
   margin-right: auto;
   margin-bottom: 1em;

--- a/src/components/MainCanvas/index.js
+++ b/src/components/MainCanvas/index.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 const MainCanvas = styled.div`
-  max-width: 50em;
+  max-width: 42em;
   margin-left: auto;
   margin-right: auto;
   margin-bottom: 1em;

--- a/src/components/QuestionnaireDesignPage/__snapshots__/QuestionnaireDesignPage.test.js.snap
+++ b/src/components/QuestionnaireDesignPage/__snapshots__/QuestionnaireDesignPage.test.js.snap
@@ -48,7 +48,7 @@ exports[`QuestionnaireDesignPage should render 1`] = `
       fillHeight={true}
     >
       <Column
-        cols={2}
+        cols={3}
         gutters={false}
       >
         <withRouter(Apollo(Apollo(UnwrappedNavigationSidebar)))

--- a/src/components/QuestionnaireDesignPage/index.js
+++ b/src/components/QuestionnaireDesignPage/index.js
@@ -82,7 +82,7 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
       <BaseLayout questionnaire={questionnaire}>
         <Titled title={this.getTitle}>
           <Grid>
-            <Column cols={2} gutters={false}>
+            <Column cols={3} gutters={false}>
               <NavigationSidebar
                 data-test="side-nav"
                 loading={loading}


### PR DESCRIPTION
### What is the context of this PR?
Increases the width of the navigation and properties sidebars.

### How to review 
- Run tests
- Ensure width of sidebars and content are consistent between views (eg. Question Editor / Routing etc.)
