### PR TITLE
Tech Debt - Slow cypress waiting for toast

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,6 +29,19 @@ Cypress.Commands.add("logout", () => {
     });
 });
 
+Cypress.Commands.add("dismissAllToast", () => {
+  cy.window()
+    .its("__store__")
+    .then(store => {
+      cy.get("[data-test='toast']").each(elem => {
+        store.dispatch({
+          type: "TOAST_DISMISS",
+          payload: { id: elem.attr("id") }
+        });
+      });
+    });
+});
+
 Cypress.Commands.add("createQuestionnaire", title => {
   cy.get(testId("logo")).click();
   cy.get(testId("create-questionnaire")).click();

--- a/cypress/utils/index.js
+++ b/cypress/utils/index.js
@@ -169,6 +169,7 @@ export const findByLabel = text =>
 export const removeAnswer = params => {
   cy.get(testId("btn-delete-answer")).click(params);
   cy.get(testId("btn-delete-answer")).should("have.length", 0);
+  cy.dismissAllToast();
   cy.get(testId("toast-item"), { timeout: 15000 }).should("have.length", 0);
 };
 

--- a/src/components/Toast/__snapshots__/index.test.js.snap
+++ b/src/components/Toast/__snapshots__/index.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Toast should render 1`] = `
 <Toast__StyledToast
+  data-test="toast"
   id="1"
   onBlur={[Function]}
   onFocus={[Function]}

--- a/src/components/Toast/index.js
+++ b/src/components/Toast/index.js
@@ -64,6 +64,7 @@ export default class Toast extends React.Component {
         onMouseLeave={this.handleResume}
         onFocus={this.handlePause}
         onBlur={this.handleResume}
+        data-test="toast"
       >
         {React.cloneElement(child, { onClose: this.handleClose })}
       </StyledToast>


### PR DESCRIPTION
### What is the context of this PR?
Trigger all toasts to be dismissed after answer deletion

This speeds up `properties_spec` from 3:15min on my local to 0:45min.

CI `test:integration` reduced by 5 mins:
- Before ~1100 seconds: 
	- [Example 1](https://travis-ci.org/ONSdigital/eq-author/builds/440668200)
	- [Example 2](https://travis-ci.org/ONSdigital/eq-author/builds/440668440)
- After ~800 seconds 
	- [Example 1](https://travis-ci.org/ONSdigital/eq-author/builds/441576602)

### How to review 
1. Ensure that cypress still passes for you locally.
1. Ensure that `properties_spec` is faster for you.
