### PR TITLE
449 - Earliest date validation

### DIFF
--- a/cypress/.eslintrc
+++ b/cypress/.eslintrc
@@ -1,7 +1,8 @@
 {
   "globals": {
     "cy": false,
-    "Cypress": false
+    "Cypress": false,
+    "before": true
   },
   "rules": {
     "jest/valid-expect": 0

--- a/cypress/fixtures/answers/ToggleValidationRule.js
+++ b/cypress/fixtures/answers/ToggleValidationRule.js
@@ -1,0 +1,12 @@
+export default {
+  data: {
+    toggleValidationRule: {
+      id: "1",
+      enabled: true,
+      customDate: null,
+      offset: { value: 0, unit: "Days", __typename: "Duration" },
+      relativePosition: "Before",
+      __typename: "EarliestDateValidationRule"
+    }
+  }
+};

--- a/cypress/fixtures/answers/createDateAnswer.js
+++ b/cypress/fixtures/answers/createDateAnswer.js
@@ -1,0 +1,24 @@
+export default {
+  data: {
+    createAnswer: {
+      id: "1",
+      description: "",
+      guidance: "",
+      label: "",
+      type: "Date",
+      properties: { format: "dd/mm/yyyy", required: false },
+      __typename: "BasicAnswer",
+      validation: {
+        earliestDate: {
+          id: "1",
+          enabled: false,
+          customDate: null,
+          offset: { value: 0, unit: "Days", __typename: "Duration" },
+          relativePosition: "Before",
+          __typename: "EarliestDateValidationRule"
+        },
+        __typename: "DateValidation"
+      }
+    }
+  }
+};

--- a/cypress/fixtures/answers/date/updateValidationRule.js
+++ b/cypress/fixtures/answers/date/updateValidationRule.js
@@ -1,0 +1,51 @@
+export const updateValidationRuleOffsetValue = {
+  data: {
+    updateValidationRule: {
+      id: "1",
+      enabled: true,
+      customDate: null,
+      offset: { value: 5, unit: "Days", __typename: "Duration" },
+      relativePosition: "Before",
+      __typename: "EarliestDateValidationRule"
+    }
+  }
+};
+
+export const updateValidationRuleOffsetUnit = {
+  data: {
+    updateValidationRule: {
+      id: "1",
+      enabled: true,
+      customDate: null,
+      offset: { value: 5, unit: "Months", __typename: "Duration" },
+      relativePosition: "Before",
+      __typename: "EarliestDateValidationRule"
+    }
+  }
+};
+
+export const updateValidationRuleRelativePosition = {
+  data: {
+    updateValidationRule: {
+      id: "1",
+      enabled: true,
+      customDate: null,
+      offset: { value: 5, unit: "Months", __typename: "Duration" },
+      relativePosition: "After",
+      __typename: "EarliestDateValidationRule"
+    }
+  }
+};
+
+export const updateValidationRuleCustomDate = {
+  data: {
+    updateValidationRule: {
+      id: "1",
+      enabled: true,
+      customDate: "1985-09-14",
+      offset: { value: 5, unit: "Months", __typename: "Duration" },
+      relativePosition: "After",
+      __typename: "EarliestDateValidationRule"
+    }
+  }
+};

--- a/cypress/integration/authenticated/validation_spec.js
+++ b/cypress/integration/authenticated/validation_spec.js
@@ -1,4 +1,5 @@
-import { CURRENCY, NUMBER } from "../../../src/constants/answer-types";
+/* eslint-disable  camelcase */
+import { CURRENCY, DATE, NUMBER } from "../../../src/constants/answer-types";
 
 import {
   addAnswerType,
@@ -8,6 +9,20 @@ import {
   toggleCheckboxOn,
   toggleCheckboxOff
 } from "../../utils";
+
+import createQuestionnaire from "../../fixtures/createQuestionnaire";
+import GetQuestionPage from "../../fixtures/GetQuestionPage";
+import GetQuestionnaire from "../../fixtures/GetQuestionnaire";
+import GetQuestionnaire_Piping from "../../fixtures/GetQuestionnaire_Piping";
+import createDateAnswer from "../../fixtures/answers/createDateAnswer";
+import UpdateQuestionPage from "../../fixtures/duplicatePage/UpdateQuestionPage";
+import ToggleValidationRule from "../../fixtures/answers/ToggleValidationRule";
+import {
+  updateValidationRuleOffsetValue,
+  updateValidationRuleOffsetUnit,
+  updateValidationRuleRelativePosition,
+  updateValidationRuleCustomDate
+} from "../../fixtures/answers/date/updateValidationRule";
 
 describe("Answer Validation", () => {
   it("Can create a questionnaire", () => {
@@ -160,6 +175,92 @@ describe("Answer Validation", () => {
 
     afterEach(() => {
       removeAnswer({ force: true });
+    });
+  });
+  describe("Date", () => {
+    let count = 0;
+    before(() => {
+      cy.visitStubbed("#/questionnaire/1/1/1/design", {
+        createQuestionnaire,
+        GetQuestionPage,
+        GetQuestionnaire,
+        GetQuestionnaire_Piping,
+        createAnswer: createDateAnswer,
+        UpdateQuestionPage,
+        ToggleValidationRule,
+        updateValidationRule: () => {
+          switch (count++) {
+            case 0:
+              return updateValidationRuleOffsetValue;
+            case 1:
+              return updateValidationRuleOffsetUnit;
+            case 2:
+              return updateValidationRuleRelativePosition;
+            case 3:
+              return updateValidationRuleCustomDate;
+            default:
+              throw new Error("Call not expected");
+          }
+        }
+      });
+      cy.login();
+      addAnswerType(DATE);
+    });
+    describe("Earliest date", () => {
+      it("should exist in the side bar", () => {
+        cy.get(testId("sidebar-button-earliest-date")).should("be.visible");
+      });
+
+      it("should show the date validation modal", () => {
+        cy.get(testId("sidebar-button-earliest-date")).as("earliestDate");
+        cy.get("@earliestDate").click();
+        cy.get(testId("sidebar-title")).contains("Date validation");
+      });
+
+      it("can be toggled on", () => {
+        cy.get(testId("earliest-date-validation")).contains(
+          "Earliest date is disabled"
+        );
+        cy.get(testId("validation-view-toggle")).within(() => {
+          cy.get('[role="switch"]').as("earliestDateToggle");
+        });
+        toggleCheckboxOn("@earliestDateToggle");
+        cy.get(testId("earliest-date-validation")).should(
+          "not.contain",
+          "Earliest date is disabled"
+        );
+      });
+
+      it("should update the offset value", () => {
+        cy.get('[name="offset.value"]')
+          .type("5")
+          .blur()
+          .should("have.value", "05");
+      });
+
+      it("should update the offset unit", () => {
+        cy.get('[name="offset.unit"]')
+          .select("Months")
+          .blur()
+          .should("have.value", "Months");
+      });
+
+      it("should update the relativePosition", () => {
+        cy.get(testId("relative-position-select"))
+          .select("After")
+          .blur();
+        cy.get(testId("relative-position-select")).should(
+          "have.value",
+          "After"
+        );
+      });
+
+      it("should update the custom value", () => {
+        cy.get('[type="date"]')
+          .type("1985-09-14")
+          .blur()
+          .should("have.value", "1985-09-14");
+      });
     });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -9,8 +9,7 @@ Cypress.Commands.add("login", options => {
     },
     options
   );
-  cy
-    .window()
+  cy.window()
     .its("__store__")
     .then(store => {
       store.dispatch({
@@ -21,8 +20,7 @@ Cypress.Commands.add("login", options => {
 });
 
 Cypress.Commands.add("logout", () => {
-  cy
-    .window()
+  cy.window()
     .its("__store__")
     .then(store => {
       store.dispatch({
@@ -40,8 +38,7 @@ Cypress.Commands.add("createQuestionnaire", title => {
 Cypress.Commands.add("deleteQuestionnaire", title => {
   cy.get(testId("logo")).click();
   cy.get("table").within(() => {
-    cy
-      .contains(title)
+    cy.contains(title)
       .closest("tr")
       .within(() => {
         cy.get("button").click();
@@ -59,7 +56,10 @@ Cypress.Commands.add("visitStubbed", function(url, operations = {}) {
   function serverStub(_, req) {
     const { operationName } = JSON.parse(req.body);
 
-    const resultStub = operations[operationName];
+    let resultStub = operations[operationName];
+    if (typeof resultStub === "function") {
+      resultStub = resultStub(req);
+    }
     if (resultStub) {
       return Promise.resolve(responseStub(resultStub));
     }

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "draftjs-filters": "^1.0.0",
     "draftjs-to-html": "^0.7.6",
     "enzyme-to-json": "^3.3.1",
-    "eq-author-graphql-schema": "0.24.0",
+    "eq-author-graphql-schema": "^0.26.0",
     "eslint-config-eq-author": "^1.1.0",
     "firebase": "^4.6.2",
     "firebaseui": "2.4.1",

--- a/src/components/Answers/BasicAnswer/index.js
+++ b/src/components/Answers/BasicAnswer/index.js
@@ -7,6 +7,7 @@ import withEntityEditor from "components/withEntityEditor";
 import answerFragment from "graphql/fragments/answer.graphql";
 import MinValueValidationRule from "graphql/fragments/min-value-validation-rule.graphql";
 import MaxValueValidationRule from "graphql/fragments/max-value-validation-rule.graphql";
+import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
 import gql from "graphql-tag";
 
 export const StatelessBasicAnswer = ({
@@ -91,10 +92,16 @@ StatelessBasicAnswer.fragments = {
             ...MaxValueValidationRule
           }
         }
+        ... on DateValidation {
+          earliestDate {
+            ...EarliestDateValidationRule
+          }
+        }
       }
     }
     ${MinValueValidationRule}
     ${MaxValueValidationRule}
+    ${EarliestDateValidationRule}
   `
 };
 

--- a/src/components/Validation/AnswerValidation.js
+++ b/src/components/Validation/AnswerValidation.js
@@ -1,22 +1,21 @@
 import React from "react";
-import { kebabCase, includes, find, get } from "lodash";
+import { kebabCase, get } from "lodash";
 import styled from "styled-components";
 import CustomPropTypes from "custom-prop-types";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 
 import { gotoTab } from "redux/tabs/actions";
-import { CURRENCY, NUMBER } from "constants/answer-types";
+import { CURRENCY, DATE, NUMBER } from "constants/answer-types";
 import { colors } from "constants/theme";
 
 import SidebarButton, { Title, Detail } from "components/SidebarButton";
 import ModalWithNav from "components/ModalWithNav";
 import MinValueValidation from "./MinValue";
 import MaxValueValidation from "./MaxValue";
+import EarliestDateValidation from "./EarliestDate";
 
 import ValidationContext from "./ValidationContext";
-
-const answerTypes = [CURRENCY, NUMBER];
 
 const Container = styled.div`
   margin-top: 1em;
@@ -26,16 +25,36 @@ const Container = styled.div`
 
 const validationTypes = [
   {
-    id: "min-value",
+    id: "minValue",
     title: "Min Value",
-    render: () => <MinValueValidation />
+    render: () => <MinValueValidation />,
+    types: [CURRENCY, NUMBER]
   },
   {
-    id: "max-value",
+    id: "maxValue",
     title: "Max Value",
-    render: () => <MaxValueValidation />
+    render: () => <MaxValueValidation />,
+    types: [CURRENCY, NUMBER]
+  },
+  {
+    id: "earliestDate",
+    title: "Earliest Date",
+    render: () => <EarliestDateValidation />,
+    types: [DATE],
+    custom: "customDate"
   }
 ];
+
+const getValidationsForType = type =>
+  validationTypes.filter(({ types }) => types.includes(type));
+
+const validations = [NUMBER, CURRENCY, DATE].reduce(
+  (hash, type) => ({
+    ...hash,
+    [type]: getValidationsForType(type)
+  }),
+  {}
+);
 
 export class UnconnectedAnswerValidation extends React.Component {
   state = {
@@ -67,27 +86,30 @@ export class UnconnectedAnswerValidation extends React.Component {
   render() {
     const { answer } = this.props;
 
-    if (!includes(answerTypes, answer.type)) {
+    const validValidationTypes = validations[answer.type] || [];
+
+    if (validValidationTypes.length === 0) {
       return null;
     }
 
     return (
       <Container>
         <ValidationContext.Provider value={{ answer }}>
-          {this.renderButton({
-            ...find(validationTypes, { id: "min-value" }),
-            value: get(answer, "validation.minValue.custom"),
-            enabled: get(answer, "validation.minValue.enabled")
-          })}
-          {this.renderButton({
-            ...find(validationTypes, { id: "max-value" }),
-            value: get(answer, "validation.maxValue.custom"),
-            enabled: get(answer, "validation.maxValue.enabled")
-          })}
+          {validValidationTypes.map(validationType =>
+            this.renderButton({
+              ...validationType,
+              value: get(
+                answer,
+                `validation.${validationType.id}.${validationType.custom ||
+                  "custom"}`
+              ),
+              enabled: get(answer, `validation.${validationType.id}.enabled`)
+            })
+          )}
           <ModalWithNav
             id={this.modalId}
             onClose={this.handleModalClose}
-            navItems={validationTypes}
+            navItems={validValidationTypes}
             title={`${answer.type} validation`}
             isOpen={this.state.modalIsOpen}
           />

--- a/src/components/Validation/AnswerValidation.test.js
+++ b/src/components/Validation/AnswerValidation.test.js
@@ -26,7 +26,7 @@ describe("AnswerValidation", () => {
     expect(render(props)).toMatchSnapshot();
   });
 
-  it("should not render when answer type invalid", () => {
+  it("should not render there are no valid validation types", () => {
     props.answer.type = "Radio";
     expect(render(props)).toMatchSnapshot();
   });

--- a/src/components/Validation/EarliestDate.js
+++ b/src/components/Validation/EarliestDate.js
@@ -1,0 +1,205 @@
+import { propType } from "graphql-anywhere";
+import { flowRight } from "lodash/fp";
+import PropTypes from "prop-types";
+import React from "react";
+import styled from "styled-components";
+
+import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
+
+import { Input, Number, Select } from "components/Forms";
+import { Grid, Column } from "components/Grid";
+import DisabledMessage from "components/Validation/DisabledMessage";
+
+import withToggleAnswerValidation from "containers/enhancers/withToggleAnswerValidation";
+import withUpdateAnswerValidation from "containers/enhancers/withUpdateAnswerValidation";
+import withEntityEditor from "components/withEntityEditor";
+
+import ValidationView from "./ValidationView";
+import withAnswerValidation from "./withAnswerValidation";
+
+import svgPath from "./path.svg";
+import svgPathEnd from "./path-end.svg";
+
+const UNITS = ["Days", "Months", "Years"];
+const RELATIVE_POSITIONS = ["Before", "After"];
+
+const DateInput = styled(Input)`
+  margin-top: 4em;
+  width: 12em;
+`;
+const ConnectedPath = styled.div`
+  padding-left: 1em;
+  position: relative;
+  height: 100%;
+
+  &::after {
+    position: absolute;
+    content: "";
+    background: url(${({ pathUrl }) => pathUrl}) no-repeat center center;
+    background-size: auto;
+    width: 100%;
+    height: calc(100% - 2em);
+    top: 0;
+    bottom: 0;
+    margin: auto;
+  }
+`;
+
+const ConnectedPathStart = styled(ConnectedPath)`
+  height: 5em;
+`;
+
+const AlignedColumn = styled(Column)`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+`;
+
+const RelativePositionSelect = styled(Select)`
+  width: 6em;
+`;
+
+const EmphasisedText = styled.p`
+  font-size: 0.9em;
+  font-weight: bold;
+  text-transform: uppercase;
+`;
+
+const START_COL_SIZE = 3;
+const END_COL_SIZE = 12 - START_COL_SIZE;
+
+export const EarliestDate = ({
+  earliestDate,
+  onToggleValidationRule,
+  onUpdate,
+  onChange
+}) => {
+  const { id, enabled, customDate, offset, relativePosition } = earliestDate;
+
+  const handleToggleChange = ({ value: enabled }) => {
+    onToggleValidationRule({
+      id,
+      enabled
+    });
+  };
+  const renderContent = () => (
+    <div>
+      <Grid>
+        <AlignedColumn cols={START_COL_SIZE}>
+          <EmphasisedText>Earliest date is</EmphasisedText>
+        </AlignedColumn>
+        <Column cols={END_COL_SIZE}>
+          <Grid>
+            <Column cols={2}>
+              <Number
+                id="offset-value"
+                name="offset.value"
+                value={offset.value}
+                onChange={onChange}
+                onBlur={onUpdate}
+                max={99999}
+                min={0}
+              />
+            </Column>
+            <Column cols={3}>
+              <Select
+                name="offset.unit"
+                value={offset.unit}
+                onChange={onChange}
+                onBlur={onUpdate}
+                data-test="offset-unit-select"
+              >
+                {UNITS.map(unit => (
+                  <option key={unit} value={unit}>
+                    {unit}
+                  </option>
+                ))}
+              </Select>
+            </Column>
+          </Grid>
+        </Column>
+      </Grid>
+      <Grid>
+        <Column cols={START_COL_SIZE}>
+          <ConnectedPathStart pathUrl={svgPath} />
+        </Column>
+      </Grid>
+      <Grid>
+        <AlignedColumn cols={START_COL_SIZE}>
+          <RelativePositionSelect
+            name="relativePosition"
+            value={relativePosition}
+            onChange={onChange}
+            onBlur={onUpdate}
+            data-test="relative-position-select"
+          >
+            {RELATIVE_POSITIONS.map(position => (
+              <option key={position} value={position}>
+                {position}
+              </option>
+            ))}
+          </RelativePositionSelect>
+        </AlignedColumn>
+      </Grid>
+      <Grid>
+        <Column cols={START_COL_SIZE}>
+          <ConnectedPath pathUrl={svgPathEnd} />
+        </Column>
+        <Column cols={END_COL_SIZE}>
+          <DateInput
+            name="customDate"
+            type="date"
+            value={customDate}
+            onChange={onChange}
+            onBlur={onUpdate}
+          />
+        </Column>
+      </Grid>
+    </div>
+  );
+
+  const renderDisabled = () => (
+    <DisabledMessage>Earliest date is disabled</DisabledMessage>
+  );
+
+  return (
+    <ValidationView
+      data-test="earliest-date-validation"
+      enabled={enabled}
+      onToggleChange={handleToggleChange}
+    >
+      {enabled ? renderContent() : renderDisabled()}
+    </ValidationView>
+  );
+};
+
+EarliestDate.propTypes = {
+  earliestDate: propType(EarliestDateValidationRule).isRequired,
+  onToggleValidationRule: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func.isRequired
+};
+
+export const readToWriteMapper = ({ id, customDate, enabled, ...rest }) => ({
+  id,
+  earliestDateInput: {
+    ...rest,
+    custom: customDate ? customDate : null
+  }
+});
+
+export const remapToOnUpdate = (propName, mapper) => Component => props => (
+  <Component
+    onUpdate={(...args) => props[propName](mapper(...args))}
+    {...props}
+  />
+);
+
+const withEditing = flowRight(
+  withAnswerValidation("earliestDate"),
+  withUpdateAnswerValidation,
+  withToggleAnswerValidation,
+  remapToOnUpdate("onUpdateAnswerValidation", readToWriteMapper),
+  withEntityEditor("earliestDate", EarliestDateValidationRule)
+);
+export default withEditing(EarliestDate);

--- a/src/components/Validation/EarliestDate.test.js
+++ b/src/components/Validation/EarliestDate.test.js
@@ -1,0 +1,151 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import {
+  EarliestDate,
+  readToWriteMapper,
+  remapToOnUpdate
+} from "./EarliestDate";
+
+describe("Earliest date", () => {
+  let props;
+  beforeEach(() => {
+    props = {
+      earliestDate: {
+        id: 123,
+        enabled: true,
+        customDate: "2018-01-01",
+        offset: {
+          value: 5,
+          unit: "Months"
+        },
+        relativePosition: "Before"
+      },
+      onToggleValidationRule: jest.fn(),
+      onChange: jest.fn(),
+      onUpdate: jest.fn()
+    };
+  });
+
+  it("should render disabled message when not enabled", () => {
+    props.earliestDate.enabled = false;
+    const wrapper = shallow(<EarliestDate {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should render the form input with the values when enabled", () => {
+    const wrapper = shallow(<EarliestDate {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it("should call onToggleValidationRule when enabled/disabled", () => {
+    const wrapper = shallow(<EarliestDate {...props} />);
+    wrapper.find("ValidationView").simulate("toggleChange", { value: true });
+    expect(props.onToggleValidationRule).toHaveBeenCalledWith({
+      id: 123,
+      enabled: true
+    });
+  });
+
+  it("should trigger update answer validation when the offset value changes", () => {
+    const wrapper = shallow(<EarliestDate {...props} />);
+    const updateValueField = wrapper.find("Number");
+    updateValueField.simulate("change", "event");
+    expect(props.onChange).toHaveBeenCalledWith("event");
+    updateValueField.simulate("blur", "event");
+    expect(props.onUpdate).toHaveBeenCalledWith("event");
+  });
+
+  it("should trigger update answer validation when the offset unit changes", () => {
+    const wrapper = shallow(<EarliestDate {...props} />);
+    const updateUnitField = wrapper.find('[data-test="offset-unit-select"]');
+    updateUnitField.simulate("change", "event");
+    expect(props.onChange).toHaveBeenCalledWith("event");
+    updateUnitField.simulate("blur", "event");
+    expect(props.onUpdate).toHaveBeenCalledWith("event");
+  });
+
+  it("should trigger update answer validation when the relative position changes", () => {
+    const wrapper = shallow(<EarliestDate {...props} />);
+    const relativePositionField = wrapper.find(
+      '[data-test="relative-position-select"]'
+    );
+    relativePositionField.simulate("change", "event");
+    expect(props.onChange).toHaveBeenCalledWith("event");
+    relativePositionField.simulate("blur", "event");
+    expect(props.onUpdate).toHaveBeenCalledWith("event");
+  });
+
+  it("should trigger update answer validation when the custom value changes", () => {
+    const wrapper = shallow(<EarliestDate {...props} />);
+    const customDateField = wrapper.find('[type="date"]');
+    customDateField.simulate("change", "event");
+    expect(props.onChange).toHaveBeenCalledWith("event");
+    customDateField.simulate("blur", "event");
+    expect(props.onUpdate).toHaveBeenCalledWith("event");
+  });
+
+  describe("readToWriteMapper", () => {
+    it("should map the read version of earliest date to the expected write input", () => {
+      expect(
+        readToWriteMapper({
+          id: 1,
+          customDate: "12/05/1987",
+          offset: {
+            unit: "Months",
+            value: 1
+          },
+          relativePosition: "Before"
+        })
+      ).toMatchObject({
+        id: 1,
+        earliestDateInput: {
+          custom: "12/05/1987",
+          offset: {
+            unit: "Months",
+            value: 1
+          },
+          relativePosition: "Before"
+        }
+      });
+    });
+
+    it("should send null when the custom date is empty", () => {
+      expect(
+        readToWriteMapper({
+          id: 1,
+          customDate: "",
+          offset: {
+            unit: "Months",
+            value: 1
+          },
+          relativePosition: "Before"
+        })
+      ).toMatchObject({
+        id: 1,
+        earliestDateInput: {
+          custom: null,
+          offset: {
+            unit: "Months",
+            value: 1
+          },
+          relativePosition: "Before"
+        }
+      });
+    });
+  });
+
+  describe("remapToOnUpdate", () => {
+    it("should remap a function prop to onUpdate", () => {
+      const Component = "div";
+      const EnhancedComponent = remapToOnUpdate(
+        "onSomething",
+        thing => `prefix-${thing}`
+      )(Component);
+      const onSomething = jest.fn();
+      const wrapper = shallow(<EnhancedComponent onSomething={onSomething} />);
+      wrapper.props().onUpdate("hello");
+      expect(onSomething).toHaveBeenCalledWith("prefix-hello");
+    });
+  });
+});

--- a/src/components/Validation/__snapshots__/AnswerValidation.test.js.snap
+++ b/src/components/Validation/__snapshots__/AnswerValidation.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AnswerValidation should not render when answer type invalid 1`] = `""`;
+exports[`AnswerValidation should not render there are no valid validation types 1`] = `""`;
 
 exports[`AnswerValidation should render 1`] = `
 <AnswerValidation__Container>
@@ -16,7 +16,7 @@ exports[`AnswerValidation should render 1`] = `
   >
     <SidebarButton
       data-test="sidebar-button-min-value"
-      key="min-value"
+      key="minValue"
       onClick={[Function]}
     >
       <SidebarButton__Title>
@@ -25,7 +25,7 @@ exports[`AnswerValidation should render 1`] = `
     </SidebarButton>
     <SidebarButton
       data-test="sidebar-button-max-value"
-      key="max-value"
+      key="maxValue"
       onClick={[Function]}
     >
       <SidebarButton__Title>
@@ -38,14 +38,22 @@ exports[`AnswerValidation should render 1`] = `
       navItems={
         Array [
           Object {
-            "id": "min-value",
+            "id": "minValue",
             "render": [Function],
             "title": "Min Value",
+            "types": Array [
+              "Currency",
+              "Number",
+            ],
           },
           Object {
-            "id": "max-value",
+            "id": "maxValue",
             "render": [Function],
             "title": "Max Value",
+            "types": Array [
+              "Currency",
+              "Number",
+            ],
           },
         ]
       }

--- a/src/components/Validation/__snapshots__/EarliestDate.test.js.snap
+++ b/src/components/Validation/__snapshots__/EarliestDate.test.js.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Earliest date should render disabled message when not enabled 1`] = `
+<ValidationView
+  data-test="earliest-date-validation"
+  enabled={false}
+  onToggleChange={[Function]}
+>
+  <DisabledMessage>
+    Earliest date is disabled
+  </DisabledMessage>
+</ValidationView>
+`;
+
+exports[`Earliest date should render the form input with the values when enabled 1`] = `
+<ValidationView
+  data-test="earliest-date-validation"
+  enabled={true}
+  onToggleChange={[Function]}
+>
+  <div>
+    <Grid
+      align="top"
+      fillHeight={true}
+    >
+      <EarliestDate__AlignedColumn
+        cols={3}
+      >
+        <EarliestDate__EmphasisedText>
+          Earliest date is
+        </EarliestDate__EmphasisedText>
+      </EarliestDate__AlignedColumn>
+      <Column
+        cols={9}
+      >
+        <Grid
+          align="top"
+          fillHeight={true}
+        >
+          <Column
+            cols={2}
+          >
+            <Number
+              id="offset-value"
+              max={99999}
+              min={0}
+              name="offset.value"
+              onBlur={[Function]}
+              onChange={[Function]}
+              step={1}
+              value={5}
+            />
+          </Column>
+          <Column
+            cols={3}
+          >
+            <withChangeHandler(Select__SimpleSelect)
+              data-test="offset-unit-select"
+              name="offset.unit"
+              onBlur={[Function]}
+              onChange={[Function]}
+              value="Months"
+            >
+              <option
+                key="Days"
+                value="Days"
+              >
+                Days
+              </option>
+              <option
+                key="Months"
+                value="Months"
+              >
+                Months
+              </option>
+              <option
+                key="Years"
+                value="Years"
+              >
+                Years
+              </option>
+            </withChangeHandler(Select__SimpleSelect)>
+          </Column>
+        </Grid>
+      </Column>
+    </Grid>
+    <Grid
+      align="top"
+      fillHeight={true}
+    >
+      <Column
+        cols={3}
+      >
+        <EarliestDate__ConnectedPathStart
+          pathUrl="path.svg"
+        />
+      </Column>
+    </Grid>
+    <Grid
+      align="top"
+      fillHeight={true}
+    >
+      <EarliestDate__AlignedColumn
+        cols={3}
+      >
+        <EarliestDate__RelativePositionSelect
+          data-test="relative-position-select"
+          name="relativePosition"
+          onBlur={[Function]}
+          onChange={[Function]}
+          value="Before"
+        >
+          <option
+            key="Before"
+            value="Before"
+          >
+            Before
+          </option>
+          <option
+            key="After"
+            value="After"
+          >
+            After
+          </option>
+        </EarliestDate__RelativePositionSelect>
+      </EarliestDate__AlignedColumn>
+    </Grid>
+    <Grid
+      align="top"
+      fillHeight={true}
+    >
+      <Column
+        cols={3}
+      >
+        <EarliestDate__ConnectedPath
+          pathUrl="path-end.svg"
+        />
+      </Column>
+      <Column
+        cols={9}
+      >
+        <EarliestDate__DateInput
+          name="customDate"
+          onBlur={[Function]}
+          onChange={[Function]}
+          type="date"
+          value="2018-01-01"
+        />
+      </Column>
+    </Grid>
+  </div>
+</ValidationView>
+`;

--- a/src/components/Validation/path-end.svg
+++ b/src/components/Validation/path-end.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="150px" height="99px" viewBox="0 0 150 99" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
+    <title>path</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="path" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
+        <polyline id="Line-Copy-3" stroke="#999999" points="125 80 50 80 50 13"></polyline>
+    </g>
+</svg>

--- a/src/components/Validation/path.svg
+++ b/src/components/Validation/path.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="150px" height="58px" viewBox="0 0 150 58" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
+    <title>path-end</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="path-end" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="square">
+        <path d="M51,8.80273438 L51,49.8027344" id="Line-Copy" stroke="#999999"></path>
+    </g>
+</svg>

--- a/src/components/Validation/withAnswerValidation.js
+++ b/src/components/Validation/withAnswerValidation.js
@@ -1,0 +1,14 @@
+import React from "react";
+import ValidationContext from "./ValidationContext";
+
+export default validationName => Component => props => (
+  <ValidationContext.Consumer>
+    {({ answer }) => {
+      let propsWithValidation = {
+        [validationName]: answer.validation[validationName],
+        ...props
+      };
+      return <Component {...propsWithValidation} />;
+    }}
+  </ValidationContext.Consumer>
+);

--- a/src/components/Validation/withAnswerValidation.test.js
+++ b/src/components/Validation/withAnswerValidation.test.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { mount } from "enzyme";
+
+describe("withAnswerValidation", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  const getwithAnswerValidationWithContext = answer => {
+    jest.doMock("./ValidationContext", () => ({
+      Consumer: ({ children }) => children({ answer })
+    }));
+    return require("./withAnswerValidation").default;
+  };
+
+  const Component = () => <div />;
+
+  it("should pass down the validation requested", () => {
+    const answer = {
+      validation: {
+        exampleValidation: { foo: "bar" }
+      }
+    };
+    const withAnswerValidation = getwithAnswerValidationWithContext(answer);
+    const WrappedComponent = withAnswerValidation("exampleValidation")(
+      Component
+    );
+    const wrapper = mount(<WrappedComponent hello="world" />);
+    expect(wrapper.find("Component").props()).toMatchObject({
+      exampleValidation: {
+        foo: "bar"
+      },
+      hello: "world"
+    });
+  });
+});

--- a/src/containers/enhancers/withToggleAnswerValidation.js
+++ b/src/containers/enhancers/withToggleAnswerValidation.js
@@ -2,17 +2,20 @@ import { graphql } from "react-apollo";
 import gql from "graphql-tag";
 import MinValueValidationRule from "graphql/fragments/min-value-validation-rule.graphql";
 import MaxValueValidationRule from "graphql/fragments/max-value-validation-rule.graphql";
+import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
 
 export const TOGGLE_VALIDATION_RULE = gql`
   mutation ToggleValidationRule($input: ToggleValidationRuleInput!) {
     toggleValidationRule(input: $input) {
       ...MinValueValidationRule
       ...MaxValueValidationRule
+      ...EarliestDateValidationRule
     }
   }
 
   ${MinValueValidationRule}
   ${MaxValueValidationRule}
+  ${EarliestDateValidationRule}
 `;
 
 export const mapMutateToProps = ({ mutate }) => ({

--- a/src/containers/enhancers/withUpdateAnswerValidation.js
+++ b/src/containers/enhancers/withUpdateAnswerValidation.js
@@ -2,17 +2,20 @@ import { graphql } from "react-apollo";
 import gql from "graphql-tag";
 import MinValueValidationRule from "graphql/fragments/min-value-validation-rule.graphql";
 import MaxValueValidationRule from "graphql/fragments/max-value-validation-rule.graphql";
+import EarliestDateValidationRule from "graphql/fragments/earliest-date-validation-rule.graphql";
 
 export const UPDATE_VALIDATION_RULE = gql`
   mutation updateValidationRule($input: UpdateValidationRuleInput!) {
     updateValidationRule(input: $input) {
       ...MinValueValidationRule
       ...MaxValueValidationRule
+      ...EarliestDateValidationRule
     }
   }
 
   ${MinValueValidationRule}
   ${MaxValueValidationRule}
+  ${EarliestDateValidationRule}
 `;
 
 export const mapMutateToProps = ({ mutate }) => ({

--- a/src/graphql/createAnswer.graphql
+++ b/src/graphql/createAnswer.graphql
@@ -2,6 +2,7 @@
 #import "./fragments/option.graphql"
 #import "./fragments/min-value-validation-rule.graphql"
 #import "./fragments/max-value-validation-rule.graphql"
+#import "./fragments/earliest-date-validation-rule.graphql"
 
 mutation createAnswer($input: CreateAnswerInput!) {
   createAnswer(input: $input) {
@@ -14,6 +15,11 @@ mutation createAnswer($input: CreateAnswerInput!) {
           }
           maxValue {
             ...MaxValueValidationRule
+          }
+        }
+        ... on DateValidation {
+          earliestDate {
+            ...EarliestDateValidationRule
           }
         }
       }

--- a/src/graphql/fragments/earliest-date-validation-rule.graphql
+++ b/src/graphql/fragments/earliest-date-validation-rule.graphql
@@ -1,0 +1,10 @@
+fragment EarliestDateValidationRule on EarliestDateValidationRule {
+  id
+  enabled
+  customDate: custom
+  offset {
+    value
+    unit
+  }
+  relativePosition
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3554,9 +3554,9 @@ enzyme@^3.3.0:
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
 
-eq-author-graphql-schema@0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.24.0.tgz#238d2ce167a9962cdf9eb7d73cd94f83a9ba7304"
+eq-author-graphql-schema@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.26.0.tgz#7b4c6dfb735dc9aa8e8e9665a9b32ef805673beb"
 
 errno@^0.1.3, errno@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
### What is the context of this PR?
This change implements updating earliest date validation for `Date` answers.

### How to review 
1. Add a Date answer to a page.
2. Ensure you can enable it and update all the fields in the modal that is opened.

### Dependencies
- [x] Schema - https://github.com/ONSdigital/eq-author-graphql-schema/pull/62
- [x] API - https://github.com/ONSdigital/eq-author-api/pull/119
