### PR TITLE
Specify node version for NVM

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/carbon


### PR DESCRIPTION
### What is the context of this PR?
Specify to use node carbon to:
1. Set netlify to use the correct node version when building
2. Set correct node version locally

### How to review 
1. Ensure that in the netlify deploy logs for this PR that it uses node 8.12.0
2. That with nvm installed correctly that when you switch into the directory that your node version switches to 8.12.0
