### PR TITLE
Bug - Unable to update date validation

### DIFF
--- a/src/components/Validation/Date/builder.js
+++ b/src/components/Validation/Date/builder.js
@@ -1,4 +1,4 @@
-import { flowRight } from "lodash/fp";
+import { flowRight, omit } from "lodash/fp";
 
 import withToggleAnswerValidation from "containers/enhancers/withToggleAnswerValidation";
 import withUpdateAnswerValidation from "containers/enhancers/withUpdateAnswerValidation";
@@ -16,7 +16,7 @@ export const readToWriteMapper = outputKey => ({
 }) => ({
   id,
   [outputKey]: {
-    ...rest,
+    ...omit("enabled", rest),
     custom: customDate ? customDate : null
   }
 });

--- a/src/components/Validation/Date/builder.test.js
+++ b/src/components/Validation/Date/builder.test.js
@@ -12,9 +12,10 @@ describe("Date validation builder", () => {
             unit: "Months",
             value: 1
           },
-          relativePosition: "Before"
+          relativePosition: "Before",
+          enabled: true
         })
-      ).toMatchObject({
+      ).toEqual({
         id: 1,
         earliestDateInput: {
           custom: "12/05/1987",
@@ -37,9 +38,10 @@ describe("Date validation builder", () => {
             unit: "Months",
             value: 1
           },
-          relativePosition: "Before"
+          relativePosition: "Before",
+          enabled: true
         })
-      ).toMatchObject({
+      ).toEqual({
         id: 1,
         latestDateInput: {
           custom: null,


### PR DESCRIPTION
### What is the context of this PR?
The lint rule of no unused vars caused the way this was working to be
removed (e8f9c1d) and the tests were not explicitly testing this usecase.

### How to review 
1. Ensure you can update an earliest/latest date validation