### PR TITLE
Fix styled component modifications failing to trigger hot reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "http-proxy-middleware": "^0.17.4",
     "husky": "^0.14.3",
     "jest": "^21.2.1",
-    "jest-styled-components": "^4.7.0",
+    "jest-styled-components": "^6.2.0",
     "jest-transform-graphql": "^2.1.0",
     "json-loader": "^0.5.7",
     "json-schema-faker": "0.4.3",
@@ -159,7 +159,7 @@
     "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.2.0",
     "serve": "^7.2.0",
-    "styled-components": "^2.2.1",
+    "styled-components": "^3.4.9",
     "synchronous-promise": "^2.0.3",
     "uncontrollable": "^4.1.0"
   },

--- a/src/components/Button/__snapshots__/index.test.js.snap
+++ b/src/components/Button/__snapshots__/index.test.js.snap
@@ -23,6 +23,7 @@ exports[`components/Button renders according to variant 1`] = `
   justify-content: center;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
@@ -91,6 +92,7 @@ exports[`components/Button renders according to variant 2`] = `
   justify-content: center;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
@@ -158,6 +160,7 @@ exports[`components/Button renders according to variant 3`] = `
   justify-content: center;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
@@ -224,6 +227,7 @@ exports[`components/Button renders according to variant 4`] = `
   justify-content: center;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;
@@ -296,6 +300,7 @@ exports[`components/Button renders as disabled 1`] = `
   justify-content: center;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: all 100ms ease-out;
   transition: all 100ms ease-out;

--- a/src/components/ContentPicker/__snapshots__/ContentPickerSingle.test.js.snap
+++ b/src/components/ContentPicker/__snapshots__/ContentPickerSingle.test.js.snap
@@ -20,8 +20,9 @@ exports[`Content Picker Single PickerWrapper should render with additional style
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
-  -ms-flex-grow: 1;
+  -ms-flex-positive: 1;
   flex-grow: 1;
 }
 

--- a/src/components/Dialog/DialogIcon/__snapshots__/DialogIcon.test.js.snap
+++ b/src/components/Dialog/DialogIcon/__snapshots__/DialogIcon.test.js.snap
@@ -2,8 +2,9 @@
 
 exports[`components/Dialog/Icon should render a delete icon 1`] = `
 .c0 {
+  -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
-  -ms-flex-grow: 0;
+  -ms-flex-positive: 0;
   flex-grow: 0;
   margin-right: 0.5em;
 }
@@ -16,8 +17,9 @@ exports[`components/Dialog/Icon should render a delete icon 1`] = `
 
 exports[`components/Dialog/Icon should render a move icon 1`] = `
 .c0 {
+  -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
-  -ms-flex-grow: 0;
+  -ms-flex-positive: 0;
   flex-grow: 0;
   margin-right: 0.5em;
 }

--- a/src/components/Menu/SubMenuItem.js
+++ b/src/components/Menu/SubMenuItem.js
@@ -41,7 +41,7 @@ const StyledSubMenuItem = styled(RMLSubMenuItem)`
   }
 `;
 
-const DisabledSubMenuItem = StyledSubMenuItem.withComponent("div").extend`
+const DisabledSubMenuItem = styled(StyledSubMenuItem.withComponent("div"))`
   cursor: default;
 
   &::after {

--- a/src/components/Tabs/__snapshots__/tabs.test.js.snap
+++ b/src/components/Tabs/__snapshots__/tabs.test.js.snap
@@ -23,6 +23,7 @@ exports[`components/Nav when no pageId should render section link 1`] = `
   border: 1px solid #5F7682;
   border-bottom: none;
   background-color: #5F7682;
+  -webkit-text-decoration: none;
   text-decoration: none;
   border-radius: 4px 4px 0 0;
   margin: 0 0.25em 0 0;
