### PR TITLE
Added inclusive number options to routing

### DIFF
--- a/src/components/routing/NumberAnswerSelector.js
+++ b/src/components/routing/NumberAnswerSelector.js
@@ -71,9 +71,11 @@ const NumberAnswerValueSelector = ({
         data-test="comparator-selector"
       >
         <option value="Equal">(=) Equal to</option>
-        <option value="NotEqual">(≠) Not equal to</option>
+        <option value="NotEqual">(&ne;) Not equal to</option>
         <option value="GreaterThan">(&gt;) More than</option>
         <option value="LessThan">(&lt;) Less than</option>
+        <option value="GreaterOrEqual">(&ge;) More than or equal to</option>
+        <option value="LessOrEqual">(&le;) Less than or equal to</option>
       </ComparatorSelector>
       <Value>
         <VisuallyHidden>

--- a/src/components/routing/__snapshots__/NumberAnswerSelector.test.js.snap
+++ b/src/components/routing/__snapshots__/NumberAnswerSelector.test.js.snap
@@ -37,6 +37,16 @@ exports[`components/NumberAnswerSelector should render 1`] = `
     >
       (&lt;) Less than
     </option>
+    <option
+      value="GreaterOrEqual"
+    >
+      (≥) More than or equal to
+    </option>
+    <option
+      value="LessOrEqual"
+    >
+      (≤) Less than or equal to
+    </option>
   </NumberAnswerSelector__ComparatorSelector>
   <NumberAnswerSelector__Value>
     <VisuallyHidden>


### PR DESCRIPTION
### What is the context of this PR?
Due to Runner limitations we were not able to include the inclusive comparators on the first pass of routing based on a number. This has since been resolved so this PR adds that functionality. 

### How to review 
Tests pass and you are able to publish a survey with an inclusive comparator in the routing conditions.