### PR TITLE
Removed only condition from cypress tests

### DIFF
--- a/cypress/integration/authenticated/builder_spec.js
+++ b/cypress/integration/authenticated/builder_spec.js
@@ -531,7 +531,7 @@ describe("builder", () => {
         .should("contain", "Or");
     });
 
-    it.only("Can be deleted and re-enable the add button", () => {
+    it("Can be deleted and re-enable the add button", () => {
       addAnswerType("Checkbox");
       cy.get(testId("btn-add-option-menu")).click();
       cy.get(testId("btn-add-mutually-exclusive-option")).click();


### PR DESCRIPTION
### What is the context of this PR?
Issue in the cypress test, from the mutually exclusive answer PR. After testing the cypress tests an only had been left in the code meaning that it would be the only test that was being run.

### How to review 
All cypress test pass and all cypress tests run.