@@ -49,6 +50,7 @@ exports[`components/Nav when no pageId should render section link 1`] = `
   border: 1px solid #5F7682;
   border-bottom: none;
   background-color: #5F7682;
+  -webkit-text-decoration: none;
   text-decoration: none;
   border-radius: 4px 4px 0 0;
   margin: 0 0.25em 0 0;
@@ -165,6 +167,7 @@ exports[`components/Nav when pageId present should render page link 1`] = `
   border: 1px solid #5F7682;
   border-bottom: none;
   background-color: #5F7682;
+  -webkit-text-decoration: none;
   text-decoration: none;
   border-radius: 4px 4px 0 0;
   margin: 0 0.25em 0 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,6 +865,10 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+atob@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+
 atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
@@ -2984,6 +2988,15 @@ css@^2.2.1:
     source-map-resolve "^0.3.0"
     urix "^0.1.0"
 
+css@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -3132,6 +3145,10 @@ debug@3.1.0, debug@^3.0.0, debug@^3.0.1, debug@^3.1.0:
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
 deep-equal@^1.0.1:
   version "1.0.1"
@@ -5401,7 +5418,7 @@ is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
-is-plain-object@^2.0.1, is-plain-object@^2.0.4:
+is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   dependencies:
@@ -5853,11 +5870,11 @@ jest-specific-snapshot@^0.3.0:
   dependencies:
     jest-snapshot ">=20.0.3"
 
-jest-styled-components@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-4.7.0.tgz#8965fa0bed02f9c040052315c955da02ebdcb01f"
+jest-styled-components@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-6.2.0.tgz#a8cbb39ff21a968e11a154c60b6e8c7b284595ff"
   dependencies:
-    css "^2.2.1"
+    css "^2.2.4"
 
 jest-transform-graphql@^2.1.0:
   version "2.1.0"
@@ -8800,7 +8817,7 @@ resolve-pathname@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
 
-resolve-url@~0.2.1:
+resolve-url@^0.2.1, resolve-url@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
@@ -9164,11 +9181,25 @@ source-map-resolve@^0.3.0:
     source-map-url "~0.3.0"
     urix "~0.1.0"
 
+source-map-resolve@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+  dependencies:
+    atob "^2.1.1"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
 source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:
     source-map "^0.5.6"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
 source-map-url@~0.3.0:
   version "0.3.0"
@@ -9427,18 +9458,18 @@ styled-components-test-utils@^0.3.0:
     css "^2.2.1"
     css-mediaquery "0.1.2"
 
-styled-components@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.2.1.tgz#f4835f1001c37bcc301ac3865b5d93466de4dd5b"
+styled-components@^3.4.9:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.9.tgz#519abeb351b37be5b7de6a15ff9e4efeb9d772da"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"
-    fbjs "^0.8.9"
-    hoist-non-react-statics "^1.2.0"
-    is-function "^1.0.1"
-    is-plain-object "^2.0.1"
+    fbjs "^0.8.16"
+    hoist-non-react-statics "^2.5.0"
     prop-types "^15.5.4"
-    stylis "^3.2.1"
+    react-is "^16.3.1"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
     supports-color "^3.2.3"
 
 stylelint-config-recommended@^1.0.0:
@@ -9505,9 +9536,17 @@ stylelint@^8.2.0:
     svg-tags "^1.0.0"
     table "^4.0.1"
 
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+
 stylis@^3.2.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.3.2.tgz#95ef285836e98243f8b8f64a9a72706ea6c893ea"
+
+stylis@^3.5.0:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.3.tgz#99fdc46afba6af4deff570825994181a5e6ce546"
 
 sugarss@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### What is the context of this PR?
- Hot reloading has stopped working when editing styled components
- Upgraded `styled-components` package to fix this
- Upgraded `jest-styled-components` package to support `styled-components` upgrade
- Fixed a warning relating to `.extend` being deprecated in upcoming `styled-components` v4 release

### How to review 
- Run tests
- Ensure styles are the same
- Ensure you can edit a styled component and it triggers a reload