### PR TITLE
Switched min/max values to use ints instead

### DIFF
--- a/src/components/Validation/MaxValue.js
+++ b/src/components/Validation/MaxValue.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import { withApollo } from "react-apollo";
 import { propType } from "graphql-anywhere";
 
-import { flowRight, inRange } from "lodash";
+import { flowRight, inRange, isNaN } from "lodash";
 
 import { colors } from "constants/theme";
 import { Grid, Column } from "components/Grid";
@@ -56,11 +56,13 @@ export const MaxValue = ({
       return false;
     }
 
+    const intValue = parseInt(value, 10);
+
     const updateValidationRuleInput = {
       id: maxValue.id,
       maxValueInput: {
         inclusive: maxValue.inclusive,
-        custom: value === "" ? null : value
+        custom: isNaN(intValue) ? null : intValue
       }
     };
 

--- a/src/components/Validation/MaxValue.test.js
+++ b/src/components/Validation/MaxValue.test.js
@@ -80,6 +80,21 @@ describe("MaxValue", () => {
     });
   });
 
+  it("should correctly coerce string inputs to integers", () => {
+    const wrapper = createWrapper(props);
+    wrapper
+      .find(byTestAttr("max-value-input"))
+      .simulate("change", { value: "1" });
+
+    expect(onUpdateAnswerValidation).toHaveBeenCalledWith({
+      id: props.maxValue.id,
+      maxValueInput: {
+        inclusive: props.maxValue.inclusive,
+        custom: 1
+      }
+    });
+  });
+
   it("should correctly handle max value change with out of range values", () => {
     const wrapper = createWrapper(props);
 

--- a/src/components/Validation/MinValue.js
+++ b/src/components/Validation/MinValue.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import { withApollo } from "react-apollo";
 import { propType } from "graphql-anywhere";
 
-import { flowRight, inRange } from "lodash";
+import { flowRight, inRange, isNaN } from "lodash";
 
 import { colors } from "constants/theme";
 import { Grid, Column } from "components/Grid";
@@ -56,11 +56,13 @@ export const MinValue = ({
       return false;
     }
 
+    const intValue = parseInt(value, 10);
+
     const updateValidationRuleInput = {
       id: minValue.id,
       minValueInput: {
         inclusive: minValue.inclusive,
-        custom: value === "" ? null : value
+        custom: isNaN(intValue) ? null : intValue
       }
     };
 

--- a/src/components/Validation/MinValue.test.js
+++ b/src/components/Validation/MinValue.test.js
@@ -54,7 +54,7 @@ describe("MinValue", () => {
     const wrapper = createWrapper(props);
     wrapper
       .find(byTestAttr("min-value-input"))
-      .simulate("change", { value: 1 });
+      .simulate("change", { value: "1" });
 
     expect(onUpdateAnswerValidation).toHaveBeenCalledWith({
       id: props.minValue.id,
@@ -76,6 +76,21 @@ describe("MinValue", () => {
       minValueInput: {
         inclusive: props.minValue.inclusive,
         custom: null
+      }
+    });
+  });
+
+  it("should correctly coerce string inputs to integers", () => {
+    const wrapper = createWrapper(props);
+    wrapper
+      .find(byTestAttr("min-value-input"))
+      .simulate("change", { value: "1" });
+
+    expect(onUpdateAnswerValidation).toHaveBeenCalledWith({
+      id: props.minValue.id,
+      minValueInput: {
+        inclusive: props.minValue.inclusive,
+        custom: 1
       }
     });
   });


### PR DESCRIPTION
### What is the context of this PR?
After graphql was updated to to the latest version a bug was introduced where the api no-longer coerced string int values into actual in values and instead it threw an error. This PR changes that so it now imports int values instead.

### How to review 
Tests pass and min and max values can be changed.
