### PR TITLE
Upgrade Prettier to 1.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "object-assign": "^4.1.1",
     "postcss-flexbugs-fixes": "^3.2.0",
     "postcss-loader": "^2.0.7",
-    "prettier": "^1.7.4",
+    "prettier": "^1.14.2",
     "promise": "^8.0.1",
     "prop-types": "^15.6.0",
     "react-dev-utils": "^4.1.0",

--- a/src/components/Answers/MultipleChoiceAnswer/OptionTransition.js
+++ b/src/components/Answers/MultipleChoiceAnswer/OptionTransition.js
@@ -25,8 +25,7 @@ const OptionTransition = styled(CSSTransition).attrs({
     opacity: 1;
     transform: scale(1);
     transition: opacity ${timeout}ms ease-out,
-      transform ${timeout}ms
-        cubic-bezier(0.175, 0.885, 0.32, 1.275);
+      transform ${timeout}ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
   }
 
   &.option-exit {

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -73,7 +73,10 @@ class UnconnectedApp extends React.Component {
   }
 }
 
-export default connect(null, {
-  lostConnection,
-  gainConnection
-})(UnconnectedApp);
+export default connect(
+  null,
+  {
+    lostConnection,
+    gainConnection
+  }
+)(UnconnectedApp);

--- a/src/components/ButtonGroup/story.js
+++ b/src/components/ButtonGroup/story.js
@@ -11,17 +11,17 @@ const Width = styled.div`
 
 storiesOf("ButtonGroup", module)
   .addDecorator(story => <Width>{story()}</Width>)
-  .add("Vertical", props =>
+  .add("Vertical", props => (
     <ButtonGroup vertical>
       <Button primary>Button 1</Button>
       <Button secondary>Button 2</Button>
       <Button tertiary>Button 3</Button>
     </ButtonGroup>
-  )
-  .add("Horizontal", props =>
+  ))
+  .add("Horizontal", props => (
     <ButtonGroup horizontal>
       <Button primary>Button 1</Button>
       <Button secondary>Button 2</Button>
       <Button tertiary>Button 3</Button>
     </ButtonGroup>
-  );
+  ));

--- a/src/components/DeleteButton/deletebutton.story.js
+++ b/src/components/DeleteButton/deletebutton.story.js
@@ -11,15 +11,11 @@ const Background = styled.div`
 `;
 
 storiesOf("DeleteButton", module)
-  .addDecorator(story =>
-    <Background>
-      {story()}
-    </Background>
-  )
+  .addDecorator(story => <Background>{story()}</Background>)
   .add("Small", () => <DeleteButton size="small" onClick={action("clicked")} />)
-  .add("Medium", () =>
+  .add("Medium", () => (
     <DeleteButton size="medium" onClick={action("clicked")} />
-  )
-  .add("Large", () =>
+  ))
+  .add("Large", () => (
     <DeleteButton size="large" onClick={action("clicked")} />
-  );
+  ));

--- a/src/components/Forms/TextArea/index.js
+++ b/src/components/Forms/TextArea/index.js
@@ -9,14 +9,15 @@ const StyledTextArea = styled.textarea`
   resize: none;
 `;
 
-const TextArea = ({ defaultValue, id, rows, ...otherProps }) =>
+const TextArea = ({ defaultValue, id, rows, ...otherProps }) => (
   <StyledTextArea
     defaultValue={defaultValue}
     rows={rows}
     id={id}
     name={id}
     {...otherProps}
-  />;
+  />
+);
 
 TextArea.propTypes = {
   defaultValue: PropTypes.string,

--- a/src/components/Grid/Column.js
+++ b/src/components/Grid/Column.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 
 const numCols = 12;
-const colWidth = num => `${num / numCols * 100}%`;
+const colWidth = num => `${(num / numCols) * 100}%`;
 
 const Column = styled.div`
   flex: 1 1 auto;

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -174,6 +174,7 @@ const mapStateToProps = state => ({
   user: getUser(state)
 });
 
-export default connect(mapStateToProps, { signOutUser, raiseToast })(
-  UnconnectedHeader
-);
+export default connect(
+  mapStateToProps,
+  { signOutUser, raiseToast }
+)(UnconnectedHeader);

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -77,7 +77,7 @@ const StyledModal = styled(ReactModalAdapter).attrs({
     justify-content: center;
     z-index: 9999999;
     background-color: rgba(0, 0, 0, 0.5);
-    
+
     &--after-open {
       opacity: 1;
     }

--- a/src/components/ModalWithNav/index.js
+++ b/src/components/ModalWithNav/index.js
@@ -146,4 +146,7 @@ const mapStateToProps = (state, ownProps) => ({
   activeTabId: state.tabs[ownProps.id]
 });
 
-export default connect(mapStateToProps, { gotoTab })(UnconnectedModalWithNav);
+export default connect(
+  mapStateToProps,
+  { gotoTab }
+)(UnconnectedModalWithNav);

--- a/src/components/MoveSectionModal/index.js
+++ b/src/components/MoveSectionModal/index.js
@@ -28,7 +28,10 @@ class MoveSectionModal extends React.Component {
   };
 
   render() {
-    const { questionnaire: { sections }, section } = this.props;
+    const {
+      questionnaire: { sections },
+      section
+    } = this.props;
 
     return (
       <MoveModal title={"Move section"} {...this.props}>

--- a/src/components/NavigationSidebar/NavigationHeader.js
+++ b/src/components/NavigationSidebar/NavigationHeader.js
@@ -104,7 +104,10 @@ class NavigationHeader extends React.Component {
                 isOpen={this.state.isModalOpen}
                 onClose={this.handleModalClose}
                 questionnaire={questionnaire}
-                onSubmit={pipeP(onUpdateQuestionnaire, this.handleModalClose)}
+                onSubmit={pipeP(
+                  onUpdateQuestionnaire,
+                  this.handleModalClose
+                )}
                 confirmText="Apply"
               />
             </IconListItem>

--- a/src/components/Panel/story.js
+++ b/src/components/Panel/story.js
@@ -11,7 +11,7 @@ const Background = styled.span`
 
 storiesOf("Panel", module)
   .addDecorator(story => <Background>{story()}</Background>)
-  .add("Default", () =>
+  .add("Default", () => (
     <Panel>
       <p>
         Curabitur blandit tempus porttitor. Fusce dapibus, tellus ac cursus
@@ -21,4 +21,4 @@ storiesOf("Panel", module)
         lacinia bibendum nulla sed consectetur. Donec sed odio dui.
       </p>
     </Panel>
-  );
+  ));

--- a/src/components/PropertiesPanel/index.js
+++ b/src/components/PropertiesPanel/index.js
@@ -51,7 +51,12 @@ const numberTitle = title => index =>
   index > 0 ? `${title} ${index + 1}` : title;
 
 const getTitle = ({ answer, answer: { type } }) =>
-  flow(filterByType(type), findIndexById(answer), numberTitle(type), toUpper);
+  flow(
+    filterByType(type),
+    findIndexById(answer),
+    numberTitle(type),
+    toUpper
+  );
 
 class PropertiesPanel extends React.Component {
   static propTypes = {

--- a/src/components/QuestionPageEditor/AnswerTransition.js
+++ b/src/components/QuestionPageEditor/AnswerTransition.js
@@ -26,8 +26,7 @@ const AnswerTransition = styled(CSSTransition).attrs({
     opacity: 1;
     transform: scale(1);
     transition: opacity ${timeout}ms ease-out,
-      transform ${timeout}ms
-        cubic-bezier(0.175, 0.885, 0.32, 1.275);
+      transform ${timeout}ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
   }
 
   &.answer-exit {
@@ -40,8 +39,7 @@ const AnswerTransition = styled(CSSTransition).attrs({
     height: 0 !important;
     transform: scale(0.9);
     transition: opacity ${halfTimeout}ms ease-out,
-      height ${halfTimeout}ms ease-in
-        ${halfTimeout}ms,
+      height ${halfTimeout}ms ease-in ${halfTimeout}ms,
       transform ${halfTimeout}ms ease-in;
   }
 `;

--- a/src/components/QuestionPageEditor/MetaEditor.js
+++ b/src/components/QuestionPageEditor/MetaEditor.js
@@ -99,6 +99,7 @@ StatelessMetaEditor.fragments = {
   Page: pageFragment
 };
 
-export default flowRight(withApollo, withEntityEditor("page", pageFragment))(
-  StatelessMetaEditor
-);
+export default flowRight(
+  withApollo,
+  withEntityEditor("page", pageFragment)
+)(StatelessMetaEditor);

--- a/src/components/QuestionPageRoute/index.js
+++ b/src/components/QuestionPageRoute/index.js
@@ -76,13 +76,18 @@ export class UnwrappedQuestionPageRoute extends React.Component {
 
   handleDeletePageConfirm = () => {
     const { onDeletePage, match } = this.props;
-    const { params: { pageId, sectionId } } = match;
+    const {
+      params: { pageId, sectionId }
+    } = match;
 
     this.handleCloseDeleteConfirmDialog(() => onDeletePage(sectionId, pageId));
   };
 
   handleAddPage = () => {
-    const { match: { params }, data: { questionPage } } = this.props;
+    const {
+      match: { params },
+      data: { questionPage }
+    } = this.props;
 
     this.props.onAddPage(params.sectionId, questionPage.position + 1);
   };
@@ -165,7 +170,10 @@ export class UnwrappedQuestionPageRoute extends React.Component {
 }
 
 const withQuestionPageEditing = flowRight(
-  connect(null, { raiseToast }),
+  connect(
+    null,
+    { raiseToast }
+  ),
   withApollo,
   withMovePage,
   withCreatePage,

--- a/src/components/QuestionnaireDesignPage/index.js
+++ b/src/components/QuestionnaireDesignPage/index.js
@@ -38,7 +38,11 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
   };
 
   handleAddPage = e => {
-    const { onAddPage, match, data: { questionnaire } } = this.props;
+    const {
+      onAddPage,
+      match,
+      data: { questionnaire }
+    } = this.props;
     const { pageId, sectionId } = match.params;
 
     const pages = flatMap(questionnaire.sections, "pages");
@@ -48,12 +52,18 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
   };
 
   getTitle = title => {
-    const { loading, data: { questionnaire } } = this.props;
+    const {
+      loading,
+      data: { questionnaire }
+    } = this.props;
     return loading ? title : `${questionnaire.title} - ${title}`;
   };
 
   renderRedirect = () => {
-    const { loading, data: { questionnaire } } = this.props;
+    const {
+      loading,
+      data: { questionnaire }
+    } = this.props;
 
     if (loading) {
       return (
@@ -76,7 +86,11 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
   };
 
   render() {
-    const { loading, data: { questionnaire }, location } = this.props;
+    const {
+      loading,
+      data: { questionnaire },
+      location
+    } = this.props;
 
     return (
       <BaseLayout questionnaire={questionnaire}>
@@ -110,7 +124,10 @@ export class UnwrappedQuestionnaireDesignPage extends Component {
 }
 
 const withMutations = flowRight(
-  connect(null, { raiseToast }),
+  connect(
+    null,
+    { raiseToast }
+  ),
   withCreateSection,
   withCreatePage
 );

--- a/src/components/QuestionnairesPage/QuestionnairesTable.js
+++ b/src/components/QuestionnairesPage/QuestionnairesTable.js
@@ -59,8 +59,8 @@ const RowTransition = styled(CSSTransition).attrs({
   classNames: "row"
 })`
   transition: opacity ${halfTimeout}ms ease-out,
-    border-color ${props => props.timeout / 10}ms ease-in ${props =>
-  props.timeout / 10 * 9}ms;
+    border-color ${props => props.timeout / 10}ms ease-in
+      ${props => (props.timeout / 10) * 9}ms;
 
   &.row-exit {
     opacity: 0.01;
@@ -71,7 +71,7 @@ const RowTransition = styled(CSSTransition).attrs({
     height: 0;
     padding: 0;
     transition: height ${halfTimeout}ms ease-in ${halfTimeout}ms,
-    padding ${halfTimeout}ms ease-in ${halfTimeout}ms;
+      padding ${halfTimeout}ms ease-in ${halfTimeout}ms;
   }
 `;
 

--- a/src/components/QuestionnairesPage/index.js
+++ b/src/components/QuestionnairesPage/index.js
@@ -115,7 +115,10 @@ const mapStateToProps = state => ({
 });
 
 export default flowRight(
-  connect(mapStateToProps, { raiseToast }),
+  connect(
+    mapStateToProps,
+    { raiseToast }
+  ),
   withQuestionnaireList,
   withCreateQuestionnaire,
   withDeleteQuestionnaire // relies on raiseToast to display undo

--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -177,7 +177,10 @@ class RichTextEditor extends React.Component {
       return;
     }
 
-    const createAnswerMap = flow(keyBy("id"), mapValues("label"));
+    const createAnswerMap = flow(
+      keyBy("id"),
+      mapValues("label")
+    );
     const fetchAnswersForEntities = flow(
       map("entity.data.id"),
       uniq,

--- a/src/components/SectionRoute/index.js
+++ b/src/components/SectionRoute/index.js
@@ -69,13 +69,17 @@ export class UnwrappedSectionRoute extends React.Component {
 
   handleDeleteSectionConfirm = () => {
     const { onDeleteSection, match } = this.props;
-    const { params: { sectionId } } = match;
+    const {
+      params: { sectionId }
+    } = match;
 
     this.handleCloseDeleteConfirmDialog(() => onDeleteSection(sectionId));
   };
 
   handleAddPage = () => {
-    const { params: { sectionId } } = this.props.match;
+    const {
+      params: { sectionId }
+    } = this.props.match;
     this.props.onAddPage(sectionId, 0);
   };
 
@@ -151,7 +155,10 @@ export class UnwrappedSectionRoute extends React.Component {
 }
 
 const withSectionEditing = flowRight(
-  connect(null, { raiseToast }),
+  connect(
+    null,
+    { raiseToast }
+  ),
   withApollo,
   withCreateSection,
   withUpdateSection,

--- a/src/components/TextButton/index.js
+++ b/src/components/TextButton/index.js
@@ -4,7 +4,6 @@ import Button from "components/Button";
 const TextButton = styled(Button).attrs({
   variant: "tertiary"
 })`
-
   padding: 0.25em 0.5em;
   letter-spacing: 0.05em;
   font-size: 0.9em;

--- a/src/components/ToggleChip/ToggleChip.story.js
+++ b/src/components/ToggleChip/ToggleChip.story.js
@@ -62,9 +62,11 @@ storiesOf("ToggleChip", module)
       </StatefulToggleChip>
       <StatefulToggleChip title="Lorem ipsum.">Lorem ipsum.</StatefulToggleChip>
       <StatefulToggleChip title="Lorem.">Lorem.</StatefulToggleChip>
-      <StatefulToggleChip title="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum quos
+      <StatefulToggleChip
+        title="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum quos
       saepe voluptatem. Ab consectetur dolore ea eaque excepturi praesentium
-      voluptate.">
+      voluptate."
+      >
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum quos
         saepe voluptatem. Ab consectetur dolore ea eaque excepturi praesentium
         voluptate.

--- a/src/components/Tooltip/story.js
+++ b/src/components/Tooltip/story.js
@@ -9,13 +9,12 @@ const Wrapper = styled.div`
   padding: 2em;
 `;
 
-const Decorator = storyFn =>
-  <Wrapper>
-    {storyFn()}
-  </Wrapper>;
+const Decorator = storyFn => <Wrapper>{storyFn()}</Wrapper>;
 
-storiesOf("Tooltip", module).addDecorator(Decorator).add("Default", () =>
-  <Tooltip content="I'm a tooltip!">
-    <Button primary>Hover me!</Button>
-  </Tooltip>
-);
+storiesOf("Tooltip", module)
+  .addDecorator(Decorator)
+  .add("Default", () => (
+    <Tooltip content="I'm a tooltip!">
+      <Button primary>Hover me!</Button>
+    </Tooltip>
+  ));

--- a/src/components/routing/MultipleChoiceAnswerOptionsSelector.js
+++ b/src/components/routing/MultipleChoiceAnswerOptionsSelector.js
@@ -36,7 +36,8 @@ const MultipleChoiceAnswerOptionsSelector = ({
           title={option.label}
           checked={includes(selectedOptions, option.id)}
           onChange={({ name, value }) =>
-            onOptionSelectionChange(condition.id, name, value)}
+            onOptionSelectionChange(condition.id, name, value)
+          }
         >
           {option.label || <strong>Unlabelled option</strong>}
         </ToggleChip>

--- a/src/components/routing/QuestionnaireRoutingPage.js
+++ b/src/components/routing/QuestionnaireRoutingPage.js
@@ -117,7 +117,7 @@ export const ROUTING_QUERY = gql`
       }
     }
   }
-  
+
   ${RoutingRule.fragments.RoutingRule}
   ${RoutingRuleSet.fragments.RoutingRuleSet}
   ${RoutingCondition.fragments.RoutingCondition}
@@ -130,7 +130,10 @@ export const ROUTING_QUERY = gql`
 `;
 
 const withRouting = flowRight(
-  connect(null, { raiseToast }),
+  connect(
+    null,
+    { raiseToast }
+  ),
   withApollo,
   withCreateRoutingRuleSet,
   withCreateRoutingCondition,

--- a/src/components/routing/RoutingCondition.js
+++ b/src/components/routing/RoutingCondition.js
@@ -75,7 +75,10 @@ const RemoveButton = styled(DeleteButton)`
   right: 2px;
 `;
 
-const firstAnswerIsValid = flow(first, isAnswerValidForRouting);
+const firstAnswerIsValid = flow(
+  first,
+  isAnswerValidForRouting
+);
 const shouldDisable = overSome([isEmpty, negate(firstAnswerIsValid)]);
 
 const convertToGroups = sections =>
@@ -106,7 +109,9 @@ const renderUnsupportedAnswer = answer => (
     <Alert data-test="invalid-answer-type-msg">
       <AlertTitle>Routing is not available for this type of answer</AlertTitle>
       <AlertText>
-        You cannot route on &lsquo;{lowerCase(answer.type)}&rsquo; answers.
+        You cannot route on &lsquo;
+        {lowerCase(answer.type)}
+        &rsquo; answers.
       </AlertText>
     </Alert>
   </Transition>

--- a/src/components/routing/Transition.js
+++ b/src/components/routing/Transition.js
@@ -26,8 +26,7 @@ const RoutingComponentTransition = styled(CSSTransition).attrs({
     opacity: 1;
     transform: scale(1);
     transition: opacity ${timeout}ms ease-out,
-      transform ${timeout}ms
-        cubic-bezier(0.175, 0.885, 0.32, 1.275);
+      transform ${timeout}ms cubic-bezier(0.175, 0.885, 0.32, 1.275);
   }
 
   &.component-exit {
@@ -40,8 +39,7 @@ const RoutingComponentTransition = styled(CSSTransition).attrs({
     height: 0 !important;
     transform: scale(0.9);
     transition: opacity ${halfTimeout}ms ease-out,
-      height ${halfTimeout}ms ease-in
-        ${halfTimeout}ms,
+      height ${halfTimeout}ms ease-in ${halfTimeout}ms,
       transform ${halfTimeout}ms ease-in;
   }
 `;

--- a/src/components/withEntityEditor/index.js
+++ b/src/components/withEntityEditor/index.js
@@ -5,7 +5,10 @@ import { isEmpty, isEqual } from "lodash";
 import { startRequest, endRequest } from "../../redux/saving/actions";
 import { connect } from "react-redux";
 
-const withSaveTracking = connect(null, { startRequest, endRequest });
+const withSaveTracking = connect(
+  null,
+  { startRequest, endRequest }
+);
 
 const withEntityEditor = (entityPropName, fragment) => WrappedComponent => {
   const entityIsUnset = state => isEmpty(state[entityPropName]);
@@ -105,7 +108,9 @@ const withEntityEditor = (entityPropName, fragment) => WrappedComponent => {
     }
   }
 
-  EntityEditor.displayName = `withEntityEditor(${WrappedComponent.displayName})`;
+  EntityEditor.displayName = `withEntityEditor(${
+    WrappedComponent.displayName
+  })`;
 
   return withSaveTracking(EntityEditor);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7730,9 +7730,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
+prettier@^1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
 
 pretty-bytes@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
### What is the context of this PR?
- Upgrades Prettier code formatter to the latest version.
- [Version 1.9](https://prettier.io/blog/2017/12/05/1.9.0.html) is particularly useful due to the updates for JSX and GraphQL.


### How to review 
- Run Tests
- Review formatting changes enforced by the update