### PR TITLE
Tech debt stop ui repeatedly building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,7 @@ Dockerfile
 .github
 .storybook
 tests
+cypress
+coverage
 
 node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,31 @@
-FROM node:8
-MAINTAINER eq.team@ons.gov.uk
+FROM node:8-alpine as build
 
-EXPOSE 3000
 WORKDIR /app
 
 ARG APPLICATION_VERSION
 ENV EQ_AUTHOR_VERSION $APPLICATION_VERSION
 
-ENTRYPOINT ["sh", "docker-entrypoint.sh"]
-
 # Install
-COPY . /app
-RUN yarn install
+COPY package.json yarn.lock /app/
+RUN yarn install --frozen-lockfile
+
+# Copy build dependencies
+COPY src /app/src
+COPY config /app/config
+COPY public /app/public
+COPY scripts /app/scripts
+COPY .babelrc .eslintrc.js .env .env.production /app/
+
+RUN yarn build
+
+FROM nginx:stable
+
+EXPOSE 3000
+
+COPY nginx /etc/nginx/
+# Log to stdout/stderr
+RUN mkdir -p /etc/nginx/logs && ln -sf /dev/stdout /etc/nginx/logs/access.log && ln -sf /dev/stderr /etc/nginx/logs/error.log
+COPY --from=build /app/build /etc/nginx/html/
+RUN cp /etc/nginx/html/index.html /etc/nginx/html/index.html.tmpl
+
+CMD ["/etc/nginx/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Spins up the Storybook development server.
 | `REACT_APP_FIREBASE_PROJECT_ID` | Firebase is used for basic authentication this environment and the two below are needed for this. The project ID for your Firebase project. Can be obtained from your Firebase project | Yes If authentication is enabled |
 | `REACT_APP_FIREBASE_API_KEY` | The api key for your Firebase project. Can be obtained from your Firebase project | Yes If authentication is enabled |
 | `REACT_APP_FIREBASE_MESSAGING_SENDER_ID` | The messaging sender ID for your Firebase project. Can be obtained from your Firebase project | Yes If authentication is enabled |
-| `REACT_APP_ENABLE_AUTH` | Used to enable and disable firebase authentication. User can sign in as guest if this is set to false | Yes |
+| `REACT_APP_ENABLE_AUTH` | Used to enable and disable firebase authentication. User can sign in as guest if this is set to false. This is always enabled in the docker images. | Yes |
 
 ### Functional
 | Name | Description | Required |
@@ -177,6 +177,14 @@ Note: CLI env vars taken precedence over `.env.development.local` vars. For more
 ### Enabling / disabling authentication
 
 Firebase authentication can be disabled by setting the env var `REACT_APP_ENABLE_AUTH=false`. Disabling firebase authentication allows users to login as a guest.
+
+### Environment variable in different environments
+
+There are two ways we use environment variables in the application:
+1. Build time environment variables. These are values that are known at build time and cannot be changed once the docker image is built. Currently these are only `NODE_ENV` and `REACT_APP_AUTH_ENABLED`. These are referenced in the code as `process.env.{key}`
+1. Runtime configurable variables. These are values that can change for each place we run the app for example in staging we want the API url to be different to production. In the code these values are read using the config object for example `config.{key}`. 
+    - Dev - Values are read from the environment.
+    - Docker - Values are read from `window.config` (as defined in `index.html`) and then `process.env`. `index.html` is rewritten in docker to read the available environment variables and pass them to the application every time the docker image starts.
 
 ## Testing
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-yarn build
-yarn serve

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Replace the window variables with desired runtime properties
+/etc/nginx/replace_env_vars.sh /etc/nginx/html/index.html.tmpl /etc/nginx/html/index.html
+
+exec nginx -g "daemon off;"

--- a/nginx/mime.types
+++ b/nginx/mime.types
@@ -1,0 +1,139 @@
+# Originally from https://github.com/h5bp/server-configs-nginx/blob/master/mime.types
+types {
+
+  # Data interchange
+
+    application/atom+xml                  atom;
+    application/json                      json map topojson;
+    application/ld+json                   jsonld;
+    application/rss+xml                   rss;
+    application/vnd.geo+json              geojson;
+    application/xml                       rdf xml;
+
+
+  # JavaScript
+
+    # Normalize to standard type.
+    # https://tools.ietf.org/html/rfc4329#section-7.2
+    application/javascript                js;
+
+
+  # Manifest files
+
+    application/manifest+json             webmanifest;
+    application/x-web-app-manifest+json   webapp;
+    text/cache-manifest                   appcache;
+
+
+  # Media files
+
+    audio/midi                            mid midi kar;
+    audio/mp4                             aac f4a f4b m4a;
+    audio/mpeg                            mp3;
+    audio/ogg                             oga ogg opus;
+    audio/x-realaudio                     ra;
+    audio/x-wav                           wav;
+    image/bmp                             bmp;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    image/jxr                             jxr hdp wdp;
+    image/png                             png;
+    image/svg+xml                         svg svgz;
+    image/tiff                            tif tiff;
+    image/vnd.wap.wbmp                    wbmp;
+    image/webp                            webp;
+    image/x-jng                           jng;
+    video/3gpp                            3gp 3gpp;
+    video/mp4                             f4p f4v m4v mp4;
+    video/mpeg                            mpeg mpg;
+    video/ogg                             ogv;
+    video/quicktime                       mov;
+    video/webm                            webm;
+    video/x-flv                           flv;
+    video/x-mng                           mng;
+    video/x-ms-asf                        asf asx;
+    video/x-ms-wmv                        wmv;
+    video/x-msvideo                       avi;
+
+    # Serving `.ico` image files with a different media type
+    # prevents Internet Explorer from displaying then as images:
+    # https://github.com/h5bp/html5-boilerplate/commit/37b5fec090d00f38de64b591bcddcb205aadf8ee
+
+    image/x-icon                          cur ico;
+
+
+  # Microsoft Office
+
+    application/msword                                                         doc;
+    application/vnd.ms-excel                                                   xls;
+    application/vnd.ms-powerpoint                                              ppt;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx;
+
+
+  # Web fonts
+
+    application/font-woff                 woff;
+    application/font-woff2                woff2;
+    application/vnd.ms-fontobject         eot;
+
+    # Browsers usually ignore the font media types and simply sniff
+    # the bytes to figure out the font type.
+    # https://mimesniff.spec.whatwg.org/#matching-a-font-type-pattern
+    #
+    # However, Blink and WebKit based browsers will show a warning
+    # in the console if the following font types are served with any
+    # other media types.
+
+    application/x-font-ttf                ttc ttf;
+    font/opentype                         otf;
+
+
+  # Other
+
+    application/java-archive              ear jar war;
+    application/mac-binhex40              hqx;
+    application/octet-stream              bin deb dll dmg exe img iso msi msm msp safariextz;
+    application/pdf                       pdf;
+    application/postscript                ai eps ps;
+    application/rtf                       rtf;
+    application/vnd.google-earth.kml+xml  kml;
+    application/vnd.google-earth.kmz      kmz;
+    application/vnd.wap.wmlc              wmlc;
+    application/x-7z-compressed           7z;
+    application/x-bb-appworld             bbaw;
+    application/x-bittorrent              torrent;
+    application/x-chrome-extension        crx;
+    application/x-cocoa                   cco;
+    application/x-java-archive-diff       jardiff;
+    application/x-java-jnlp-file          jnlp;
+    application/x-makeself                run;
+    application/x-opera-extension         oex;
+    application/x-perl                    pl pm;
+    application/x-pilot                   pdb prc;
+    application/x-rar-compressed          rar;
+    application/x-redhat-package-manager  rpm;
+    application/x-sea                     sea;
+    application/x-shockwave-flash         swf;
+    application/x-stuffit                 sit;
+    application/x-tcl                     tcl tk;
+    application/x-x509-ca-cert            crt der pem;
+    application/x-xpinstall               xpi;
+    application/xhtml+xml                 xhtml;
+    application/xslt+xml                  xsl;
+    application/zip                       zip;
+    text/css                              css;
+    text/csv                              csv;
+    text/html                             htm html shtml;
+    text/markdown                         md;
+    text/mathml                           mml;
+    text/plain                            txt;
+    text/vcard                            vcard vcf;
+    text/vnd.rim.location.xloc            xloc;
+    text/vnd.sun.j2me.app-descriptor      jad;
+    text/vnd.wap.wml                      wml;
+    text/vtt                              vtt;
+    text/x-component                      htc;
+
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,154 @@
+# Originally from https://github.com/h5bp/server-configs-nginx/blob/master/nginx.conf
+# Configuration File - Nginx Server Configs
+# http://nginx.org/en/docs/dirindex.html
+
+# Sets the worker threads to the number of CPU cores available in the system for best performance.
+# Should be > the number of CPU cores.
+# Maximum number of connections = worker_processes * worker_connections
+# Default: 1
+worker_processes auto;
+
+# Maximum number of open files per worker process.
+# Should be > worker_connections.
+# Default: no limit
+worker_rlimit_nofile 8192;
+
+events {
+  # If you need more connections than this, you start optimizing your OS.
+  # That's probably the point at which you hire people who are smarter than you as this is *a lot* of requests.
+  # Should be < worker_rlimit_nofile.
+  # Default: 512
+  worker_connections 8000;
+}
+
+# Log errors and warnings to this file
+# This is only used when you don't override it on a server{} level
+# Default: logs/error.log error
+error_log  logs/error.log warn;
+
+# The file storing the process ID of the main process
+# Default: nginx.pid
+pid        /var/run/nginx.pid;
+
+http {
+
+  # Hide nginx version information.
+  # Default: on
+  server_tokens off;
+
+  # Specify MIME types for files.
+  include       mime.types;
+
+  # Default: text/plain
+  default_type  application/octet-stream;
+
+  # Update charset_types to match updated mime.types.
+  # text/html is always included by charset module.
+  # Default: text/html text/xml text/plain text/vnd.wap.wml application/javascript application/rss+xml
+  charset_types
+    text/css
+    text/plain
+    text/vnd.wap.wml
+    application/javascript
+    application/json
+    application/rss+xml
+    application/xml;
+
+  # Include $http_x_forwarded_for within default format used in log files
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+  # Log access to this file
+  # This is only used when you don't override it on a server{} level
+  # Default: logs/access.log combined
+  access_log logs/access.log main;
+
+  # How long to allow each connection to stay idle.
+  # Longer values are better for each individual client, particularly for SSL,
+  # but means that worker connections are tied up longer.
+  # Default: 75s
+  keepalive_timeout 20s;
+
+  # Speed up file transfers by using sendfile() to copy directly
+  # between descriptors rather than using read()/write().
+  # For performance reasons, on FreeBSD systems w/ ZFS
+  # this option should be disabled as ZFS's ARC caches
+  # frequently used files in RAM by default.
+  # Default: off
+  sendfile        on;
+
+  # Don't send out partial frames; this increases throughput
+  # since TCP frames are filled up before being sent out.
+  # Default: off
+  tcp_nopush      on;
+
+  # Enable gzip compression.
+  # Default: off
+  gzip on;
+
+  # Compression level (1-9).
+  # 5 is a perfect compromise between size and CPU usage, offering about
+  # 75% reduction for most ASCII files (almost identical to level 9).
+  # Default: 1
+  gzip_comp_level    5;
+
+  # Don't compress anything that's already small and unlikely to shrink much
+  # if at all (the default is 20 bytes, which is bad as that usually leads to
+  # larger files after gzipping).
+  # Default: 20
+  gzip_min_length    256;
+
+  # Compress data even for clients that are connecting to us via proxies,
+  # identified by the "Via" header (required for CloudFront).
+  # Default: off
+  gzip_proxied       any;
+
+  # Tell proxies to cache both the gzipped and regular version of a resource
+  # whenever the client's Accept-Encoding capabilities header varies;
+  # Avoids the issue where a non-gzip capable client (which is extremely rare
+  # today) would display gibberish if their proxy gave them the gzipped version.
+  # Default: off
+  gzip_vary          on;
+
+  # Compress all output labeled with one of the following MIME-types.
+  # text/html is always compressed by gzip module.
+  # Default: text/html
+  gzip_types
+    application/atom+xml
+    application/javascript
+    application/json
+    application/ld+json
+    application/manifest+json
+    application/rss+xml
+    application/vnd.geo+json
+    application/vnd.ms-fontobject
+    application/x-font-ttf
+    application/x-web-app-manifest+json
+    application/xhtml+xml
+    application/xml
+    font/opentype
+    image/bmp
+    image/svg+xml
+    image/x-icon
+    text/cache-manifest
+    text/css
+    text/plain
+    text/vcard
+    text/vnd.rim.location.xloc
+    text/vtt
+    text/x-component
+    text/x-cross-domain-policy;
+
+  # This should be turned on if you are going to have pre-compressed copies (.gz) of
+  # static files available. If not it should be left off as it will cause extra I/O
+  # for the check. It is best if you enable this in a location{} block for
+  # a specific directory, or on an individual server{} level.
+  # gzip_static on;
+
+  # Include files in the sites-enabled folder. server{} configuration files should be
+  # placed in the sites-available folder, and then the configuration should be enabled
+  # by creating a symlink to it in the sites-enabled folder.
+  # See doc/sites-enabled.md for more info.
+  include sites-enabled/*;
+}

--- a/nginx/replace_env_vars.sh
+++ b/nginx/replace_env_vars.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euf
+
+read_file="$1"
+write_file="$2"
+echo "Replacing window variables in $read_file into $write_file"
+
+cp "$read_file" "$write_file"
+
+# Find all REACT_APP variables in environment
+variables=$(export | grep 'declare -x REACT_APP_' | sed 's/declare -x //')
+
+for env in $variables; do
+    key=$(cut -d'=' -f1 <<<"$env");
+    escape_regex="s/\//\\\\\//g"
+    value=$(echo "${!key}" | sed -e "$escape_regex")
+    window_replacement="s/window.config.$key=\"\"/window.config.$key=\"$value\"/g"
+    echo "Setting: $key to ${!key}"
+    sed -i.bak -e "$window_replacement" "$write_file"
+done
+
+echo "All done!";

--- a/nginx/sites-enabled/eq-author
+++ b/nginx/sites-enabled/eq-author
@@ -1,0 +1,10 @@
+server {
+  listen 3000;
+  server_name eq-author;
+  root /etc/nginx/html;
+  index index.html;
+  
+  location / {
+    try_files $uri /index.html =404;
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -45,6 +45,20 @@
       })(window,document,window['_fs_namespace'],'script','user');
     }
   </script>
+  <script type="text/javascript">
+    window.config = {};
+    window.config.REACT_APP_API_URL="";
+    window.config.REACT_APP_BASE_NAME="";
+    window.config.REACT_APP_FIREBASE_API_KEY="";
+    window.config.REACT_APP_FIREBASE_MESSAGING_SENDER_ID="";
+    window.config.REACT_APP_FIREBASE_PROJECT_ID="";
+    window.config.REACT_APP_FUNCTIONAL_TEST="";
+    window.config.REACT_APP_GO_LAUNCH_A_SURVEY_URL="";
+    window.config.REACT_APP_LAUNCH_URL="";
+    window.config.REACT_APP_PUBLISHER_URL="";
+    window.config.REACT_APP_USE_FULLSTORY="";
+    window.config.REACT_APP_USE_SENTRY="";
+  </script>
   <body>
     <div id="root"></div>
     <div id="toast"></div>

--- a/scripts/test_docker-compose.yml
+++ b/scripts/test_docker-compose.yml
@@ -12,7 +12,7 @@ services:
   eq-author:
     image: "onsdigital/eq-author:${TRAVIS_BUILD_NUMBER:-latest}"
     environment:
-      REACT_APP_BASE_NAME: ""
+      REACT_APP_BASE_NAME: "/"
       REACT_APP_API_URL: http://localhost:14000/graphql
       REACT_APP_USE_MOCK_API: "false"
       REACT_APP_PUBLISHER_URL: http://eq-publisher:9000/publish

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -1,10 +1,11 @@
 import firebase from "firebase/app";
 import "firebase/auth";
 import firebaseui from "firebaseui";
+import config from "config";
 
-const PROJECT_ID = process.env.REACT_APP_FIREBASE_PROJECT_ID;
-const API_KEY = process.env.REACT_APP_FIREBASE_API_KEY;
-const MESSAGING_SENDER_ID = process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID;
+const PROJECT_ID = config.REACT_APP_FIREBASE_PROJECT_ID;
+const API_KEY = config.REACT_APP_FIREBASE_API_KEY;
+const MESSAGING_SENDER_ID = config.REACT_APP_FIREBASE_MESSAGING_SENDER_ID;
 
 firebase.initializeApp({
   apiKey: API_KEY,

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -1,19 +1,21 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { UnconnectedHeader, StyledUserProfile } from "components/Header";
 
 describe("components/Header", () => {
-  let env;
   let now;
   let handleSignOut;
   let raiseToast;
+  let UnconnectedHeader;
+  let StyledUserProfile;
 
   beforeEach(() => {
-    env = process.env;
-    process.env = {
+    jest.mock("config", () => ({
       REACT_APP_PUBLISHER_URL: "http://eq-publisher/publish",
       REACT_APP_GO_LAUNCH_A_SURVEY_URL: "http://go-launch-a-survey/quick-launch"
-    };
+    }));
+    const Header = require("components/Header");
+    UnconnectedHeader = Header.UnconnectedHeader;
+    StyledUserProfile = Header.StyledUserProfile;
 
     now = Date.now;
     Date.now = () => 1507793425522;
@@ -33,7 +35,6 @@ describe("components/Header", () => {
     );
 
   afterEach(() => {
-    process.env = env;
     Date.now = now;
   });
 

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 import styled from "styled-components";
 import { colors } from "constants/theme";
+import config from "config";
 
 import { raiseToast } from "redux/toast/actions";
 
@@ -97,17 +98,17 @@ export class UnconnectedHeader extends React.Component {
   };
 
   getPreviewUrl(questionnaireId) {
-    if (process.env.REACT_APP_GO_LAUNCH_A_SURVEY_URL) {
+    if (config.REACT_APP_GO_LAUNCH_A_SURVEY_URL) {
       const timestamp = Date.now();
-      const publisherUrl = process.env.REACT_APP_PUBLISHER_URL;
+      const publisherUrl = config.REACT_APP_PUBLISHER_URL;
       const goLaunchASurveyQuickLaunchUrl =
-        process.env.REACT_APP_GO_LAUNCH_A_SURVEY_URL;
+        config.REACT_APP_GO_LAUNCH_A_SURVEY_URL;
       const urlEncodedParam = encodeURIComponent(
         `${publisherUrl}/${questionnaireId}?r=${timestamp}`
       );
       return `${goLaunchASurveyQuickLaunchUrl}?url=${urlEncodedParam}`;
     } else {
-      return `${process.env.REACT_APP_LAUNCH_URL}/${questionnaireId}`;
+      return `${config.REACT_APP_LAUNCH_URL}/${questionnaireId}`;
     }
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,34 @@
+window.config = window.config || {};
+const config = {
+  REACT_APP_API_URL:
+    window.config.REACT_APP_API_URL || process.env.REACT_APP_API_URL,
+  REACT_APP_BASE_NAME:
+    window.config.REACT_APP_BASE_NAME || process.env.REACT_APP_BASE_NAME,
+  REACT_APP_FIREBASE_API_KEY:
+    window.config.REACT_APP_FIREBASE_API_KEY ||
+    process.env.REACT_APP_FIREBASE_API_KEY,
+  REACT_APP_FIREBASE_MESSAGING_SENDER_ID:
+    window.config.REACT_APP_FIREBASE_MESSAGING_SENDER_ID ||
+    process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  REACT_APP_FIREBASE_PROJECT_ID:
+    window.config.REACT_APP_FIREBASE_PROJECT_ID ||
+    process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  REACT_APP_FUNCTIONAL_TEST:
+    window.config.REACT_APP_FUNCTIONAL_TEST ||
+    process.env.REACT_APP_FUNCTIONAL_TEST,
+  REACT_APP_GO_LAUNCH_A_SURVEY_URL:
+    window.config.REACT_APP_GO_LAUNCH_A_SURVEY_URL ||
+    process.env.REACT_APP_GO_LAUNCH_A_SURVEY_URL,
+  REACT_APP_LAUNCH_URL:
+    window.config.REACT_APP_LAUNCH_URL || process.env.REACT_APP_LAUNCH_URL,
+  REACT_APP_PUBLISHER_URL:
+    window.config.REACT_APP_PUBLISHER_URL ||
+    process.env.REACT_APP_PUBLISHER_URL,
+  REACT_APP_USE_FULLSTORY:
+    window.config.REACT_APP_USE_FULLSTORY ||
+    process.env.REACT_APP_USE_FULLSTORY,
+  REACT_APP_USE_SENTRY:
+    window.config.REACT_APP_USE_SENTRY || process.env.REACT_APP_USE_SENTRY
+};
+
+export default config;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,6 @@
-import render from "utils/render";
 import createHistory from "history/createHashHistory";
 import configureStore from "redux/configureStore";
-import App from "containers/App";
 import Raven from "raven-js";
-import getIdForObject from "utils/getIdForObject";
 import fragmentMatcher from "apollo/fragmentMatcher";
 import createApolloClient from "apollo/createApolloClient";
 import createApolloCache from "apollo/createApolloCache";
@@ -11,7 +8,12 @@ import createHttpLink from "apollo/createHttpLink";
 import createErrorLink from "apollo/createApolloErrorLink";
 import { ApolloLink } from "apollo-link";
 
-if (process.env.REACT_APP_USE_SENTRY === "true") {
+import config from "config";
+import App from "containers/App";
+import getIdForObject from "utils/getIdForObject";
+import render from "utils/render";
+
+if (config.REACT_APP_USE_SENTRY === "true") {
   Raven.config(
     "https://b72ac0e6b36344fca4698290bf9a191d@sentry.io/233989"
   ).install();
@@ -38,19 +40,19 @@ const cache = createApolloCache({
 });
 
 const history = createHistory({
-  basename: process.env.REACT_APP_BASE_NAME
+  basename: config.REACT_APP_BASE_NAME
 });
 
 const link = ApolloLink.from([
   createErrorLink(getStore),
-  createHttpLink(process.env.REACT_APP_API_URL)
+  createHttpLink(config.REACT_APP_API_URL)
 ]);
 
 const client = createApolloClient(link, cache);
 
 store = configureStore(history, client);
 
-if (window.Cypress && process.env.REACT_APP_FUNCTIONAL_TEST === "true") {
+if (window.Cypress && config.REACT_APP_FUNCTIONAL_TEST === "true") {
   window.__store__ = store;
 }
 

--- a/src/redux/auth/actions.js
+++ b/src/redux/auth/actions.js
@@ -1,9 +1,11 @@
+import config from "config";
+
 export const SIGN_IN_USER = "SIGN_IN_USER";
 export const SIGN_OUT_USER = "SIGN_OUT_USER";
 export const SIGN_IN_ERROR = "SIGN_IN_ERROR";
 
 export const signInUser = ({ displayName, email, photoURL }) => {
-  if (process.env.REACT_APP_USE_FULLSTORY === "true") {
+  if (config.REACT_APP_USE_FULLSTORY === "true") {
     window.FS.identify(email, { displayName });
   }
 
@@ -24,7 +26,7 @@ export const signedOutUser = () => {
 };
 
 export const signOutUser = () => (dispatch, getState, { auth }) => {
-  if (process.env.REACT_APP_USE_FULLSTORY === "true") {
+  if (config.REACT_APP_USE_FULLSTORY === "true") {
     window.FS.identify(false);
   }
 


### PR DESCRIPTION
### What is the context of this PR?
Change the way we build the UI docker image so that:
1. It does not build every time you run it (to be updated for the new environment variables)
1. Make the image significantly smaller as it just contains the build output and the nginx configuration.
1. Runtime environment variables passed to docker are still applied. 
1. Only `NODE_ENV` and `REACT_APP_ENABLE_AUTH` are determined when the docker image is built. Both are either hardcoded or picked up automatically as part of the `.env.production`.
1. Image size now: 124MB from 1.77GB
1. Image start time 2-3 seconds from >80 seconds

### How to review 
1. Ensure you can build and run the built image locally. 

### Dependencies
- [x] - #451 