### PR TITLE
Removed problematic metadata keys from the type ahead

### DIFF
--- a/cypress/integration/authenticated/metadata_spec.js
+++ b/cypress/integration/authenticated/metadata_spec.js
@@ -29,7 +29,7 @@ describe("Metadata", () => {
     });
     describe("Update", () => {
       it("Should allow key value to be updated with custom value", () => {
-        const input = "tx_id_custom";
+        const input = "ru_ref_custom";
         cy.get(testId("metadata-table-row")).within(() =>
           cy.get("[name='key']").as("metadataKey")
         );
@@ -37,7 +37,7 @@ describe("Metadata", () => {
         cy.get("@metadataKey").should("have.value", input);
       });
       it("Should allow key value to be updated from select list", () => {
-        const select = "eq_id";
+        const select = "ru_name";
         cy.get(testId("metadata-table-row")).within(() =>
           cy.get("[name='key']").as("metadataKey")
         );
@@ -46,7 +46,7 @@ describe("Metadata", () => {
         cy.get("@metadataKey").should("have.value", select);
       });
       it("Should allow alias value to be updated", () => {
-        const input = "tx_id_alias";
+        const input = "ru_ref_alias";
         cy.get(testId("metadata-table-row")).within(() =>
           cy.get("[name='alias']").as("metadataAlias")
         );

--- a/src/components/MetadataTable/Controls/KeySelect.js
+++ b/src/components/MetadataTable/Controls/KeySelect.js
@@ -10,23 +10,12 @@ import {
 } from "components/DataTable/Controls";
 
 export const suggestedKeys = [
-  { value: "tx_id" },
-  { value: "iat" },
-  { value: "exp" },
-  { value: "eq_id" },
-  { value: "collection_exercise_sid" },
-  { value: "form_type" },
   { value: "ru_ref" },
   { value: "ru_name" },
   { value: "trad_as" },
-  { value: "user_id" },
   { value: "period_id" },
-  { value: "case_id" },
-  { value: "account_service_url" },
   { value: "period_str" },
   { value: "language_code" },
-  { value: "survey_url" },
-  { value: "case_ref" },
   { value: "ref_p_start_date" },
   { value: "ref_p_end_date" },
   { value: "return_by" },


### PR DESCRIPTION
### What is the context of this PR?
The type-ahead in the metadata table is currently allowing users to set keys like exp which is used in the generation of the JWT meaning that users could get in a very broken state where the JWT could expire before it could be used.

### How to review 
Tests should continue to pass and users should no longer see the problematic keys in the typeahead.