### PR TITLE
Add cypress plugins template file

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,0 +1,18 @@
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+// eslint-disable-next-line
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+};


### PR DESCRIPTION
### What is the context of this PR?
- Adds `cypress/plugins/index.js` template file back into the repository as it keeps on reappearing when running `yarn install`
- `eslint-disable-next-line` has been added to ensure linting still passes

### How to review 
- Run tests