### PR TITLE
Bug - Storybook upgrade broke with our webpack config

### DIFF
--- a/config/webpack.config.common.js
+++ b/config/webpack.config.common.js
@@ -77,7 +77,8 @@ module.exports.loaders = {
       /\.gif$/,
       /\.jpe?g$/,
       /\.png$/,
-      /\.(graphql|gql)$/
+      /\.(graphql|gql)$/,
+      /\.ejs$/
     ],
     loader: require.resolve("file-loader"),
     options: {


### PR DESCRIPTION
### What is the context of this PR?
As part of an unintentional bump of the storybook version in
e8f9c1dfc6c143c834d11bf68d8070cb3597b68e (#452) it would no longer run
correctly.

The issue was already reported and relates to our webpack config
derived from CRA. https://github.com/storybooks/storybook/issues/2615

### How to review 
1. Upgrade your modules by running `rm -rf node_modules && yarn --frozen-lockfile`
1. Ensure you can run storybook locally
