### PR TITLE
Add description field on numeric answer types.

### DIFF
--- a/cypress/integration/authenticated/builder_spec.js
+++ b/cypress/integration/authenticated/builder_spec.js
@@ -332,7 +332,7 @@ describe("builder", () => {
     answerTypes.forEach(answerType => {
       addAnswerType(answerType);
       cy.get(testId("txt-answer-label")).type(answerType + " label");
-      if (includes(["Currency"], answerType)) {
+      if (includes(["Currency", "Number"], answerType)) {
         cy.get(testId("txt-answer-description")).type(
           answerType + " description"
         );

--- a/src/components/AnswerEditor/__snapshots__/answereditor.test.js.snap
+++ b/src/components/AnswerEditor/__snapshots__/answereditor.test.js.snap
@@ -304,6 +304,7 @@ exports[`Answer Editor should render Number 1`] = `
       onDeleteOther={[MockFunction]}
       onUpdate={[MockFunction]}
       onUpdateOption={[MockFunction]}
+      showDescription={true}
     />
   </AnswerEditor__Padding>
   <Tooltip

--- a/src/components/AnswerEditor/index.js
+++ b/src/components/AnswerEditor/index.js
@@ -72,9 +72,10 @@ class AnswerEditor extends React.Component {
   renderAnswer(answer) {
     switch (answer.type) {
       case TEXTFIELD:
-      case NUMBER:
       case TEXTAREA:
         return <BasicAnswer {...this.props} />;
+      case NUMBER:
+        return <BasicAnswer {...this.props} showDescription />;
       case CURRENCY:
         return <CurrencyAnswer {...this.props} />;
       case CHECKBOX:


### PR DESCRIPTION
### What is the context of this PR?
Number answer description re enabled because Runner now supports it

### How to review 
- Run tests
- Make sure description appears on number answers
