### PR TITLE
Refactor plaintextTitle to utilise displayName

### DIFF
--- a/cypress/fixtures/GetQuestionPage.js
+++ b/cypress/fixtures/GetQuestionPage.js
@@ -6,7 +6,7 @@ export default {
       description: "",
       position: 0,
       guidance: null,
-      plaintextTitle: "",
+      displayName: "",
       answers: [],
       __typename: "QuestionPage"
     }

--- a/cypress/fixtures/GetQuestionnaire.js
+++ b/cypress/fixtures/GetQuestionnaire.js
@@ -15,12 +15,12 @@ export default {
           id: "1",
           title: "",
           position: 0,
-          plaintextTitle: "",
+          displayName: "",
           pages: [
             {
               id: "1",
               title: "",
-              plaintextTitle: "",
+              displayName: "",
               position: 0,
               __typename: "QuestionPage"
             }

--- a/cypress/fixtures/createQuestionnaire.js
+++ b/cypress/fixtures/createQuestionnaire.js
@@ -8,7 +8,7 @@ export default {
       sections: [
         {
           id: "1",
-          plaintextTitle: "",
+          displayName: "",
           pages: [{ id: "1", __typename: "QuestionPage" }],
           __typename: "Section"
         }

--- a/cypress/fixtures/duplicatePage/UpdateQuestionPage.js
+++ b/cypress/fixtures/duplicatePage/UpdateQuestionPage.js
@@ -4,7 +4,7 @@ export default {
       id: "1",
       __typename: "QuestionPage",
       title: "<p>Question 1</p>",
-      plaintextTitle: "Question 1",
+      displayName: "Question 1",
       guidance: "",
       description: "",
       position: 0,

--- a/cypress/fixtures/duplicatePage/duplicatePage.js
+++ b/cypress/fixtures/duplicatePage/duplicatePage.js
@@ -4,7 +4,7 @@ export default {
       id: "2",
       __typename: "QuestionPage",
       title: "<p>Copy of Question 1</p>",
-      plaintextTitle: "Copy of Question 1",
+      displayName: "Copy of Question 1",
       guidance: "",
       description: "",
       position: 1,

--- a/cypress/integration/authenticated/builder_spec.js
+++ b/cypress/integration/authenticated/builder_spec.js
@@ -366,21 +366,8 @@ describe("builder", () => {
       .click();
     typeIntoDraftEditor(testId("txt-question-title", "testid"), `Page 0`);
 
-    let pageCount = 1;
-
     times(2, i => {
-      addQuestionPage();
-
-      // this causes cypress to wait until the assertion is correct,
-      // which avoids a race condition where cypress will type into
-      // a matching text box on the prev page, while animation is underway
-      pageCount++;
-      cy.get(testId("page-item")).should("have.length", pageCount);
-
-      typeIntoDraftEditor(
-        testId("txt-question-title", "testid"),
-        `Page ${i + 1}`
-      );
+      addQuestionPage(`Page ${i + 1}`);
     });
 
     cy.get(testId("btn-move")).click();

--- a/cypress/integration/authenticated/routing_spec.js
+++ b/cypress/integration/authenticated/routing_spec.js
@@ -142,7 +142,7 @@ describe("Routing", () => {
 
     addSection();
 
-    cy.contains("Page Title").click();
+    cy.contains("Untitled Page").click();
 
     typeIntoDraftEditor(testId("txt-question-title", "testid"), "Question 4");
     buildMultipleChoiceAnswer(["G", "H", "I"]);
@@ -158,53 +158,44 @@ describe("Routing", () => {
     cy.get(testId("routing-rule"));
 
     cy.get(testId("routing-editor")).within(() => {
-      cy
-        .get(testId("routing-rule"))
+      cy.get(testId("routing-rule"))
         .last()
         .within(() => setRoutingCondition("Question 1", "A"));
 
       cy.get(testId("btn-add-rule")).click();
       cy.get(testId("routing-rule")).should("have.length", 2);
 
-      cy
-        .get(testId("routing-rule"))
+      cy.get(testId("routing-rule"))
         .last()
         .within(() => setRoutingCondition("Question 2", "D"));
 
       cy.get(testId("btn-add-rule")).click();
       cy.get(testId("routing-rule")).should("have.length", 3);
 
-      cy
-        .get(testId("routing-rule"))
+      cy.get(testId("routing-rule"))
         .last()
         .within(() => setRoutingCondition("Question 3", "G"));
     });
 
-    cy
-      .get(testId("options-selector"))
+    cy.get(testId("options-selector"))
       .eq(0)
       .within(() => {
-        cy
-          .get("input")
+        cy.get("input")
           .first()
           .should("be.checked");
       });
 
-    cy
-      .get(testId("options-selector"))
+    cy.get(testId("options-selector"))
       .eq(1)
       .within(() => {
-        cy
-          .get("input")
+        cy.get("input")
           .first()
           .should("be.checked");
       });
-    cy
-      .get(testId("options-selector"))
+    cy.get(testId("options-selector"))
       .eq(2)
       .within(() => {
-        cy
-          .get("input")
+        cy.get("input")
           .first()
           .should("be.checked");
       });
@@ -255,8 +246,7 @@ describe("Routing", () => {
 
     cy.get(testId("btn-add-rule")).click();
 
-    cy
-      .get(testId("options-selector"))
+    cy.get(testId("options-selector"))
       .first()
       .contains("D");
 
@@ -264,8 +254,7 @@ describe("Routing", () => {
       .first()
       .select("Question 1");
 
-    cy
-      .get(testId("options-selector"))
+    cy.get(testId("options-selector"))
       .first()
       .contains("A");
   });
@@ -292,8 +281,7 @@ describe("Routing", () => {
 
     cy.get(testId("routing-rule"));
 
-    cy
-      .get(testId("result-selector"))
+    cy.get(testId("result-selector"))
       .first()
       .within(() => {
         cy.contains("Question 1").should("not.exist");
@@ -359,15 +347,13 @@ describe("Routing", () => {
 
     cy.get(testId("btn-add-rule")).click();
 
-    cy
-      .get(testId("routing-rule"))
+    cy.get(testId("routing-rule"))
       .last()
       .within(() => setRoutingCondition("Question 1", "A"));
 
     cy.contains("Question 1").click();
 
-    cy
-      .get(testId("tabs-nav"))
+    cy.get(testId("tabs-nav"))
       .contains("Builder")
       .click();
 

--- a/cypress/utils/index.js
+++ b/cypress/utils/index.js
@@ -80,7 +80,7 @@ export const addQuestionPage = (title = "hello world") => {
     });
 
     cy.get(testId("nav-page-link")).should("have.length", prevCount + 1);
-    cy.get(testId("nav-page-link")).should("contain", "Page Title");
+    cy.get(testId("nav-page-link")).should("contain", "Untitled Page");
 
     typeIntoDraftEditor(testId("txt-question-title", "testid"), title);
   });

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "draftjs-filters": "^1.0.0",
     "draftjs-to-html": "^0.7.6",
     "enzyme-to-json": "^3.3.1",
-    "eq-author-graphql-schema": "^0.26.0",
+    "eq-author-graphql-schema": "0.27.0",
     "eslint-config-eq-author": "^1.1.0",
     "firebase": "^4.6.2",
     "firebaseui": "2.4.1",

--- a/src/components/MovePageModal/__snapshots__/index.test.js.snap
+++ b/src/components/MovePageModal/__snapshots__/index.test.js.snap
@@ -7,8 +7,8 @@ exports[`MovePageModal should render 1`] = `
   onMovePage={[Function]}
   page={
     Object {
+      "displayName": "Page 1.1",
       "id": "1.1",
-      "plaintextTitle": "Page 1.1",
       "position": 0,
       "title": "Page 1.1",
     }
@@ -18,42 +18,42 @@ exports[`MovePageModal should render 1`] = `
       "id": "1",
       "sections": Array [
         Object {
+          "displayName": "Section 1",
           "id": "1",
           "pages": Array [
             Object {
+              "displayName": "Page 1.1",
               "id": "1.1",
-              "plaintextTitle": "Page 1.1",
               "position": 0,
               "title": "Page 1.1",
             },
             Object {
+              "displayName": "Page 1.2",
               "id": "1.2",
-              "plaintextTitle": "Page 1.2",
               "position": 1,
               "title": "Page 1.2",
             },
           ],
-          "plaintextTitle": "Section 1",
           "position": 0,
           "title": "Section 1",
         },
         Object {
+          "displayName": "Section 2",
           "id": "2",
           "pages": Array [
             Object {
+              "displayName": "Page 2.1",
               "id": "2.1",
-              "plaintextTitle": "Page 2.1",
               "position": 0,
               "title": "Page 2.1",
             },
             Object {
+              "displayName": "Page 2.2",
               "id": "2.2",
-              "plaintextTitle": "Page 2.2",
               "position": 1,
               "title": "Page 2.2",
             },
           ],
-          "plaintextTitle": "Section 2",
           "position": 1,
           "title": "Section 2",
         },
@@ -115,14 +115,14 @@ exports[`MovePageModal should render 1`] = `
     options={
       Array [
         Object {
+          "displayName": "Page 1.1",
           "id": "1.1",
-          "plaintextTitle": "Page 1.1",
           "position": 0,
           "title": "Page 1.1",
         },
         Object {
+          "displayName": "Page 1.2",
           "id": "1.2",
-          "plaintextTitle": "Page 1.2",
           "position": 1,
           "title": "Page 1.2",
         },
@@ -130,8 +130,8 @@ exports[`MovePageModal should render 1`] = `
     }
     page={
       Object {
+        "displayName": "Page 1.1",
         "id": "1.1",
-        "plaintextTitle": "Page 1.1",
         "position": 0,
         "title": "Page 1.1",
       }
@@ -141,42 +141,42 @@ exports[`MovePageModal should render 1`] = `
         "id": "1",
         "sections": Array [
           Object {
+            "displayName": "Section 1",
             "id": "1",
             "pages": Array [
               Object {
+                "displayName": "Page 1.1",
                 "id": "1.1",
-                "plaintextTitle": "Page 1.1",
                 "position": 0,
                 "title": "Page 1.1",
               },
               Object {
+                "displayName": "Page 1.2",
                 "id": "1.2",
-                "plaintextTitle": "Page 1.2",
                 "position": 1,
                 "title": "Page 1.2",
               },
             ],
-            "plaintextTitle": "Section 1",
             "position": 0,
             "title": "Section 1",
           },
           Object {
+            "displayName": "Section 2",
             "id": "2",
             "pages": Array [
               Object {
+                "displayName": "Page 2.1",
                 "id": "2.1",
-                "plaintextTitle": "Page 2.1",
                 "position": 0,
                 "title": "Page 2.1",
               },
               Object {
+                "displayName": "Page 2.2",
                 "id": "2.2",
-                "plaintextTitle": "Page 2.2",
                 "position": 1,
                 "title": "Page 2.2",
               },
             ],
-            "plaintextTitle": "Section 2",
             "position": 1,
             "title": "Section 2",
           },
@@ -186,8 +186,8 @@ exports[`MovePageModal should render 1`] = `
     sectionId="1"
     selected={
       Object {
+        "displayName": "Page 1.1",
         "id": "1.1",
-        "plaintextTitle": "Page 1.1",
         "position": 0,
         "title": "Page 1.1",
       }

--- a/src/components/MovePageModal/index.js
+++ b/src/components/MovePageModal/index.js
@@ -129,7 +129,7 @@ class MovePageModal extends React.Component {
         >
           {questionnaire.sections.map(section => (
             <Option key={section.id} value={section.id}>
-              {section.plaintextTitle || "Untitled Section"}
+              {section.displayName}
             </Option>
           ))}
         </ItemSelect>
@@ -146,9 +146,7 @@ class MovePageModal extends React.Component {
       <MoveModal title={"Move question"} {...this.props}>
         <Label htmlFor={sectionButtonId}>Section</Label>
         <Trigger id={sectionButtonId} onClick={this.handleOpenSectionSelect}>
-          <Truncated>
-            {selectedSection.plaintextTitle || "Untitled Section"}
-          </Truncated>
+          <Truncated>{selectedSection.displayName}</Truncated>
         </Trigger>
         {this.renderSectionSelect(selectedSection)}
 

--- a/src/components/MoveSectionModal/__snapshots__/index.test.js.snap
+++ b/src/components/MoveSectionModal/__snapshots__/index.test.js.snap
@@ -10,42 +10,42 @@ exports[`MoveSectionModal should render 1`] = `
       "id": "1",
       "sections": Array [
         Object {
+          "displayName": "Section 1",
           "id": "1",
           "pages": Array [
             Object {
+              "displayName": "Page 1.1",
               "id": "1.1",
-              "plaintextTitle": "Page 1.1",
               "position": 0,
               "title": "Page 1.1",
             },
             Object {
+              "displayName": "Page 1.2",
               "id": "1.2",
-              "plaintextTitle": "Page 1.2",
               "position": 1,
               "title": "Page 1.2",
             },
           ],
-          "plaintextTitle": "Section 1",
           "position": 0,
           "title": "Section 1",
         },
         Object {
+          "displayName": "Section 2",
           "id": "2",
           "pages": Array [
             Object {
+              "displayName": "Page 2.1",
               "id": "2.1",
-              "plaintextTitle": "Page 2.1",
               "position": 0,
               "title": "Page 2.1",
             },
             Object {
+              "displayName": "Page 2.2",
               "id": "2.2",
-              "plaintextTitle": "Page 2.2",
               "position": 1,
               "title": "Page 2.2",
             },
           ],
-          "plaintextTitle": "Section 2",
           "position": 1,
           "title": "Section 2",
         },
@@ -54,22 +54,22 @@ exports[`MoveSectionModal should render 1`] = `
   }
   section={
     Object {
+      "displayName": "Section 1",
       "id": "1",
       "pages": Array [
         Object {
+          "displayName": "Page 1.1",
           "id": "1.1",
-          "plaintextTitle": "Page 1.1",
           "position": 0,
           "title": "Page 1.1",
         },
         Object {
+          "displayName": "Page 1.2",
           "id": "1.2",
-          "plaintextTitle": "Page 1.2",
           "position": 1,
           "title": "Page 1.2",
         },
       ],
-      "plaintextTitle": "Section 1",
       "position": 0,
       "title": "Section 1",
     }
@@ -84,42 +84,42 @@ exports[`MoveSectionModal should render 1`] = `
     options={
       Array [
         Object {
+          "displayName": "Section 1",
           "id": "1",
           "pages": Array [
             Object {
+              "displayName": "Page 1.1",
               "id": "1.1",
-              "plaintextTitle": "Page 1.1",
               "position": 0,
               "title": "Page 1.1",
             },
             Object {
+              "displayName": "Page 1.2",
               "id": "1.2",
-              "plaintextTitle": "Page 1.2",
               "position": 1,
               "title": "Page 1.2",
             },
           ],
-          "plaintextTitle": "Section 1",
           "position": 0,
           "title": "Section 1",
         },
         Object {
+          "displayName": "Section 2",
           "id": "2",
           "pages": Array [
             Object {
+              "displayName": "Page 2.1",
               "id": "2.1",
-              "plaintextTitle": "Page 2.1",
               "position": 0,
               "title": "Page 2.1",
             },
             Object {
+              "displayName": "Page 2.2",
               "id": "2.2",
-              "plaintextTitle": "Page 2.2",
               "position": 1,
               "title": "Page 2.2",
             },
           ],
-          "plaintextTitle": "Section 2",
           "position": 1,
           "title": "Section 2",
         },
@@ -130,42 +130,42 @@ exports[`MoveSectionModal should render 1`] = `
         "id": "1",
         "sections": Array [
           Object {
+            "displayName": "Section 1",
             "id": "1",
             "pages": Array [
               Object {
+                "displayName": "Page 1.1",
                 "id": "1.1",
-                "plaintextTitle": "Page 1.1",
                 "position": 0,
                 "title": "Page 1.1",
               },
               Object {
+                "displayName": "Page 1.2",
                 "id": "1.2",
-                "plaintextTitle": "Page 1.2",
                 "position": 1,
                 "title": "Page 1.2",
               },
             ],
-            "plaintextTitle": "Section 1",
             "position": 0,
             "title": "Section 1",
           },
           Object {
+            "displayName": "Section 2",
             "id": "2",
             "pages": Array [
               Object {
+                "displayName": "Page 2.1",
                 "id": "2.1",
-                "plaintextTitle": "Page 2.1",
                 "position": 0,
                 "title": "Page 2.1",
               },
               Object {
+                "displayName": "Page 2.2",
                 "id": "2.2",
-                "plaintextTitle": "Page 2.2",
                 "position": 1,
                 "title": "Page 2.2",
               },
             ],
-            "plaintextTitle": "Section 2",
             "position": 1,
             "title": "Section 2",
           },
@@ -174,44 +174,44 @@ exports[`MoveSectionModal should render 1`] = `
     }
     section={
       Object {
+        "displayName": "Section 1",
         "id": "1",
         "pages": Array [
           Object {
+            "displayName": "Page 1.1",
             "id": "1.1",
-            "plaintextTitle": "Page 1.1",
             "position": 0,
             "title": "Page 1.1",
           },
           Object {
+            "displayName": "Page 1.2",
             "id": "1.2",
-            "plaintextTitle": "Page 1.2",
             "position": 1,
             "title": "Page 1.2",
           },
         ],
-        "plaintextTitle": "Section 1",
         "position": 0,
         "title": "Section 1",
       }
     }
     selected={
       Object {
+        "displayName": "Section 1",
         "id": "1",
         "pages": Array [
           Object {
+            "displayName": "Page 1.1",
             "id": "1.1",
-            "plaintextTitle": "Page 1.1",
             "position": 0,
             "title": "Page 1.1",
           },
           Object {
+            "displayName": "Page 1.2",
             "id": "1.2",
-            "plaintextTitle": "Page 1.2",
             "position": 1,
             "title": "Page 1.2",
           },
         ],
-        "plaintextTitle": "Section 1",
         "position": 0,
         "title": "Section 1",
       }

--- a/src/components/NavigationSidebar/PageNavItem.js
+++ b/src/components/NavigationSidebar/PageNavItem.js
@@ -31,11 +31,11 @@ export const UnwrappedPageNavItem = ({
         pageId: page.id,
         tab: match.params.tab || "design"
       })}
-      title={page.plaintextTitle}
+      title={page.displayName}
       icon={PageIcon}
       data-test="nav-page-link"
     >
-      {page.plaintextTitle || "Page Title"}
+      {page.displayName}
     </NavLink>
   </StyledPageItem>
 );
@@ -46,7 +46,7 @@ UnwrappedPageNavItem.fragments = {
       id
       title
       position
-      plaintextTitle: title(format: Plaintext)
+      displayName
     }
   `
 };

--- a/src/components/NavigationSidebar/PageNavItem.test.js
+++ b/src/components/NavigationSidebar/PageNavItem.test.js
@@ -4,7 +4,7 @@ import { UnwrappedPageNavItem } from "./PageNavItem";
 
 const page = {
   id: "3",
-  plaintextTitle: "Page title"
+  displayName: "Page title"
 };
 
 describe("PageNavItem", () => {

--- a/src/components/NavigationSidebar/SectionNavItem.js
+++ b/src/components/NavigationSidebar/SectionNavItem.js
@@ -31,10 +31,10 @@ class SectionNavItem extends React.Component {
           exact
           to={url}
           data-test="nav-section-link"
-          title={section.plaintextTitle}
+          title={section.displayName}
           icon={SectionIcon}
         >
-          {section.plaintextTitle || "Section Title"}
+          {section.displayName}
         </NavLink>
 
         <PageNav section={section} questionnaire={questionnaire} />
@@ -48,7 +48,7 @@ SectionNavItem.fragments = {
     fragment SectionNavItem on Section {
       id
       title
-      plaintextTitle: title(format: Plaintext)
+      displayName
       ...PageNav
     }
 

--- a/src/components/NavigationSidebar/SectionNavItem.test.js
+++ b/src/components/NavigationSidebar/SectionNavItem.test.js
@@ -5,17 +5,17 @@ import React from "react";
 describe("SectionNavItem", () => {
   let wrapper, handleAddPage;
 
-  const page = { id: "2", title: "Page", plaintextTitle: "Page" };
+  const page = { id: "2", title: "Page", displayName: "Page" };
   const section = {
     id: "3",
     title: "Section",
-    plaintextTitle: "Section",
+    displayName: "Section",
     pages: [page]
   };
   const questionnaire = {
     id: "1",
     title: "Questionnaire",
-    plaintextTitle: "Questionnaire",
+    displayName: "Questionnaire",
     sections: [section]
   };
 

--- a/src/components/NavigationSidebar/__snapshots__/SectionNavItem.test.js.snap
+++ b/src/components/NavigationSidebar/__snapshots__/SectionNavItem.test.js.snap
@@ -19,19 +19,19 @@ exports[`SectionNavItem should render 1`] = `
   <PageNav
     questionnaire={
       Object {
+        "displayName": "Questionnaire",
         "id": "1",
-        "plaintextTitle": "Questionnaire",
         "sections": Array [
           Object {
+            "displayName": "Section",
             "id": "3",
             "pages": Array [
               Object {
+                "displayName": "Page",
                 "id": "2",
-                "plaintextTitle": "Page",
                 "title": "Page",
               },
             ],
-            "plaintextTitle": "Section",
             "title": "Section",
           },
         ],
@@ -40,15 +40,15 @@ exports[`SectionNavItem should render 1`] = `
     }
     section={
       Object {
+        "displayName": "Section",
         "id": "3",
         "pages": Array [
           Object {
+            "displayName": "Page",
             "id": "2",
-            "plaintextTitle": "Page",
             "title": "Page",
           },
         ],
-        "plaintextTitle": "Section",
         "title": "Section",
       }
     }

--- a/src/components/NavigationSidebar/story.js
+++ b/src/components/NavigationSidebar/story.js
@@ -14,30 +14,30 @@ const Wrapper = styled.div`
 `;
 
 const section1 = {
-  plaintextTitle: "Section 1",
+  displayName: "Section 1",
   id: "1",
   pages: [
     {
-      plaintextTitle: "Question 1.1",
+      displayName: "Question 1.1",
       id: "2"
     },
     {
-      plaintextTitle: "Question 1.2",
+      displayName: "Question 1.2",
       id: "3"
     }
   ]
 };
 
 const section2 = {
-  plaintextTitle: "Section 2",
+  displayName: "Section 2",
   id: "4",
   pages: [
     {
-      plaintextTitle: "Question 2.1",
+      displayName: "Question 2.1",
       id: "5"
     },
     {
-      plaintextTitle: "Question 2.2",
+      displayName: "Question 2.2",
       id: "6"
     }
   ]

--- a/src/components/PositionModal/index.js
+++ b/src/components/PositionModal/index.js
@@ -43,7 +43,7 @@ class PositionModal extends React.Component {
     options: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string.isRequired,
-        plaintextTitle: PropTypes.string.isRequired,
+        displayName: PropTypes.string.isRequired,
         position: PropTypes.number.isRequired
       })
     ).isRequired,
@@ -52,7 +52,7 @@ class PositionModal extends React.Component {
     onMove: PropTypes.func.isRequired,
     selected: PropTypes.shape({
       id: PropTypes.string.isRequired,
-      plaintextTitle: PropTypes.string.isRequired,
+      displayName: PropTypes.string.isRequired,
       position: PropTypes.number.isRequired
     }).isRequired
   };
@@ -120,7 +120,7 @@ class PositionModal extends React.Component {
         >
           {data.map((item, i) => (
             <Option key={i} value={String(i)}>
-              {item.plaintextTitle || "Untitled Page"}
+              {item.displayName}
             </Option>
           ))}
         </ItemSelect>

--- a/src/components/QuestionPageEditor/MetaEditor.js
+++ b/src/components/QuestionPageEditor/MetaEditor.js
@@ -37,7 +37,6 @@ export class StatelessMetaEditor extends React.Component {
   render() {
     const { page, onChange, onUpdate, client } = this.props;
     const handleUpdate = partial(flip(onChange), onUpdate);
-    const pageTitleText = page.plaintextTitle;
 
     const fetchAnswers = ids => {
       return client
@@ -59,7 +58,7 @@ export class StatelessMetaEditor extends React.Component {
           size="large"
           fetchAnswers={fetchAnswers}
           testSelector="txt-question-title"
-          autoFocus={!pageTitleText}
+          autoFocus={!page.title}
         />
 
         <RichTextEditor

--- a/src/components/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
+++ b/src/components/QuestionPageEditor/__snapshots__/MetaEditor.test.js.snap
@@ -3,7 +3,7 @@
 exports[`MetaEditor should render 1`] = `
 <div>
   <RichTextEditor
-    autoFocus={true}
+    autoFocus={false}
     controls={
       Object {
         "emphasis": true,

--- a/src/components/QuestionPageEditor/index.js
+++ b/src/components/QuestionPageEditor/index.js
@@ -136,7 +136,7 @@ export default class QuestionPageEditor extends React.Component {
               isOpen={showDeleteConfirmDialog}
               onClose={onCloseDeleteConfirmDialog}
               onDelete={onDeletePageConfirm}
-              title={page.plaintextTitle || "Untitled Page"}
+              title={page.displayName}
               alertText="All edits, properties and routing settings will also be removed."
               icon={iconPage}
               data-test="delete-page"
@@ -166,7 +166,7 @@ QuestionPageEditor.fragments = {
   QuestionPage: gql`
     fragment QuestionPage on QuestionPage {
       ...Page
-      plaintextTitle: title(format: Plaintext)
+      displayName
       position
       answers {
         ...AnswerEditor

--- a/src/components/QuestionPageRoute/index.js
+++ b/src/components/QuestionPageRoute/index.js
@@ -117,7 +117,7 @@ export class UnwrappedQuestionPageRoute extends React.Component {
   };
 
   getPageTitle = page => title => {
-    const pageTitle = page.plaintextTitle || "Untitled page";
+    const pageTitle = page.displayName;
     return `${pageTitle} - ${title}`;
   };
 

--- a/src/components/QuestionPageRoute/index.test.js
+++ b/src/components/QuestionPageRoute/index.test.js
@@ -36,21 +36,21 @@ const movePageMock = {
             __typename: "Section",
             id: "2",
             title: "foo",
-            plaintextTitle: "foo",
+            displayName: "foo",
             position: 0,
             pages: [
               {
                 __typename: "QuestionPage",
                 id: "3",
                 title: "bar",
-                plaintextTitle: "bar",
+                displayName: "bar",
                 position: 0
               },
               {
                 __typename: "QuestionPage",
                 id: "4",
                 title: "blah",
-                plaintextTitle: "blah",
+                displayName: "blah",
                 position: 1
               }
             ],
@@ -116,7 +116,7 @@ describe("QuestionPageRoute", () => {
               __typename: "QuestionPage",
               id: "3",
               title: "foo",
-              plaintextTitle: "foo",
+              displayName: "foo",
               description: "bar",
               pageType: "QuestionPage",
               position: 0,
@@ -149,7 +149,7 @@ describe("QuestionPageRoute", () => {
               __typename: "QuestionPage",
               id: "3",
               title: "foo",
-              plaintextTitle: "foo",
+              displayName: "foo",
               description: "bar",
               pageType: "QuestionPage",
               position: 0,
@@ -267,7 +267,7 @@ describe("QuestionPageRoute", () => {
           __typename: "QuestionPage",
           id: "3",
           title: "foo",
-          plaintextTitle: "foo",
+          displayName: "foo",
           description: "bar",
           pageType: "QuestionPage",
           position: 0,

--- a/src/components/QuestionnaireMenu/index.js
+++ b/src/components/QuestionnaireMenu/index.js
@@ -13,7 +13,7 @@ const PageMenu = ({ pages, sectionNumber, menuZIndex, ...otherProps }) => (
   <Dropdown maxWidth={"25em"}>
     <MenuList maxHeight={`${MAX_HEIGHT}em`}>
       {map(pages, (page, i) => {
-        const title = page.plaintextTitle;
+        const title = page.displayName;
         const menu = page.answers.length ? (
           <AnswerMenu answers={page.answers} {...otherProps} />
         ) : (
@@ -28,7 +28,7 @@ const PageMenu = ({ pages, sectionNumber, menuZIndex, ...otherProps }) => (
             menuZIndex={menuZIndex}
             disabled={!menu}
           >
-            {sectionNumber}.{i + 1} {title || "Page Title"}
+            {sectionNumber}.{i + 1} {title}
           </SubMenuItem>
         );
       })}
@@ -48,7 +48,7 @@ const AnswerMenu = ({ answers, ...otherProps }) => (
       {map(answers, (answer, i) => {
         return (
           <MenuItem key={`answer-${i}`} item={answer} {...otherProps}>
-            {answer.label || "Answer Label"}
+            {answer.displayName}
           </MenuItem>
         );
       })}
@@ -64,7 +64,7 @@ const SectionMenu = ({ sections, menuZIndex, ...otherProps }) => (
   <Dropdown maxWidth={"10em"}>
     <MenuList>
       {map(sections, (section, i) => {
-        const title = section.plaintextTitle;
+        const title = section.displayName;
         const menu = section.pages.length ? (
           <PageMenu
             pages={section.pages}

--- a/src/components/RichTextEditor/Piping.graphql
+++ b/src/components/RichTextEditor/Piping.graphql
@@ -3,19 +3,21 @@ query GetQuestionnaire_Piping($id: ID!) {
     id
     sections {
       id
-      plaintextTitle: title(format: Plaintext)
+      displayName
       pages {
         ... on QuestionPage {
           id
-          plaintextTitle: title(format: Plaintext)
+          displayName
           answers {
             id
             label
+            displayName
             type
             ... on CompositeAnswer {
               childAnswers {
                 id
                 label
+                displayName
                 type
               }
             }

--- a/src/components/RichTextEditor/RichTextEditor.test.js
+++ b/src/components/RichTextEditor/RichTextEditor.test.js
@@ -190,9 +190,24 @@ describe("components/RichTextEditor", function() {
 
     describe("existing piped values", () => {
       const answers = [
-        { id: "1", label: "answer 1", type: "TextField" },
-        { id: "2", label: "answer 2", type: "TextField" },
-        { id: "3", label: "answer 3", type: "TextField" }
+        {
+          id: "1",
+          displayName: "answer 1",
+          label: "answer 1",
+          type: "TextField"
+        },
+        {
+          id: "2",
+          displayName: "answer 2",
+          label: "answer 2",
+          type: "TextField"
+        },
+        {
+          id: "3",
+          displayName: "answer 3",
+          label: "answer 3",
+          type: "TextField"
+        }
       ];
 
       let fetch;
@@ -227,9 +242,9 @@ describe("components/RichTextEditor", function() {
         );
 
         const expected = new Raw()
-          .addBlock("[Deleted Piped Value] [answer 2]")
-          .addEntity(createPipedEntity(createEntity, nonExistentAnswer), 0, 21)
-          .addEntity(createPipedEntity(createEntity, answers[1]), 22, 10)
+          .addBlock("[Deleted Answer] [answer 2]")
+          .addEntity(createPipedEntity(createEntity, nonExistentAnswer), 0, 16)
+          .addEntity(createPipedEntity(createEntity, answers[1]), 17, 10)
           .toRawContentState();
 
         expect(toRaw(wrapper)).toEqual(expected);
@@ -263,30 +278,32 @@ describe("components/RichTextEditor", function() {
         const answer = {
           id: "123",
           label: "pipe",
+          displayName: "FooBar",
           type: "TextField"
         };
 
         wrapper.find(Toolbar).simulate("piping", answer);
 
         const expected = new Raw()
-          .addBlock("[pipe]")
-          .addEntity(createPipedEntity(createEntity, answer), 0, 6)
+          .addBlock("[FooBar]")
+          .addEntity(createPipedEntity(createEntity, answer), 0, 8)
           .toRawContentState();
 
         expect(toRaw(wrapper)).toEqual(expected);
       });
 
-      it("should use generic label if answer doesn't have label", () => {
+      it("should use displayName", () => {
         const answer = {
           id: "123",
+          displayName: "FooBar",
           type: "TextField"
         };
 
         wrapper.find(Toolbar).simulate("piping", answer);
 
         const expected = new Raw()
-          .addBlock("[Piped Value]")
-          .addEntity(createPipedEntity(createEntity, answer), 0, 13)
+          .addBlock("[FooBar]")
+          .addEntity(createPipedEntity(createEntity, answer), 0, 8)
           .toRawContentState();
 
         expect(toRaw(wrapper)).toEqual(expected);
@@ -299,7 +316,8 @@ describe("components/RichTextEditor", function() {
       const answer = {
         id: "123",
         label: "pipe",
-        type: "TextField"
+        type: "TextField",
+        displayName: "FooBar"
       };
 
       wrapper.find(Toolbar).simulate("piping", answer);
@@ -307,7 +325,7 @@ describe("components/RichTextEditor", function() {
 
       const { value } = props.onUpdate.mock.calls[0][0];
       expect(value).toEqual(
-        '<p><span data-piped="answers" data-id="123" data-type="TextField">[Piped Value]</span></p>'
+        '<p><span data-piped="answers" data-id="123" data-type="TextField">[FooBar]</span></p>'
       );
     });
   });

--- a/src/components/RichTextEditor/entities/PipedValue.js
+++ b/src/components/RichTextEditor/entities/PipedValue.js
@@ -22,9 +22,9 @@ const PipedValueDecorator = styled.span`
   white-space: pre;
 `;
 
-const PipedValueSerialized = ({ data: { id, type } }) => (
+const PipedValueSerialized = ({ data: { id, type, text } }) => (
   <span data-piped="answers" data-id={id} data-type={type}>
-    [Piped Value]
+    {text}
   </span>
 );
 
@@ -64,7 +64,7 @@ export const replacePipedValues = labels => (
 ) => {
   const text = labels.hasOwnProperty(entity.data.id)
     ? labels[entity.data.id]
-    : "Deleted Piped Value";
+    : `Deleted Answer`;
 
   return text
     ? replaceEntityText(contentState, entityKey, blockKey, `[${text}]`)
@@ -78,7 +78,7 @@ export const insertPipedValue = (answer, contentState, selection) => {
   );
 
   const entityKey = newContent.getLastCreatedEntityKey();
-  const text = answer.label || "Piped Value";
+  const text = answer.displayName;
 
   return Modifier.insertText(
     newContent,

--- a/src/components/RichTextEditor/entities/__snapshots__/PipedValue.test.js.snap
+++ b/src/components/RichTextEditor/entities/__snapshots__/PipedValue.test.js.snap
@@ -21,6 +21,6 @@ exports[`PipedValue entityToHTML should convert entity to HTML 1`] = `
   data-piped="answers"
   data-type="TextField"
 >
-  [Piped Value]
+  hello world
 </span>
 `;

--- a/src/components/SectionEditor/__snapshots__/SectionEditor.test.js.snap
+++ b/src/components/SectionEditor/__snapshots__/SectionEditor.test.js.snap
@@ -12,14 +12,13 @@ exports[`SectionEditor should render 1`] = `
     isOpen={false}
     onClose={[Function]}
     onDelete={[Function]}
-    title="Untitled Section"
   />
   <MoveSectionQuery
     questionnaireId="1"
   />
   <SectionEditor__Padding>
     <RichTextEditor
-      autoFocus={true}
+      autoFocus={false}
       controls={
         Object {
           "emphasis": true,
@@ -50,14 +49,13 @@ exports[`SectionEditor should render 2`] = `
     isOpen={false}
     onClose={[Function]}
     onDelete={[Function]}
-    title="Untitled Section"
   />
   <MoveSectionQuery
     questionnaireId="1"
   />
   <SectionEditor__Padding>
     <RichTextEditor
-      autoFocus={true}
+      autoFocus={false}
       controls={
         Object {
           "emphasis": true,

--- a/src/components/SectionEditor/index.js
+++ b/src/components/SectionEditor/index.js
@@ -74,7 +74,6 @@ export class UnwrappedSectionEditor extends React.Component {
       match
     } = this.props;
     const handleUpdate = partial(flip(onChange), onUpdate);
-    const sectionTitleText = section.plaintextTitle;
 
     return (
       <SectionCanvas data-test="section-editor" id={getIdForObject(section)}>
@@ -82,7 +81,7 @@ export class UnwrappedSectionEditor extends React.Component {
           isOpen={showDeleteConfirmDialog}
           onClose={onCloseDeleteConfirmDialog}
           onDelete={onDeleteSectionConfirm}
-          title={sectionTitleText || "Untitled Section"}
+          title={section.displayName}
           alertText="All questions in this section will also be removed. This may affect piping and routing rules elsewhere."
           icon={iconSection}
           data-test="dialog-delete-confirm"
@@ -99,7 +98,7 @@ export class UnwrappedSectionEditor extends React.Component {
             controls={titleControls}
             size="large"
             testSelector="txt-section-title"
-            autoFocus={!sectionTitleText}
+            autoFocus={!section.title}
           />
         </Padding>
       </SectionCanvas>

--- a/src/components/SectionRoute/index.js
+++ b/src/components/SectionRoute/index.js
@@ -84,7 +84,7 @@ export class UnwrappedSectionRoute extends React.Component {
   };
 
   getSectionTitle = section => title => {
-    const sectionTitle = section.plaintextTitle || "Untitled section";
+    const sectionTitle = section.displayName;
     return `${sectionTitle} - ${title}`;
   };
 
@@ -171,7 +171,7 @@ export const SECTION_QUERY = gql`
   query SectionQuery($id: ID!) {
     section(id: $id) {
       ...Section
-      plaintextTitle: title(format: Plaintext)
+      displayName
       position
       questionnaire {
         questionnaireInfo {

--- a/src/components/SectionRoute/index.test.js
+++ b/src/components/SectionRoute/index.test.js
@@ -35,21 +35,21 @@ const moveSectionMock = {
             __typename: "Section",
             id: "2",
             title: "foo",
-            plaintextTitle: "foo",
+            displayName: "foo",
             position: 0,
             pages: [
               {
                 __typename: "QuestionPage",
                 id: "3",
                 title: "bar",
-                plaintextTitle: "bar",
+                displayName: "bar",
                 position: 0
               },
               {
                 __typename: "QuestionPage",
                 id: "4",
                 title: "blah",
-                plaintextTitle: "blah",
+                displayName: "blah",
                 position: 1
               }
             ],
@@ -65,21 +65,21 @@ const moveSectionMock = {
             __typename: "Section",
             id: "3",
             title: "foo",
-            plaintextTitle: "foo",
+            displayName: "foo",
             position: 1,
             pages: [
               {
                 __typename: "QuestionPage",
                 id: "5",
                 title: "bar",
-                plaintextTitle: "bar",
+                displayName: "bar",
                 position: 0
               },
               {
                 __typename: "QuestionPage",
                 id: "6",
                 title: "blah",
-                plaintextTitle: "blah",
+                displayName: "blah",
                 position: 1
               }
             ],
@@ -145,7 +145,7 @@ describe("SectionRoute", () => {
               __typename: "Section",
               id: "1",
               title: "foo",
-              plaintextTitle: "foo",
+              displayName: "foo",
               description: "bar",
               position: 0,
               questionnaire: {
@@ -179,7 +179,7 @@ describe("SectionRoute", () => {
               __typename: "Section",
               id: "2",
               title: "foo",
-              plaintextTitle: "foo",
+              displayName: "foo",
               description: "bar",
               position: 0,
               questionnaire: {
@@ -337,7 +337,7 @@ describe("SectionRoute", () => {
         section: {
           id: "1",
           title: "foo",
-          plaintextTitle: "foo",
+          displayName: "foo",
           description: "bar",
           position: 0,
           questionnaire: {
@@ -372,7 +372,7 @@ describe("SectionRoute", () => {
         section: {
           id: "1",
           title: "foo",
-          plaintextTitle: "foo",
+          displayName: "foo",
           description: "bar",
           position: 0,
           questionnaire: {

--- a/src/components/routing/QuestionnaireRoutingPage.js
+++ b/src/components/routing/QuestionnaireRoutingPage.js
@@ -82,11 +82,11 @@ export const ROUTING_QUERY = gql`
       id
       sections {
         id
-        plaintextTitle: title(format: Plaintext)
+        displayName
         pages {
           id
           ... on QuestionPage {
-            plaintextTitle: title(format: Plaintext)
+            displayName
             answers {
               id
               type
@@ -97,7 +97,7 @@ export const ROUTING_QUERY = gql`
     }
     currentPage: questionPage(id: $pageId) {
       id
-      plaintextTitle: title(format: Plaintext)
+      displayName
       routingRuleSet {
         ...RoutingRuleSet
       }

--- a/src/components/routing/QuestionnaireRoutingPage.test.js
+++ b/src/components/routing/QuestionnaireRoutingPage.test.js
@@ -62,7 +62,7 @@ describe("QuestionnaireRoutingPage", () => {
             currentPage: {
               __typename: "QuestionPage",
               id: "3",
-              plaintextTitle: "hello world",
+              displayName: "hello world",
               routingRuleSet: null,
               answers: []
             },
@@ -98,7 +98,7 @@ describe("QuestionnaireRoutingPage", () => {
             currentPage: {
               __typename: "QuestionPage",
               id: "3",
-              plaintextTitle: "hello world",
+              displayName: "hello world",
               routingRuleSet: null,
               answers: []
             },

--- a/src/components/routing/RoutingCondition.js
+++ b/src/components/routing/RoutingCondition.js
@@ -83,10 +83,10 @@ const shouldDisable = overSome([isEmpty, negate(firstAnswerIsValid)]);
 
 const convertToGroups = sections =>
   sections.map(section => ({
-    label: section.plaintextTitle || "Section Title",
+    label: section.displayName,
     id: section.id,
     options: section.pages.map(page => ({
-      label: page.plaintextTitle || "Page Title",
+      label: page.displayName,
       value: page.id,
       disabled: shouldDisable(page.answers)
     }))

--- a/src/components/routing/RoutingEditor.js
+++ b/src/components/routing/RoutingEditor.js
@@ -157,7 +157,7 @@ class RoutingEditor extends React.Component {
 
     return (
       <div data-test="routing-editor">
-        <Title>{get(currentPage, "plaintextTitle") || "Page Title"}</Title>
+        <Title>{get(currentPage, "displayName")}</Title>
         <Padding>
           <TransitionGroup>{content}</TransitionGroup>
         </Padding>

--- a/src/components/routing/RoutingRuleDestinationSelector.js
+++ b/src/components/routing/RoutingRuleDestinationSelector.js
@@ -42,7 +42,7 @@ const toLogicalDestination = destinationType => ({
 });
 
 const toOption = defaultTitle => entity => ({
-  label: entity.plaintextTitle || defaultTitle,
+  label: entity.displayName,
   value: toAbsoluteDestination(entity)
 });
 

--- a/src/components/routing/RoutingRuleDestinationSelector.test.js
+++ b/src/components/routing/RoutingRuleDestinationSelector.test.js
@@ -19,12 +19,32 @@ describe("components/RoutingRuleDestinationSelector", () => {
       id: "test-select",
       destinations: {
         questionPages: [
-          { id: "1", title: "page 1", __typename: "QuestionPage" },
-          { id: "2", title: "page 2", __typename: "QuestionPage" }
+          {
+            id: "1",
+            displayName: "page 1",
+            title: "page 1",
+            __typename: "QuestionPage"
+          },
+          {
+            id: "2",
+            displayName: "page 2",
+            title: "page 2",
+            __typename: "QuestionPage"
+          }
         ],
         sections: [
-          { id: "3", title: "section 1", __typename: "Section" },
-          { id: "4", title: "section 2", __typename: "Section" }
+          {
+            id: "3",
+            displayName: "section 1",
+            title: "section 1",
+            __typename: "Section"
+          },
+          {
+            id: "4",
+            displayName: "section 2",
+            title: "section 2",
+            __typename: "Section"
+          }
         ]
       },
       sections

--- a/src/components/routing/__snapshots__/RoutingCondition.test.js.snap
+++ b/src/components/routing/__snapshots__/RoutingCondition.test.js.snap
@@ -27,16 +27,16 @@ exports[`components/RoutingCondition should render consistently 1`] = `
           Array [
             Object {
               "id": "1",
-              "label": "Section Title",
+              "label": "1. Integer posuere erat a ante",
               "options": Array [
                 Object {
                   "disabled": true,
-                  "label": "Page Title",
+                  "label": "1.1 Curabitur blandit tempus porttitor",
                   "value": "2",
                 },
                 Object {
                   "disabled": true,
-                  "label": "Page Title",
+                  "label": "1.2 Nulla vitae elit libero, a pharetra augue.",
                   "value": "9",
                 },
               ],

--- a/src/components/routing/__snapshots__/RoutingEditor.test.js.snap
+++ b/src/components/routing/__snapshots__/RoutingEditor.test.js.snap
@@ -4,9 +4,7 @@ exports[`RoutingEditor routing rule set should render routing rule set 1`] = `
 <div
   data-test="routing-editor"
 >
-  <RoutingEditor__Title>
-    Page Title
-  </RoutingEditor__Title>
+  <RoutingEditor__Title />
   <RoutingEditor__Padding>
     <TransitionGroup
       childFactory={[Function]}
@@ -116,9 +114,7 @@ exports[`RoutingEditor routing rules should render routing rules 1`] = `
 <div
   data-test="routing-editor"
 >
-  <RoutingEditor__Title>
-    Page Title
-  </RoutingEditor__Title>
+  <RoutingEditor__Title />
   <RoutingEditor__Padding>
     <TransitionGroup
       childFactory={[Function]}
@@ -225,9 +221,7 @@ exports[`RoutingEditor when not routing rule set should render when no routing r
 <div
   data-test="routing-editor"
 >
-  <RoutingEditor__Title>
-    Page Title
-  </RoutingEditor__Title>
+  <RoutingEditor__Title />
   <RoutingEditor__Padding>
     <TransitionGroup
       childFactory={[Function]}

--- a/src/components/routing/__snapshots__/RoutingRuleDestinationSelector.test.js.snap
+++ b/src/components/routing/__snapshots__/RoutingRuleDestinationSelector.test.js.snap
@@ -37,11 +37,11 @@ exports[`components/RoutingRuleDestinationSelector should render 1`] = `
               "label": "Questions in this section",
               "options": Array [
                 Object {
-                  "label": "Page Title",
+                  "label": "page 1",
                   "value": "{\\"absoluteDestination\\":{\\"destinationType\\":\\"QuestionPage\\",\\"destinationId\\":\\"1\\"}}",
                 },
                 Object {
-                  "label": "Page Title",
+                  "label": "page 2",
                   "value": "{\\"absoluteDestination\\":{\\"destinationType\\":\\"QuestionPage\\",\\"destinationId\\":\\"2\\"}}",
                 },
               ],
@@ -51,11 +51,11 @@ exports[`components/RoutingRuleDestinationSelector should render 1`] = `
               "label": "Sections in this questionnaire",
               "options": Array [
                 Object {
-                  "label": "Section Title",
+                  "label": "section 1",
                   "value": "{\\"absoluteDestination\\":{\\"destinationType\\":\\"Section\\",\\"destinationId\\":\\"3\\"}}",
                 },
                 Object {
-                  "label": "Section Title",
+                  "label": "section 2",
                   "value": "{\\"absoluteDestination\\":{\\"destinationType\\":\\"Section\\",\\"destinationId\\":\\"4\\"}}",
                 },
               ],

--- a/src/components/routing/mockstate.js
+++ b/src/components/routing/mockstate.js
@@ -1,9 +1,11 @@
 export default [
   {
     title: "1. Integer posuere erat a ante",
+    displayName: "1. Integer posuere erat a ante",
     pages: [
       {
         title: "1.1 Curabitur blandit tempus porttitor",
+        displayName: "1.1 Curabitur blandit tempus porttitor",
         pageType: "QuestionPage",
         options: [
           { label: "Bibendum Cras", id: "3", selected: false },
@@ -22,6 +24,7 @@ export default [
       },
       {
         title: "1.2 Nulla vitae elit libero, a pharetra augue.",
+        displayName: "1.2 Nulla vitae elit libero, a pharetra augue.",
         pageType: "QuestionPage",
         options: [
           { label: "Yes", id: "10", selected: false },

--- a/src/containers/SignInPage/index.js
+++ b/src/containers/SignInPage/index.js
@@ -110,6 +110,7 @@ export const mapStateToProps = (state, { location }) => ({
   returnURL: get(location, "state.returnURL")
 });
 
-export default connect(mapStateToProps, { signInUser, verifyAuthStatus })(
-  UnconnectedSignInPage
-);
+export default connect(
+  mapStateToProps,
+  { signInUser, verifyAuthStatus }
+)(UnconnectedSignInPage);

--- a/src/containers/enhancers/withCreateSection.js
+++ b/src/containers/enhancers/withCreateSection.js
@@ -5,7 +5,10 @@ import { buildSectionPath } from "utils/UrlUtils";
 import { get, tap } from "lodash/fp";
 
 export const redirectToNewSection = ownProps => section => {
-  const { history, match: { params } } = ownProps;
+  const {
+    history,
+    match: { params }
+  } = ownProps;
 
   history.push(
     buildSectionPath({
@@ -38,7 +41,9 @@ export const createUpdater = questionnaireId => (proxy, result) => {
 
 export const mapMutateToProps = ({ mutate, ownProps }) => ({
   onAddSection() {
-    const { match: { params } } = ownProps;
+    const {
+      match: { params }
+    } = ownProps;
     const section = {
       title: "",
       description: "",

--- a/src/containers/enhancers/withDeleteSection.js
+++ b/src/containers/enhancers/withDeleteSection.js
@@ -68,7 +68,9 @@ export const deleteUpdater = (questionnaireId, sectionId) => (
 };
 
 export const displayToast = (ownProps, questionnaire) => {
-  const { match: { params } } = ownProps;
+  const {
+    match: { params }
+  } = ownProps;
   const { sectionId, questionnaireId } = params;
 
   const numberOfDeletedPages = find(questionnaire.sections, {
@@ -91,7 +93,10 @@ export const displayToast = (ownProps, questionnaire) => {
 
 export const mapMutateToProps = ({ ownProps, mutate }) => ({
   onDeleteSection(sectionId) {
-    const { match: { params }, client } = ownProps;
+    const {
+      match: { params },
+      client
+    } = ownProps;
     const section = { id: sectionId };
     const update = deleteUpdater(params.questionnaireId, sectionId);
 

--- a/src/containers/enhancers/withMoveSection.js
+++ b/src/containers/enhancers/withMoveSection.js
@@ -7,7 +7,11 @@ export const createUpdater = ({ from, to, questionnaireId }) => (
   proxy,
   result
 ) => {
-  const { data: { moveSection: { id, position } } } = result;
+  const {
+    data: {
+      moveSection: { id, position }
+    }
+  } = result;
   const questionnaireFragmentId = `Questionnaire${questionnaireId}`;
 
   const questionnaire = proxy.readFragment({
@@ -28,7 +32,11 @@ export const createUpdater = ({ from, to, questionnaireId }) => (
 
 export const mapMutateToProps = ({ ownProps, mutate }) => ({
   onMoveSection({ from, to }) {
-    const { match: { params: { questionnaireId } } } = ownProps;
+    const {
+      match: {
+        params: { questionnaireId }
+      }
+    } = ownProps;
     const input = {
       ...to,
       questionnaireId

--- a/src/custom-prop-types/index.js
+++ b/src/custom-prop-types/index.js
@@ -16,24 +16,28 @@ const CustomPropTypes = {
   section: PropTypes.shape({
     id: PropTypes.string,
     title: PropTypes.string,
+    displayName: PropTypes.string,
     description: PropTypes.string,
     position: PropTypes.number
   }),
   page: PropTypes.shape({
     id: PropTypes.string,
     title: PropTypes.string,
+    displayName: PropTypes.string,
     description: PropTypes.string,
     guidance: PropTypes.string
   }),
   answer: PropTypes.shape({
     id: PropTypes.string,
     label: PropTypes.string,
+    displayName: PropTypes.string,
     description: PropTypes.string,
     type: PropTypes.oneOf(Object.values(answerTypes))
   }),
   option: PropTypes.shape({
     id: PropTypes.string.isRequired,
     label: PropTypes.string,
+    displayName: PropTypes.string,
     description: PropTypes.string,
     qCode: PropTypes.string,
     value: PropTypes.string

--- a/src/graphql/createQuestionPage.graphql
+++ b/src/graphql/createQuestionPage.graphql
@@ -3,7 +3,7 @@
 mutation createQuestionPage($input: CreateQuestionPageInput!) {
   createQuestionPage(input: $input) {
     ...Page
-    plaintextTitle: title(format: Plaintext)
+    displayName
     position
     pageType
     answers {

--- a/src/graphql/createSection.graphql
+++ b/src/graphql/createSection.graphql
@@ -4,14 +4,14 @@ mutation CreateSection($input: CreateSectionInput!) {
   createSection(input: $input) {
     ...Section
     position
-    plaintextTitle: title(format: Plaintext)
+    displayName
     pages {
       id
       title
       description
       position
       ... on QuestionPage {
-        plaintextTitle: title(format: Plaintext)
+        displayName
         guidance
         pageType
         answers {

--- a/src/graphql/deleteSection.graphql
+++ b/src/graphql/deleteSection.graphql
@@ -1,6 +1,6 @@
 mutation DeleteSection($input: DeleteSectionInput!) {
   deleteSection(input: $input) {
-    id,
+    id
     questionnaire {
       questionnaireInfo {
         totalSectionCount

--- a/src/graphql/duplicatePage.graphql
+++ b/src/graphql/duplicatePage.graphql
@@ -4,15 +4,15 @@ mutation duplicatePage($input: DuplicatePageInput!) {
   duplicatePage(input: $input) {
     ...Page
     ... on QuestionPage {
-        plaintextTitle: title(format: Plaintext)
-        position
-        pageType
-        answers {
-          id
-        }
-        section {
-          id
-        }
+      displayName
+      position
+      pageType
+      answers {
+        id
+      }
+      section {
+        id
+      }
     }
   }
 }

--- a/src/graphql/fragments/question-page-destination.graphql
+++ b/src/graphql/fragments/question-page-destination.graphql
@@ -1,7 +1,7 @@
 fragment QuestionPageDestination on QuestionPage {
   ... on QuestionPage {
     id
-    plaintextTitle: title(format: Plaintext)
+    displayName
     section {
       id
     }

--- a/src/graphql/fragments/routing-condition.graphql
+++ b/src/graphql/fragments/routing-condition.graphql
@@ -7,7 +7,7 @@ fragment RoutingCondition on RoutingCondition {
   comparator
   questionPage {
     id
-    plaintextTitle: title(format: Plaintext)
+    displayName
   }
   answer {
     ...Answer

--- a/src/graphql/fragments/routing-rule-set.graphql
+++ b/src/graphql/fragments/routing-rule-set.graphql
@@ -11,7 +11,7 @@ fragment RoutingRuleSet on RoutingRuleSet {
     id
     description
     guidance
-    plaintextTitle: title(format: Plaintext)
+    displayName
   }
   else {
     ...LogicalDestination

--- a/src/graphql/fragments/section-destination.graphql
+++ b/src/graphql/fragments/section-destination.graphql
@@ -1,6 +1,6 @@
 fragment SectionDestination on Section {
   ... on Section {
     id
-    plaintextTitle: title(format: Plaintext)
+    displayName
   }
 }

--- a/src/graphql/getQuestionnaire.graphql
+++ b/src/graphql/getQuestionnaire.graphql
@@ -5,14 +5,14 @@ query GetQuestionnaire($id: ID!) {
     ...Questionnaire
     sections {
       id
-      plaintextTitle: title(format: Plaintext)
+      displayName
       position
       pages {
         id
         title
         position
         ... on QuestionPage {
-          plaintextTitle: title(format: Plaintext)
+          displayName
         }
       }
       questionnaire {

--- a/src/graphql/updateAnswer.graphql
+++ b/src/graphql/updateAnswer.graphql
@@ -3,5 +3,6 @@
 mutation UpdateAnswer($input: UpdateAnswerInput!) {
   updateAnswer(input: $input) {
     ...Answer
+    displayName
   }
 }

--- a/src/graphql/updatePage.graphql
+++ b/src/graphql/updatePage.graphql
@@ -3,6 +3,6 @@
 mutation UpdateQuestionPage($input: UpdateQuestionPageInput!) {
   updateQuestionPage(input: $input) {
     ...Page
-    plaintextTitle: title(format: Plaintext)
+    displayName
   }
 }

--- a/src/graphql/updateSection.graphql
+++ b/src/graphql/updateSection.graphql
@@ -3,6 +3,6 @@
 mutation UpdateSection($input: UpdateSectionInput!) {
   updateSection(input: $input) {
     ...Section
-    plaintextTitle: title(format: Plaintext)
+    displayName
   }
 }

--- a/src/tests/utils/actionMatching.js
+++ b/src/tests/utils/actionMatching.js
@@ -1,7 +1,7 @@
 export default function actionMatching(type, payload) {
   var action = { type };
 
-  if(arguments.length === 2) {
+  if (arguments.length === 2) {
     action.payload = payload;
   }
 

--- a/src/tests/utils/createMockQuestionnaire.js
+++ b/src/tests/utils/createMockQuestionnaire.js
@@ -4,7 +4,7 @@ export const buildPages = (sectionNumber, count) =>
   times(count, i => ({
     id: `${sectionNumber}.${i + 1}`,
     title: `Page ${sectionNumber}.${i + 1}`,
-    plaintextTitle: `Page ${sectionNumber}.${i + 1}`,
+    displayName: `Page ${sectionNumber}.${i + 1}`,
     position: i
   }));
 
@@ -12,7 +12,7 @@ export const buildSections = count =>
   times(count, i => ({
     id: `${i + 1}`,
     title: `Section ${i + 1}`,
-    plaintextTitle: `Section ${i + 1}`,
+    displayName: `Section ${i + 1}`,
     pages: buildPages(i + 1, 2),
     position: i
   }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3554,9 +3554,9 @@ enzyme@^3.3.0:
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
 
-eq-author-graphql-schema@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.26.0.tgz#7b4c6dfb735dc9aa8e8e9665a9b32ef805673beb"
+eq-author-graphql-schema@0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/eq-author-graphql-schema/-/eq-author-graphql-schema-0.27.0.tgz#333ea6a89a234421b5d987089112fa0c940e83d5"
 
 errno@^0.1.3, errno@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
### What is the context of this PR?

We have inconsistent display values scattered through the author application. In some places, we display titles, in other places we display labels and in other places we have inconsistent unnamed or untitled placeholders.

This technical improvement makes it the responsibility of the API to provide the most relevant displayable value.

More info can be found here: https://github.com/ONSdigital/eq-author/wiki/Display-names

### How to review

- Run tests

### Dependencies 

- [x] https://github.com/ONSdigital/eq-author-graphql-schema/pull/63
- [x] https://github.com/ONSdigital/eq-author-api/pull/122
