### PR TITLE
Lint errors should not block server from running

### DIFF
--- a/config/webpack.config.common.js
+++ b/config/webpack.config.common.js
@@ -2,7 +2,6 @@
 "use strict";
 
 const path = require("path");
-const eslintFormatter = require("react-dev-utils/eslintFormatter");
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
 const paths = require("./paths");
 
@@ -36,26 +35,6 @@ module.exports.resolve = {
 };
 
 module.exports.loaders = {
-  eslint: {
-    // TODO: Disable require.ensure as it's not a standard language feature.
-    // We are waiting for https://github.com/facebookincubator/create-react-app/issues/2176.
-    // { parser: { requireEnsure: false } },
-
-    // First, run the linter.
-    // It's important to do this before Babel processes the JS.
-    test: /\.(js|jsx)$/,
-    enforce: "pre",
-    use: [
-      {
-        options: {
-          formatter: eslintFormatter
-        },
-        loader: require.resolve("eslint-loader")
-      }
-    ],
-    include: paths.appSrc
-  },
-
   fileExclusions: {
     // ** ADDING/UPDATING LOADERS **
     // The "file" loader handles all assets unless explicitly excluded.

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -80,7 +80,6 @@ module.exports = {
   module: {
     strictExportPresence: true,
     rules: [
-      loaders.eslint,
       loaders.fileExclusions,
       loaders.url,
       {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -76,7 +76,6 @@ module.exports = {
       // TODO: Disable require.ensure as it's not a standard language feature.
       // We are waiting for https://github.com/facebookincubator/create-react-app/issues/2176.
       // { parser: { requireEnsure: false } },
-      loaders.eslint,
       loaders.fileExclusions,
       loaders.url,
       {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "storybook-build": "export NODE_PATH=src/ && build-storybook -s public -o storybook-static",
     "storybook-deploy": "yarn storybook-build && gh-pages -d .out",
     "precommit": "lint-staged",
+    "prepush": "yarn lint",
     "coverage": "yarn test -- --coverage",
     "cypress:open": "CYPRESS_baseUrl=${CYPRESS_baseUrl:=http://localhost:3000/} cypress open"
   },


### PR DESCRIPTION
### What is the context of this PR?
1. Build errors are the only thing that should stop a build from starting/updating
1. We now check linting on push (and people should have it set up in their editors)
1. We can now treat all linting warnings as errors by making it so in the config.

### How to review 
1. Ensure you can make changes that cause linting errors (e.g. unused variables) but you can still run the app.
1. Make a commit with a linting error in and it should fail to push.
