### PR TITLE
Fixed bug that would occur when creating a rule on unsupported answer.

### DIFF
--- a/cypress/integration/authenticated/routing_spec.js
+++ b/cypress/integration/authenticated/routing_spec.js
@@ -322,6 +322,21 @@ describe("Routing", () => {
       });
   });
 
+  it("defaults to unselected if rule is made on a unsupported answer", () => {
+    title = "Test unsupported answer";
+    cy.createQuestionnaire(title);
+
+    typeIntoDraftEditor(testId("txt-question-title", "testid"), "Question 1");
+
+    addAnswerType("Date");
+
+    navigateToRoutingTab();
+
+    cy.get(testId("btn-add-rule")).click();
+
+    findByLabel("IF").should("have.value", null);
+  });
+
   it("can build an AND rule", () => {
     title = "Test AND";
 

--- a/src/components/routing/RoutingCondition.js
+++ b/src/components/routing/RoutingCondition.js
@@ -187,6 +187,8 @@ class RoutingCondition extends React.Component {
     this.pageSelectIsValid = true;
 
     this.id = uniqueId("RoutingCondition");
+
+    this.value = get(props.condition, "questionPage.id", null);
   }
 
   static defaultProps = {
@@ -226,9 +228,11 @@ class RoutingCondition extends React.Component {
       isValid = false;
       routingEditor = renderDeletedQuestion();
     } else if (isNil(condition.answer)) {
+      this.value = null;
       isValid = false;
       routingEditor = renderNoAnswer(this.props.match.params);
     } else if (!isAnswerValidForRouting(condition.answer)) {
+      this.value = null;
       isValid = false;
       routingEditor = renderUnsupportedAnswer(condition.answer);
     } else if (!this.props.canAddAndCondition) {
@@ -236,6 +240,7 @@ class RoutingCondition extends React.Component {
       routingEditor = renderCannotAddAndCondition();
     } else {
       isValid = true;
+      this.value = get(this.props.condition, "questionPage.id", null);
       const type = get(condition, "answer.type");
       if (type === RADIO) {
         routingEditor = renderMultipleChoiceEditor(
@@ -268,7 +273,7 @@ class RoutingCondition extends React.Component {
           </Column>
           <Column gutters={false} cols={10}>
             <PageSelect
-              value={get(this.props.condition, "questionPage.id", null)}
+              value={this.value}
               valid={isValid}
               onChange={this.handlePageChange}
               groups={convertToGroups(this.props.sections)}


### PR DESCRIPTION
### What is the context of this PR?
A bug was found where if a user creates a date answer then goes to create a routing rule on that same question then the routing rule question selector would default to that question instead of null leading to a bad routing rule which would end in an error being thrown by Publisher. 

### How to review 
The bug cannot be re-created and the new test to ensure the bug has been fixed, passes.
