### PR TITLE
Fix setState being called on unmounted component. Issue #397

### DIFF
--- a/src/components/RichTextEditor/RichTextEditor.test.js
+++ b/src/components/RichTextEditor/RichTextEditor.test.js
@@ -43,6 +43,13 @@ describe("components/RichTextEditor", function() {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it("should correctly un-mount component", () => {
+    const instance = wrapper.instance();
+    expect(instance.unmounted).toBeFalsy();
+    wrapper.unmount();
+    expect(instance.unmounted).toBeTruthy();
+  });
+
   it("should render existing content", () => {
     wrapper = shallow(<RichTextEditor {...props} value={content} />);
     expect(wrapper).toMatchSnapshot();

--- a/src/components/RichTextEditor/index.js
+++ b/src/components/RichTextEditor/index.js
@@ -166,6 +166,10 @@ class RichTextEditor extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    this.unmounted = true;
+  }
+
   updatePipedValues() {
     const { editorState } = this.state;
     const { fetchAnswers } = this.props;
@@ -263,7 +267,7 @@ class RichTextEditor extends React.Component {
     });
 
     this.timeoutID = setTimeout(() => {
-      if (this.state.focused) {
+      if (!this.unmounted && this.state.focused) {
         this.setState({ focused: false });
       }
     }, 0);
@@ -272,7 +276,7 @@ class RichTextEditor extends React.Component {
   handleFocus = e => {
     clearTimeout(this.timeoutID);
 
-    if (!this.state.focused) {
+    if (!this.unmounted && !this.state.focused) {
       this.setState({ focused: true });
     }
   };

--- a/src/components/withEntityEditor/index.js
+++ b/src/components/withEntityEditor/index.js
@@ -54,8 +54,9 @@ const withEntityEditor = (entityPropName, fragment) => WrappedComponent => {
         ...currentEntity,
         [name]: value
       };
-
-      this.setState(() => ({ [entityPropName]: entity, isDirty: true }), cb);
+      if (!this.unmounted) {
+        this.setState(() => ({ [entityPropName]: entity, isDirty: true }), cb);
+      }
     };
 
     handleUpdate = () => {
@@ -86,7 +87,9 @@ const withEntityEditor = (entityPropName, fragment) => WrappedComponent => {
       e.preventDefault();
 
       this.props.onSubmit(this.getFilteredEntity()).then(() => {
-        this.setState(() => ({ isDirty: false }));
+        if (!this.unmounted) {
+          this.setState(() => ({ isDirty: false }));
+        }
       });
     };
 


### PR DESCRIPTION
### What is the context of this PR?
- Fixes an error caused by setting the state on unmounted components which indicates a memory leak
- Fixes https://github.com/ONSdigital/eq-author/issues/397
- We suspect this was contributing to our Cypress tests becoming slow, unpredictable and flakey

### How to review 
- Run Tests
- Run Cypress tests, open browser console and ensure there are no errors
- Use steps described in https://github.com/ONSdigital/eq-author/issues/397