### PR TITLE
Fixed visual bug

### DIFF
--- a/src/components/AnswerEditor/index.js
+++ b/src/components/AnswerEditor/index.js
@@ -5,6 +5,7 @@ import { colors, radius } from "constants/theme";
 
 import CustomPropTypes from "custom-prop-types";
 import DeleteButton from "components/DeleteButton";
+import fp from "lodash/fp";
 
 import MultipleChoiceAnswer from "components/Answers/MultipleChoiceAnswer";
 import DateRange from "components/Answers/DateRange";
@@ -62,6 +63,12 @@ class AnswerEditor extends React.Component {
     this.props.onDeleteAnswer(this.props.answer.id);
   };
 
+  formatIncludes = x =>
+    fp.flow(
+      fp.get("properties.format"),
+      fp.includes(x)
+    );
+
   renderAnswer(answer) {
     switch (answer.type) {
       case TEXTFIELD:
@@ -83,7 +90,14 @@ class AnswerEditor extends React.Component {
       case DATE_RANGE:
         return <DateRange {...this.props} />;
       case DATE:
-        return <Date {...this.props} />;
+        return (
+          <Date
+            {...this.props}
+            showDay={this.formatIncludes("dd")(answer)}
+            showMonth={this.formatIncludes("mm")(answer)}
+            showYear={this.formatIncludes("yyyy")(answer)}
+          />
+        );
       default:
         throw new TypeError(`Unknown answer type: ${answer.type}`);
     }

--- a/src/components/Answers/Date/index.js
+++ b/src/components/Answers/Date/index.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import CustomPropTypes from "custom-prop-types";
-import fp from "lodash/fp";
 import DummyDate from "components/Answers/Dummy/Date";
 
 import { Field, Label } from "components/Forms";
@@ -29,16 +28,16 @@ const Fieldset = styled.fieldset`
 
 const Legend = VisuallyHidden.withComponent("legend");
 
-const formatIncludes = x =>
-  fp.flow(fp.get("properties.format"), fp.includes(x));
-
 export const UnwrappedDate = ({
   label,
   name,
   answer,
   onChange,
   onUpdate,
-  placeholder
+  placeholder,
+  showDay,
+  showMonth,
+  showYear
 }) => (
   <Fieldset>
     <Legend>Date options</Legend>
@@ -61,9 +60,9 @@ export const UnwrappedDate = ({
       <Label>Date</Label>
       <Format>
         <DummyDate
-          showDay={formatIncludes("dd")(answer)}
-          showMonth={formatIncludes("mm")(answer)}
-          showYear={formatIncludes("yyyy")(answer)}
+          showDay={showDay}
+          showMonth={showMonth}
+          showYear={showYear}
         />
       </Format>
     </Field>
@@ -76,7 +75,10 @@ UnwrappedDate.propTypes = {
   onUpdate: PropTypes.func.isRequired,
   name: PropTypes.string,
   label: PropTypes.string,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
+  showDay: PropTypes.bool,
+  showMonth: PropTypes.bool,
+  showYear: PropTypes.bool
 };
 
 UnwrappedDate.defaultProps = {

--- a/src/components/Answers/DateRange/__snapshots__/index.test.js.snap
+++ b/src/components/Answers/DateRange/__snapshots__/index.test.js.snap
@@ -14,6 +14,9 @@ exports[`DateRange should render 1`] = `
     key="1from"
     onChange={[Function]}
     onUpdate={[Function]}
+    showDay={true}
+    showMonth={true}
+    showYear={true}
     store={
       Object {
         "dispatch": [Function],
@@ -32,6 +35,9 @@ exports[`DateRange should render 1`] = `
     key="1to"
     onChange={[Function]}
     onUpdate={[Function]}
+    showDay={true}
+    showMonth={true}
+    showYear={true}
     store={
       Object {
         "dispatch": [Function],

--- a/src/components/Answers/DateRange/index.js
+++ b/src/components/Answers/DateRange/index.js
@@ -14,7 +14,14 @@ const Wrapper = styled.div`
 const DateRange = ({ answer, ...otherProps }) => (
   <Wrapper data-test="date-range-editor">
     {answer.childAnswers.map(answer => (
-      <Date key={answer.id} answer={answer} {...otherProps} />
+      <Date
+        key={answer.id}
+        answer={answer}
+        showDay
+        showMonth
+        showYear
+        {...otherProps}
+      />
     ))}
   </Wrapper>
 );

--- a/src/components/Answers/Dummy/Date/__snapshots__/index.test.js.snap
+++ b/src/components/Answers/Dummy/Date/__snapshots__/index.test.js.snap
@@ -5,3 +5,72 @@ exports[`Dummy/Date should render 1`] = `
   data-test="dummy-date"
 />
 `;
+
+exports[`Dummy/Date should render dd/mm/yyy 1`] = `
+<Date__Wrapper
+  data-test="dummy-date"
+>
+  <Date__Field
+    data-test="dummy-date-day"
+  >
+    <Date__Label>
+      Day
+    </Date__Label>
+    <Date__Input />
+  </Date__Field>
+  <Date__SelectField
+    data-test="dummy-date-month"
+  >
+    <Date__Label>
+      Month
+    </Date__Label>
+    <Date__Input />
+  </Date__SelectField>
+  <Date__Field
+    data-test="dummy-date-year"
+  >
+    <Date__Label>
+      Year
+    </Date__Label>
+    <Date__Input />
+  </Date__Field>
+</Date__Wrapper>
+`;
+
+exports[`Dummy/Date should render mm/yyyy 1`] = `
+<Date__Wrapper
+  data-test="dummy-date"
+>
+  <Date__SelectField
+    data-test="dummy-date-month"
+  >
+    <Date__Label>
+      Month
+    </Date__Label>
+    <Date__Input />
+  </Date__SelectField>
+  <Date__Field
+    data-test="dummy-date-year"
+  >
+    <Date__Label>
+      Year
+    </Date__Label>
+    <Date__Input />
+  </Date__Field>
+</Date__Wrapper>
+`;
+
+exports[`Dummy/Date should render yyyy 1`] = `
+<Date__Wrapper
+  data-test="dummy-date"
+>
+  <Date__Field
+    data-test="dummy-date-year"
+  >
+    <Date__Label>
+      Year
+    </Date__Label>
+    <Date__Input />
+  </Date__Field>
+</Date__Wrapper>
+`;

--- a/src/components/Answers/Dummy/Date/index.test.js
+++ b/src/components/Answers/Dummy/Date/index.test.js
@@ -7,4 +7,19 @@ describe("Dummy/Date", () => {
     const wrapper = shallow(<Date />);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it("should render dd/mm/yyy", () => {
+    const wrapper = shallow(<Date showDay showMonth showYear />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should render mm/yyyy", () => {
+    const wrapper = shallow(<Date showMonth showYear />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should render yyyy", () => {
+    const wrapper = shallow(<Date showYear />);
+    expect(wrapper).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
### What is the context of this PR?
There is small visual bug where the date range type was not correctly displaying the dummy data entry. This Pr fixes that issue by adding an extra prop type that can override the others. 

### How to review 
Tests pass and the date range answer displays correctly and the date properties can also be correctly changed. 
