### PR TITLE
Prevent noisy logging during cypress tests

### DIFF
--- a/scripts/run_e2e_tests_author.sh
+++ b/scripts/run_e2e_tests_author.sh
@@ -43,7 +43,7 @@ trap finish INT KILL TERM EXIT
 # start API/DB, and wait until running
 docker-compose -f ./scripts/e2e.yml down --rmi all
 docker-compose -f ./scripts/e2e.yml pull
-docker-compose -f ./scripts/e2e.yml up &
+docker-compose -f ./scripts/e2e.yml up -d
 ./node_modules/.bin/wait-on http-get://localhost:4000/status
 
 # Run the tests


### PR DESCRIPTION
### What is the context of this PR?
A recent change has led to noisy log output when running the cypress tests.
This PR reverts the specific change and runs the API docker containers in detached mode during the Cypress tests.

### How to review 
Observe travis log output to ensure that API HTTP logs are not displayed.
